### PR TITLE
fix: solve slim-build-compilation error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,11 +75,13 @@ use std::{
   io::{self, stdout, Write},
   panic,
   path::PathBuf,
-  sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-  },
-  time::{Duration, Instant, SystemTime},
+  sync::{atomic::AtomicU64, Arc},
+  time::SystemTime,
+};
+#[cfg(feature = "streaming")]
+use std::{
+  sync::atomic::Ordering,
+  time::{Duration, Instant},
 };
 use tokio::sync::Mutex;
 use user_config::{UserConfig, UserConfigPaths};
@@ -1719,7 +1721,7 @@ async fn start_ui(
 async fn start_ui(
   user_config: UserConfig,
   app: &Arc<Mutex<App>>,
-  shared_position: Option<Arc<AtomicU64>>,
+  _shared_position: Option<Arc<AtomicU64>>,
   _mpris_manager: Option<()>,
   discord_rpc_manager: DiscordRpcHandle,
 ) -> Result<()> {


### PR DESCRIPTION
# Summary

Fixes https://github.com/LargeModGames/spotatui/issues/80, the slim build (`--no-default-features --features telemetry`) from CONTRIBUTING.md fails to compile.

The root cause is that `auto_select_streaming_device()` and some imports/variables are only meaningful with the `streaming` feature but weren't properly feature-gated.

Changes:

- Gate `auto_select_streaming_device()` and its match arm behind `#[cfg(feature = "streaming")]`, with a no-op fallback for non-streaming builds

#

The following three changes are to just fix compilation warnings that appeared alongside the error.

- Move `Duration`, `Instant`, `Ordering` imports behind `#[cfg(feature = "streaming")]` in `main.rs`
- Prefix unused `shared_position` parameter with `_` in non-MPRIS `start_ui`
- Add `#[allow(unused_mut)]` on match arm where `c` is only mutated in streaming-gated code

# Testing

```sh
cargo check --no-default-features --features telemetry (compiles)
cargo fmt --all -- --check
cargo test --no-default-features --features telemetry     (49 passed, 0 failed)
```

# Additional notes

No logic or behavior changes, this is purely conditional compilation hygiene. The default (full-feature) build is unaffected.

Note: after fixing these compilation errors, running `cargo clippy --no-default-features --features telemetry -- -D warnings` reveals ~100 pre-existing `uninlined_format_args` warnings across the codebase (also present on the default-feature build). This is a separate issue from the compilation failures fixed here.
