### PR TITLE
Fixed Windows compilation bug introduced in v0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ objc2 = { version = "0.6", optional = true }
 block2 = { version = "0.6", optional = true }
 
 [features]
-default = ["telemetry", "streaming", "audio-viz-cpal", "mpris", "macos-media", "discord-rpc"]
+default = ["telemetry", "streaming", "audio-viz-cpal", "macos-media", "discord-rpc"]
 telemetry = []
 streaming = ["librespot-core", "librespot-playback", "librespot-connect", "librespot-oauth", "librespot-metadata", "librespot-protocol", "protobuf"]
 # Audio backend features


### PR DESCRIPTION
# Summary

Version **v0.36.0** introduced a minor issue that resulted in the project not successfully building on Windows hosts.  A Linux-only feature -- `mpris` -- was added to the default list of features despite being internally labeled as optional.

So specifically, all this PR does is remove the optional Linux-only feature `mpris` from the default list within `Cargo.toml`, fixing Windows compilation.

# Testing

Compilation failure at line 302 of `main.rs` due to being unable to locate `mpris` on a Windows host.
```
cargo install spotatui
```
<img width="1099" height="535" alt="image" src="https://github.com/user-attachments/assets/914051a7-3360-47e3-ad4d-39c8d4b60bb2" />

---

Root cause being this "optional" feature being included in the "default" list within `Cargo.toml`.

<img width="1094" height="789" alt="image" src="https://github.com/user-attachments/assets/5dac6fd2-0324-412a-9ff9-05688bc3472d" />
<img width="750" height="412" alt="image" src="https://github.com/user-attachments/assets/742d24f2-1228-459c-b4e9-30ef79d01cba" />

---

Compilation in both Windows and Linux successful after removing `mpris` from the default list.
```
# Linux
cargo install --path ./ --features "mpris"

# Windows
cargo install --path ./
```
<img width="1541" height="930" alt="image" src="https://github.com/user-attachments/assets/195af989-ac55-4bdd-a084-627b1da94704" />
