### PR TITLE
chore: update documentation and release instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["command-line-utilities"]
 version = "0.27.1"
 authors = ["LargeModGames <LargeModGames@gmail.com>"]
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Alexander Keliris
+Copyright (c) 2025 LargeModGames
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 
 
+[![Crates.io](https://img.shields.io/crates/v/spotatui.svg)](https://crates.io/crates/spotatui)
+[![Upstream](https://img.shields.io/badge/upstream-Rigellute%2Fspotify--tui-blue)](https://github.com/Rigellute/spotify-tui)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-94-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-[![Follow Alexander Keliris (Rigellute)](https://img.shields.io/twitter/follow/AlexKeliris?label=Follow%20Alexander%20Keliris%20%28Rigellute%29&style=social)](https://twitter.com/intent/follow?screen_name=AlexKeliris)
 
 A Spotify client for the terminal written in Rust.
 
@@ -19,7 +20,11 @@ A Spotify client for the terminal written in Rust.
 The terminal in the demo above is using the [Rigel theme](https://rigel.netlify.com/).
 
 - [Spotatui](#spotatui)
-
+  - [Migrating from spotify-tui](#migrating-from-spotify-tui)
+  - [Installation](#installation)
+    - [Pre-built Binaries](#pre-built-binaries)
+    - [Cargo](#cargo)
+    - [Building from Source](#building-from-source)
   - [Connecting to Spotify’s API](#connecting-to-spotifys-api)
   - [Usage](#usage)
 - [Configuration](#configuration)
@@ -29,12 +34,52 @@ The terminal in the demo above is using the [Rigel theme](https://rigel.netlify.
   - [Libraries used](#libraries-used)
   - [Development](#development)
     - [Windows Subsystem for Linux](#windows-subsystem-for-linux)
+  - [Maintainer](#maintainer)
   - [Contributors](#contributors)
   - [Roadmap](#roadmap)
     - [High-level requirements yet to be implemented](#high-level-requirements-yet-to-be-implemented)
 
+## Migrating from spotify-tui
+
+If you used the original `spotify-tui` before:
+
+- The binary name changed from `spt` → `spotatui`.
+- Config paths changed:
+  - Old: `~/.config/spotify-tui/`
+  - New: `~/.config/spotatui/`
+
+You can copy your existing config:
+
+```bash
+mkdir -p ~/.config/spotatui
+cp -r ~/.config/spotify-tui/* ~/.config/spotatui/
+```
+
+You may be asked to re-authenticate with Spotify the first time.
+
 ## Installation
 
+### Pre-built Binaries
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/LargeModGames/spotatui/releases/latest):
+
+| Platform                           | File                                  |
+| ---------------------------------- | ------------------------------------- |
+| Windows 10/11 (64-bit)             | `spotatui-windows-x86_64.zip`         |
+| Linux (Ubuntu, Arch, Fedora, etc.) | `spotatui-linux-x86_64.tar.gz`        |
+| Linux (Alpine / musl)              | `spotatui-linux-alpine-x86_64.tar.gz` |
+| macOS (Intel)                      | `spotatui-macos-x86_64.tar.gz`        |
+| macOS (Apple Silicon M1/M2/M3)     | `spotatui-macos-aarch64.tar.gz`       |
+
+Checksums (`.sha256`) are provided if you want to verify the download.
+
+### Cargo
+
+If you have Rust installed:
+
+```bash
+cargo install spotatui
+```
 
 ### Building from Source
 
@@ -120,7 +165,7 @@ The following is a sample config.yml file:
 # The theme colours can be an rgb string of the form "255, 255, 255" or a string that references the colours from your terminal theme: Reset, Black, Red, Green, Yellow, Blue, Magenta, Cyan, Gray, DarkGray, LightRed, LightGreen, LightYellow, LightBlue, LightMagenta, LightCyan, White.
 theme:
   active: Cyan # current playing song in list
-  banner: LightCyan # the "spotify-tui" banner on launch
+  banner: LightCyan # the "spotatui" banner on launch
   error_border: Red # error dialog border
   error_text: LightRed # error message text (e.g. "Spotify API reported error 404")
   hint: Yellow # hint text in errors
@@ -240,9 +285,9 @@ sudo apt-get install -y -qq pkg-config libssl-dev libxcb1-dev libxcb-render0-dev
 
 ## Maintainer
 
-Maintained by **LargeModGames** (<LargeModGames@gmail.com>).
+Maintained by **[LargeModGames](https://github.com/LargeModGames)**.
 
-Original author: Alexander Keliris.
+Original author: [Alexander Keliris](https://github.com/Rigellute).
 
 ## Contributors
 

--- a/how_to_release.md
+++ b/how_to_release.md
@@ -1,6 +1,6 @@
 # To create a release
 
-The releases are automated via GitHub actions, using [this configuration file](https://github.com/Rigellute/spotify-tui/blob/master/.github/workflows/cd.yml).
+The releases are automated via GitHub actions, using [this configuration file](https://github.com/LargeModGames/spotatui/blob/master/.github/workflows/cd.yml).
 
 The release is triggered by pushing a tag.
 
@@ -9,15 +9,9 @@ The release is triggered by pushing a tag.
 1. Commit the changes and push them.
 1. Create a new tag e.g. `git tag -a v0.7.0` and add the CHANGELOG to the commit body
 1. Push the tag `git push --tags`
-1. Wait for the build to finish on the [Actions page](https://github.com/Rigellute/spotify-tui/actions)
+1. Wait for the build to finish on the [Actions page](https://github.com/LargeModGames/spotatui/actions)
 1. This should publish to cargo as well
 
-### Update `brew`
+### Homebrew / Scoop Packaging
 
-1. `cd` to the [`tap` repo](https://github.com/Rigellute/homebrew-tap)
-1. Run script to update the Formula `sh scripts/spotify-tui.sh $VERSION`
-
-### Update `scoop` (Windows 10)
-
-1. `cd` to [the `scoop` repo](https://github.com/Rigellute/scoop-bucket)
-1. Run the script to update the manifest `sh scripts/spotify-tui.sh $VERSION`
+TODO: Homebrew and Scoop packaging is not yet set up for spotatui. If you'd like to contribute packaging, PRs are welcome!


### PR DESCRIPTION
This pull request updates project documentation and metadata to reflect the migration from `spotify-tui` to `spotatui`, clarifies licensing, and improves contributor and maintainer information. The most significant changes are the addition of migration instructions, updated installation guidance, and modifications to licensing and attribution.

### Migration and Installation Updates
* Added a new "Migrating from spotify-tui" section to the `README.md`, detailing binary and config path changes, and providing instructions to transfer existing configurations.
* Expanded installation instructions in `README.md` with a table of pre-built binaries for major platforms and updated `cargo install` guidance.

### Licensing and Attribution
* Changed the license in `Cargo.toml` from "MIT OR Apache-2.0" to "MIT".
* Updated the `LICENSE` file to add copyright for LargeModGames (2025).

### Documentation and Branding
* Updated references in documentation from "spotify-tui" to "spotatui", including the banner description in the sample config and links to the new upstream repository. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R168) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L243-R290) [[3]](diffhunk://#diff-17260e2557dddc77f3506b2cd0516804aa225acdee560fd8c83ef649658b5fc2L3-R3) [[4]](diffhunk://#diff-17260e2557dddc77f3506b2cd0516804aa225acdee560fd8c83ef649658b5fc2L12-R17)
* Improved contributor and maintainer attribution by linking to GitHub profiles in the `README.md`.

### Release and Packaging Process
* Updated release instructions in `how_to_release.md` to reference the new repository and clarify that Homebrew and Scoop packaging for `spotatui` is not yet set up, inviting contributions.