### PR TITLE
fix(theme): fix playbar background not being transparent on dark mode…

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -77,7 +77,7 @@ impl Default for Theme {
       hint: Color::Rgb(200, 200, 0),              // Yellow equivalent
       hovered: Color::Rgb(180, 0, 180),           // Magenta equivalent
       inactive: Color::Rgb(128, 128, 128),        // Gray equivalent
-      playbar_background: Color::Rgb(20, 20, 20), // Near-black
+      playbar_background: Color::Reset,
       playbar_progress: Color::Rgb(0, 200, 200),  // LightCyan equivalent
       playbar_progress_text: Color::Rgb(255, 255, 255), // Bright white for visibility
       playbar_text: Color::Reset,
@@ -183,7 +183,7 @@ impl ThemePreset {
         hint: Color::Rgb(241, 250, 140),            // Yellow
         hovered: Color::Rgb(189, 147, 249),         // Purple
         inactive: Color::Rgb(98, 114, 164),         // Comment
-        playbar_background: Color::Rgb(40, 42, 54), // Background
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(80, 250, 123), // Green
         playbar_progress_text: Color::Rgb(248, 248, 242),
         playbar_text: Color::Rgb(248, 248, 242),
@@ -203,7 +203,7 @@ impl ThemePreset {
         hint: Color::Rgb(235, 203, 139),            // Nord13 (yellow)
         hovered: Color::Rgb(180, 142, 173),         // Nord15 (purple)
         inactive: Color::Rgb(76, 86, 106),          // Nord3
-        playbar_background: Color::Rgb(46, 52, 64), // Nord0
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(136, 192, 208), // Nord8
         playbar_progress_text: Color::Rgb(236, 239, 244),
         playbar_text: Color::Rgb(236, 239, 244),
@@ -223,7 +223,7 @@ impl ThemePreset {
         hint: Color::Rgb(181, 137, 0),              // Yellow
         hovered: Color::Rgb(211, 54, 130),          // Magenta
         inactive: Color::Rgb(88, 110, 117),         // Base01
-        playbar_background: Color::Rgb(0, 43, 54),  // Base03
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(42, 161, 152), // Cyan
         playbar_progress_text: Color::Rgb(253, 246, 227),
         playbar_text: Color::Rgb(147, 161, 161), // Base1
@@ -243,7 +243,7 @@ impl ThemePreset {
         hint: Color::Rgb(230, 219, 116),            // Yellow
         hovered: Color::Rgb(174, 129, 255),         // Purple
         inactive: Color::Rgb(117, 113, 94),         // Comment
-        playbar_background: Color::Rgb(39, 40, 34), // Background
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(166, 226, 46), // Green
         playbar_progress_text: Color::Rgb(248, 248, 242),
         playbar_text: Color::Rgb(248, 248, 242),
@@ -263,7 +263,7 @@ impl ThemePreset {
         hint: Color::Rgb(250, 189, 47),             // Yellow
         hovered: Color::Rgb(211, 134, 155),         // Purple
         inactive: Color::Rgb(146, 131, 116),        // Gray
-        playbar_background: Color::Rgb(40, 40, 40), // bg
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(184, 187, 38), // Green
         playbar_progress_text: Color::Rgb(235, 219, 178),
         playbar_text: Color::Rgb(235, 219, 178),
@@ -303,7 +303,7 @@ impl ThemePreset {
         hint: Color::Rgb(250, 179, 135),                // Peach
         hovered: Color::Rgb(137, 180, 250),             // Blue
         inactive: Color::Rgb(108, 112, 134),            // Overlay 0
-        playbar_background: Color::Rgb(49, 50, 68),     // Surface 0
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(180, 190, 254),    // Lavender
         playbar_progress_text: Color::Rgb(88, 91, 112), // Surface 2
         playbar_text: Color::Rgb(186, 194, 222),        // Subtext 1
@@ -323,7 +323,7 @@ impl ThemePreset {
         hint: Color::Rgb(179, 179, 179),            // Gray hint
         hovered: Color::Rgb(29, 185, 84),           // Spotify Green
         inactive: Color::Rgb(83, 83, 83),           // Dark gray
-        playbar_background: Color::Rgb(24, 24, 24), // Near black
+        playbar_background: Color::Reset,
         playbar_progress: Color::Rgb(29, 185, 84),  // Spotify Green
         playbar_progress_text: Color::Rgb(255, 255, 255),
         playbar_text: Color::Rgb(179, 179, 179), // Light gray


### PR DESCRIPTION
This pull request standardizes the appearance of the playbar background across all theme presets in the `src/user_config.rs` file. Instead of specifying a custom RGB color for each theme, the `playbar_background` is now set to `Color::Reset`, which will use the terminal's default background color. This change ensures consistency and allows the playbar to better integrate with various terminal color schemes.
