### PR TITLE
Update Spotify app setup instructions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -137,10 +137,9 @@ impl ClientConfig {
 
       let instructions = [
         "Go to the Spotify dashboard - https://developer.spotify.com/dashboard/applications",
-        "Click `Create a Client ID` and create an app",
-        "Now click `Edit Settings`",
+        "Click `Create app` and add your own name and description",
         &format!(
-          "Add `http://127.0.0.1:{}/callback` to the Redirect URIs",
+          "Add `http://127.0.0.1:{}/callback` to Redirect URIs",
           DEFAULT_PORT
         ),
         "You are now ready to authenticate with Spotify!",


### PR DESCRIPTION
Ensure the instructions match the current Spotify Developer app creation flow. Updates 'click' instruction to match button, and removes 'edit settings' step - you can't actually create a Spotify app anymore without declaring a redirect URI, it is a required field.

---

_Thank you so much for this project, it is exactly what I was looking for and the native streaming works like a charm out of the box!_