### PR TITLE
feat: add vesper theme

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -96,6 +96,7 @@ pub enum ThemePreset {
   #[default]
   Default,
   Spotify,
+  Vesper,
   Dracula,
   Nord,
   SolarizedDark,
@@ -111,6 +112,7 @@ impl ThemePreset {
     &[
       ThemePreset::Default,
       ThemePreset::Spotify,
+      ThemePreset::Vesper,
       ThemePreset::Dracula,
       ThemePreset::Nord,
       ThemePreset::SolarizedDark,
@@ -125,6 +127,7 @@ impl ThemePreset {
     match self {
       ThemePreset::Default => "Default (Cyan)",
       ThemePreset::Spotify => "Spotify",
+      ThemePreset::Vesper => "Vesper",
       ThemePreset::Dracula => "Dracula",
       ThemePreset::Nord => "Nord",
       ThemePreset::SolarizedDark => "Solarized Dark",
@@ -140,6 +143,7 @@ impl ThemePreset {
     match name {
       "Default (Cyan)" => ThemePreset::Default,
       "Spotify" => ThemePreset::Spotify,
+      "Vesper" => ThemePreset::Vesper,
       "Dracula" => ThemePreset::Dracula,
       "Nord" => ThemePreset::Nord,
       "Solarized Dark" => ThemePreset::SolarizedDark,
@@ -173,6 +177,26 @@ impl ThemePreset {
   pub fn to_theme(self) -> Theme {
     match self {
       ThemePreset::Default => Theme::default(),
+      ThemePreset::Vesper => Theme {
+        analysis_bar: Color::Rgb(153, 255, 228),     // Mint (#99FFE4)
+        analysis_bar_text: Color::Rgb(16, 16, 16),   // Near-black (#101010)
+        active: Color::Rgb(255, 199, 153),           // Accent orange (#FFC799)
+        banner: Color::Rgb(255, 199, 153),           // Accent orange
+        error_border: Color::Rgb(255, 128, 128),     // Error red (#FF8080)
+        error_text: Color::Rgb(255, 128, 128),       // Error red
+        hint: Color::Rgb(255, 199, 153),             // Accent orange
+        hovered: Color::Rgb(255, 207, 168),          // Hover orange (#FFCFA8)
+        inactive: Color::Rgb(190, 190, 190),         // Higher-contrast muted gray
+        playbar_background: Color::Rgb(22, 22, 22),  // Elevated bg (#161616)
+        playbar_progress: Color::Rgb(153, 255, 228), // Mint
+        playbar_progress_text: Color::Rgb(255, 255, 255), // White for readability
+        playbar_text: Color::Rgb(210, 210, 210),     // Higher-contrast playbar text
+        selected: Color::Rgb(255, 199, 153),         // Accent orange
+        text: Color::Rgb(255, 255, 255),             // White
+        background: Color::Rgb(16, 16, 16),          // Base bg (#101010)
+        header: Color::Rgb(255, 255, 255),           // White
+        highlighted_lyrics: Color::Rgb(153, 255, 228), // Mint
+      },
       ThemePreset::Dracula => Theme {
         analysis_bar: Color::Rgb(189, 147, 249),      // Purple
         analysis_bar_text: Color::Rgb(248, 248, 242), // Foreground


### PR DESCRIPTION
# Summary

<!-- What does this PR change and why? Keep it short. -->
Adds the Vesper theme.

# Testing

<!-- List the commands you ran and their output. Example:
- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked
-->

<img width="1051" height="264" alt="image" src="https://github.com/user-attachments/assets/0cdb73aa-27b1-4c0e-a88b-aee3631c4a08" />

# Additional notes

<!-- Screenshots for UI changes, breaking change callouts, or follow-up work. -->

## Home
<img width="1790" height="1073" alt="image" src="https://github.com/user-attachments/assets/38124b62-d7bf-4e85-9315-6f8efe821dc5" />

## Playlist
<img width="1790" height="1075" alt="image" src="https://github.com/user-attachments/assets/fd100293-c7a3-4b15-ad8a-d3c864abae91" />