### PR TITLE
feat(mpris): Add album art URL to MPRIS metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,18 @@ struct DiscordPresenceState {
   last_progress_ms: u128,
 }
 
+#[cfg(feature = "mpris")]
+#[derive(Default, PartialEq)]
+struct MprisMetadata {
+  title: String,
+  artists: Vec<String>,
+  album: String,
+  duration_ms: u32,
+  art_url: Option<String>,
+}
+#[cfg(feature = "mpris")]
+type MprisMetadataTuple = (String, Vec<String>, String, u32, Option<String>);
+
 #[cfg(feature = "discord-rpc")]
 fn resolve_discord_app_id(user_config: &UserConfig) -> Option<String> {
   std::env::var("SPOTATUI_DISCORD_APP_ID")
@@ -214,6 +226,34 @@ fn build_discord_playback(app: &App) -> Option<discord_rpc::DiscordPlayback> {
   })
 }
 
+#[cfg(feature = "mpris")]
+fn get_mpris_metadata(app: &App) -> Option<MprisMetadataTuple> {
+  use crate::ui::util::create_artist_string;
+  use rspotify::model::PlayableItem;
+
+  if let Some(context) = &app.current_playback_context {
+    let item = context.item.as_ref()?;
+    match item {
+      PlayableItem::Track(track) => Some((
+        track.name.clone(),
+        vec![create_artist_string(&track.artists)],
+        track.album.name.clone(),
+        track.duration.num_milliseconds() as u32,
+        track.album.images.first().map(|image| image.url.clone()),
+      )),
+      PlayableItem::Episode(episode) => Some((
+        episode.name.clone(),
+        vec![episode.show.name.clone()],
+        String::new(),
+        episode.duration.num_milliseconds() as u32,
+        episode.images.first().map(|image| image.url.clone()),
+      )),
+    }
+  } else {
+    None
+  }
+}
+
 #[cfg(feature = "discord-rpc")]
 fn update_discord_presence(
   manager: &discord_rpc::DiscordRpcManager,
@@ -251,6 +291,34 @@ fn update_discord_presence(
         state.last_is_playing = None;
         state.last_progress_ms = 0;
       }
+    }
+  }
+}
+
+#[cfg(feature = "mpris")]
+fn update_mpris_metadata(
+  manager: &mpris::MprisManager,
+  last_metadata: &mut Option<MprisMetadata>,
+  app: &App,
+) {
+  if let Some((title, artists, album, duration_ms, art_url)) = get_mpris_metadata(app) {
+    let new_metadata = MprisMetadata {
+      title: title.clone(),
+      artists: artists.clone(),
+      album: album.clone(),
+      duration_ms,
+      art_url: art_url.clone(),
+    };
+
+    // Only update if metadata changed
+    if last_metadata.as_ref() != Some(&new_metadata) {
+      manager.set_metadata(&title, &artists, &album, duration_ms, art_url);
+      *last_metadata = Some(new_metadata);
+    }
+  } else {
+    // Clear if no playback
+    if last_metadata.is_some() {
+      *last_metadata = None;
     }
   }
 }
@@ -1090,7 +1158,13 @@ async fn handle_player_events(
 
         // Update MPRIS metadata
         if let Some(ref mpris) = mpris_manager {
-          mpris.set_metadata(&audio_item.name, &artists, &album, audio_item.duration_ms, None);
+          mpris.set_metadata(
+            &audio_item.name,
+            &artists,
+            &album,
+            audio_item.duration_ms,
+            None,
+          );
         }
 
         if let Ok(mut app) = app.try_lock() {
@@ -1481,6 +1555,9 @@ async fn start_ui(
   #[cfg(feature = "discord-rpc")]
   let mut discord_presence_state = DiscordPresenceState::default();
 
+  #[cfg(feature = "mpris")]
+  let mut mpris_metadata_state: Option<MprisMetadata> = None;
+
   // Update check will run async after first render to avoid blocking startup
   let mut update_check_spawned = false;
   let mut is_first_render = true;
@@ -1631,16 +1708,7 @@ async fn start_ui(
 
         #[cfg(feature = "mpris")]
         if let Some(ref mpris) = mpris_manager {
-          if let Some(playback) = build_discord_playback(&app) {
-            let artists: Vec<String> = playback.artist.split(", ").map(String::from).collect();
-            mpris.set_metadata(
-              &playback.title,
-              &artists,
-              &playback.album,
-              playback.duration_ms,
-              playback.image_url,
-            );
-          }
+          update_mpris_metadata(mpris, &mut mpris_metadata_state, &app);
         }
 
         // Read position from shared atomic if native streaming is active
@@ -1877,20 +1945,6 @@ async fn start_ui(
         #[cfg(feature = "discord-rpc")]
         if let Some(ref manager) = discord_rpc_manager {
           update_discord_presence(manager, &mut discord_presence_state, &app);
-        }
-
-        #[cfg(feature = "mpris")]
-        if let Some(ref mpris) = mpris_manager {
-          if let Some(playback) = build_discord_playback(&app) {
-            let artists: Vec<String> = playback.artist.split(", ").map(String::from).collect();
-            mpris.set_metadata(
-              &playback.title,
-              &artists,
-              &playback.album,
-              playback.duration_ms,
-              playback.image_url,
-            );
-          }
         }
 
         #[cfg(feature = "streaming")]

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -156,7 +156,6 @@ impl MprisManager {
               }
             }
 
-
             MprisCommand::PlaybackStatus(is_playing) => {
               let status = if is_playing {
                 PlaybackStatus::Playing
@@ -200,7 +199,14 @@ impl MprisManager {
   }
 
   /// Update track metadata
-pub fn set_metadata(&self, title: &str, artists: &[String], album: &str, duration_ms: u32, art_url: Option<String>) {
+  pub fn set_metadata(
+    &self,
+    title: &str,
+    artists: &[String],
+    album: &str,
+    duration_ms: u32,
+    art_url: Option<String>,
+  ) {
     let _ = self.command_tx.send(MprisCommand::Metadata {
       title: title.to_string(),
       artists: artists.to_vec(),


### PR DESCRIPTION
- Added art_url parameter to MPRIS metadata
- Updated metadata on playback tick using build_discord_playback
- Fixes album artwork not displaying in media controls

# Summary

Adds album artwork support to MPRIS metadata by including the `art_url` field. The album art URL is now extracted from playback data (reusing the existing Discord RPC integration logic) and exposed via MPRIS, allowing media controls and desktop widgets to display album covers.

# Testing

- cargo fmt --all
(no output)
- cargo clippy --locked -- -D warnings
    Checking spotatui v0.35.5 (/home/elmundos/projects/spotatui-fork)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 43.25s
- cargo test --locked
running 49 tests
test handlers::common_key_events::tests::test_on_up_press_handler ... ok
test handlers::common_key_events::tests::test_on_down_press_handler ... ok
test handlers::input::tests::test_compute_character_width_with_multiple_characters ... ok
test handlers::album_list::tests::on_esc ... ok
test handlers::album_tracks::tests::on_left_press ... ok
test handlers::album_tracks::tests::on_esc ... ok
test handlers::empty::tests::on_right_press ... ok
test handlers::artist::tests::on_esc ... ok
test handlers::home::tests::on_large_down_press ... ok
test handlers::home::tests::on_large_up_press ... ok
test handlers::home::tests::on_small_down_press ... ok
test handlers::empty::tests::on_down_press ... ok
test handlers::empty::tests::on_enter ... ok
test handlers::empty::tests::on_left_press ... ok
test handlers::input::tests::test_input_handler_ctrl_u ... ok
test handlers::home::tests::on_small_up_press ... ok
test handlers::input::tests::test_input_handler_ctrl_k ... ok
test handlers::empty::tests::on_up_press ... ok
test handlers::input::tests::test_input_handler_ctrl_w ... ok
test handlers::input::tests::test_input_handler_esc_back_to_playlist ... ok
test handlers::input::tests::test_uri_parsing::artist ... ok
test handlers::input::tests::test_uri_parsing::album ... ok
test handlers::input::tests::test_uri_parsing::mismatched_resource_types_do_not_match ... ok
test handlers::input::tests::test_uri_parsing::invalid_format_doesnt_match ... ok
test handlers::input::tests::test_input_handler_backspace ... ok
test handlers::input::tests::test_uri_parsing::parse_with_query_parameters ... ok
test handlers::input::tests::test_uri_parsing::playlist ... ok
test handlers::input::tests::test_uri_parsing::show ... ok
test handlers::input::tests::test_uri_parsing::track ... ok
test handlers::playlist::tests::test ... ok
test sort::tests::test_context_available_fields ... ok
test sort::tests::test_sort_order_toggle ... ok
test sort::tests::test_sort_state_apply_field ... ok
test ui::util::tests::display_track_progress_test ... ok
test ui::util::tests::get_track_progress_percentage_test ... ok
test ui::util::tests::millis_to_minutes_test ... ok
test user_config::tests::parse_theme_item_test ... ok
test user_config::tests::test_parse_key ... ok
test user_config::tests::test_reserved_key ... ok
test handlers::input::tests::test_input_handler_clear_input_on_ctrl_l ... ok
test handlers::input::tests::test_input_handler_left_event ... ok
test handlers::input::tests::test_input_handler_on_enter_text_non_english_char ... ok
test handlers::input::tests::test_input_handler_on_enter_text ... ok
test handlers::input::tests::test_input_handler_on_enter_text_wide_char ... ok
test handlers::playbar::tests::on_left_press ... ok
test handlers::recently_played::tests::on_left_press ... ok
test handlers::recently_played::tests::on_esc ... ok
test handlers::album_list::tests::on_left_press ... ok
test handlers::input::tests::test_input_handler_delete ... ok

test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

# Additional notes

New:
<img width="434" height="158" alt="image" src="https://github.com/user-attachments/assets/2d22e1d1-6fd6-4657-bcf4-5e746368d438" />

Old:
<img width="435" height="170" alt="image" src="https://github.com/user-attachments/assets/545b704b-4478-404e-8ac2-63100b3f4134" />

New:
![WhatsApp Image 2026-02-06 at 22 00 14](https://github.com/user-attachments/assets/9f3981e2-6e5a-4efa-bfaf-0c911ecfe082)

Old:
![WhatsApp Image 2026-02-06 at 22 00 14](https://github.com/user-attachments/assets/32ce9522-b127-4b5c-a6fd-b455b8d4c414)
