### PR TITLE
fix: mark reqwest as mandatory dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = "1.0.43"
 chrono = "0.4.43"
 open = "5.3"
 self_update = { version = "0.42", features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 openssl = { version = "0.10", optional = true }
 cpal = { version = "0.17", optional = true }
 realfft = { version = "3.4", optional = true }
@@ -90,7 +90,7 @@ block2 = { version = "0.6", optional = true }
 
 [features]
 default = ["telemetry", "streaming", "audio-viz-cpal", "mpris", "macos-media", "discord-rpc"]
-telemetry = ["reqwest", "reqwest/rustls-tls"]
+telemetry = []
 streaming = ["librespot-core", "librespot-playback", "librespot-connect", "librespot-oauth", "librespot-metadata"]
 # Audio backend features
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]


### PR DESCRIPTION
# Summary

We always use `reqwest` regardless of feature flags. This changes the definition of the dependency to reflect this, fixing a build failure with the telemetry feature disabled.

# Testing

```
$ cargo build
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 56.66s

$ cargo build --no-default-features --features "streaming"

   Compiling spotatui v0.35.5 (/home/lordmzte/Downloads/spotatui)
warning: struct `SpectrumData` is never constructed
  --> src/audio/mod.rs:40:12
   |
40 | pub struct SpectrumData {
   |            ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: struct `AudioCaptureManager` is never constructed
  --> src/audio/mod.rs:49:12
   |
49 | pub struct AudioCaptureManager;
   |            ^^^^^^^^^^^^^^^^^^^

warning: associated items `new`, `get_spectrum`, and `is_active` are never used
  --> src/audio/mod.rs:56:10
   |
55 | impl AudioCaptureManager {
   | ------------------------ associated items in this implementation
56 |   pub fn new() -> Option<Self> {
   |          ^^^
...
60 |   pub fn get_spectrum(&self) -> Option<SpectrumData> {
   |          ^^^^^^^^^^^^
...
64 |   pub fn is_active(&self) -> bool {
   |          ^^^^^^^^^

warning: struct `GlobalSongCountResponse` is never constructed
   --> src/network.rs:141:8
    |
141 | struct GlobalSongCountResponse {
    |        ^^^^^^^^^^^^^^^^^^^^^^^

warning: `spotatui` (bin "spotatui") generated 4 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.98s
```

# Additional notes

Some additional work could be done to get rid of warnings that are emitted when compiling without telemetry.

Closes #73