### PR TITLE
fix: Search input horizontal scroll

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ use rspotify::{
   },
   prelude::*, // Adds Id trait for .id() method
 };
+use std::cell::Cell;
 use std::sync::mpsc::Sender;
 #[cfg(feature = "streaming")]
 use std::sync::Arc;
@@ -476,6 +477,8 @@ pub struct App {
   pub input: Vec<char>,
   pub input_idx: usize,
   pub input_cursor_position: u16,
+  /// Horizontal scroll offset for the input box, computed during rendering.
+  pub input_scroll_offset: Cell<u16>,
   pub liked_song_ids_set: HashSet<String>,
   pub followed_artist_ids_set: HashSet<String>,
   pub saved_album_ids_set: HashSet<String>,
@@ -657,6 +660,7 @@ impl Default for App {
       input: vec![],
       input_idx: 0,
       input_cursor_position: 0,
+      input_scroll_offset: Cell::new(0),
       playlist_offset: 0,
       playlist_tracks: None,
       playlists: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1754,7 +1754,7 @@ async fn start_ui(
 
       // Put the cursor back inside the input box
       terminal.backend_mut().execute(MoveTo(
-        cursor_offset + app.input_cursor_position,
+        cursor_offset + app.input_cursor_position - app.input_scroll_offset.get(),
         cursor_offset,
       ))?;
 
@@ -2024,7 +2024,7 @@ async fn start_ui(
         1
       };
       terminal.backend_mut().execute(MoveTo(
-        cursor_offset + app.input_cursor_position,
+        cursor_offset + app.input_cursor_position - app.input_scroll_offset.get(),
         cursor_offset,
       ))?;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -177,7 +177,19 @@ pub fn draw_input_and_help_box(f: &mut Frame<'_>, app: &App, layout_chunk: Rect)
 
   let input_string: String = app.input.iter().collect();
   let lines = Text::from(input_string.clone());
-  let input = Paragraph::new(lines).block(
+  // Compute horizontal scroll so the cursor stays visible within the input box.
+  // inner width = total width - 2 (for left and right borders)
+  let inner_width = input_area.width.saturating_sub(2);
+  let scroll_offset = if inner_width > 0 && app.input_cursor_position >= inner_width {
+    app.input_cursor_position - inner_width + 1
+  } else {
+    0
+  };
+  app.input_scroll_offset.set(scroll_offset);
+
+  let input = Paragraph::new(lines)
+    .scroll((0, scroll_offset))
+    .block(
     Block::default()
       .borders(Borders::ALL)
       .border_type(border_type)


### PR DESCRIPTION
# Summary

Fixes the search input box (`/`) losing the cursor when text overflows the visible width. Before, typing a long query would cause the text to be clipped by the `Paragraph` widget while the terminal cursor kept advancing past the box boundary, making it impossible to see what you're typing actively typing beyond the width.
Now, the cursor simply follows the text being typed.

Changes:

- Add `input_scroll_offset: Cell<u16>` to `App` to track horizontal scroll state across render and cursor-positioning phases
- Compute a scroll offset in `draw_input_and_help_box` when `input_cursor_position` exceeds the inner width of the input box, and apply `.scroll((0, offset))` to the `Paragraph` widget so text pans left
- Subtract the scroll offset from the terminal cursor X coordinate in both `start_ui` cursor-positioning sites so the blinking cursor stays aligned with the visible text
