### PR TITLE
Add macOS Installation Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We respect your privacy. This is purely a fun community metric with zero trackin
   - [Installation](#installation)
     - [Pre-built Binaries](#pre-built-binaries)
       - [Linux Requirements](#linux-requirements)
+      - [macOS Requirements](#macos-requirements)
     - [Arch Linux (AUR)](#arch-linux-aur)
     - [Cargo](#cargo)
     - [Building from Source](#building-from-source)
@@ -127,6 +128,16 @@ sudo dnf install pipewire
 
 > **Note:** Most modern Linux distributions already have PipeWire installed by default.
 
+#### macOS Requirements
+
+For macOS, `spotatui` uses the `portaudio` backend for better stability and bluetooth device support (such as AirPods).
+
+`portaudio` needs to be installed first, via homebrew:
+
+```bash
+brew install portaudio
+```
+
 ### Arch Linux (AUR)
 
 For Arch Linux users, spotatui is available in the AUR:
@@ -149,16 +160,6 @@ cargo install spotatui
 > ```bash
 > sudo apt install libssl-dev pkg-config
 > ```
-
-### macOS
-
-For macOS, `spotatui` uses the `portaudio` backend for better stability and bluetooth device support (such as AirPods).
-
-`portaudio` needs to be installed first, via homebrew:
-
-```bash
-brew install portaudio
-```
 
 ### Building from Source
 


### PR DESCRIPTION
This PR adds macOS-specific installation instructions to the `README`, ensuring users on macOS can easily run `spotatui` with the required dependencies.

### Changes Made

Added a new section under the installation instructions for macOS, specifying the use of the `portaudio` backend for better stability and Bluetooth device support (e.g., AirPods).

Included a command to install `portaudio` via `Homebrew`, which is necessary for macOS compatibility.

### Why This Change?

The existing `README` did not include macOS-specific instructions for running the pre-compiled binary.

### Code of Conduct Compliance:

- Respectful and Inclusive: The change ensures all users, regardless of their operating system, have clear instructions for installation.
- Collaborative: This PR is open for feedback and further improvements from the community.
- Transparency: The rationale for the change is clearly outlined, and the instructions are straightforward and actionable.

### Additional Notes

- The instructions assume users have [Homebrew](https://brew.sh/) installed, which is standard for macOS package management.
- The `portaudio` dependency is explicitly called out to avoid confusion with other backends.

### Files Changed

- `README.md`