### PR TITLE
Implement new logging system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4653,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "discord-rich-presence",
+ "fern",
  "futures",
  "librespot-connect",
  "librespot-core",
@@ -4651,6 +4661,7 @@ dependencies = [
  "librespot-oauth",
  "librespot-playback",
  "librespot-protocol",
+ "log",
  "mpris-server",
  "objc2",
  "objc2-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ librespot-metadata = { version = "0.8", optional = true }
 librespot-protocol = { version = "0.8", optional = true, default-features = false }
 protobuf = { version = "3.7", optional = true }
 futures = "0.3.31"
+log = "0.4.29"
+fern = "0.7.1"
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 pipewire = { version = "0.9", optional = true }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1669,6 +1669,11 @@ fn build_changelog_lines(
   let max_width = usize::from(max_width);
 
   lines.push(Line::from(Span::styled(
+    format!("Log located in /tmp/spotatui_logs/spotatuilog{}",std::process::id()),
+    Style::default().fg(theme.hint),
+  )));
+
+  lines.push(Line::from(Span::styled(
     "Please report any bugs or missing features to https://github.com/LargeModGames/spotatui",
     Style::default().fg(theme.hint),
   )));


### PR DESCRIPTION
# Summary

I modified spotatui to use log and fern for logging. Instead of waiting for panics to occur, you can watch the logs in `/tmp/spotatui_logs/spotatuilog{PID}` while using spotatui

closes #103 

# Testing

You can run spotatui, and run `tail -f /tmp/spotatui_logs/{PID}` while running spotatui. PID is the Process ID of the current spotatui session. You can also check the file with less and use grep to isolate errors. 

# Additional notes

<img width="1728" height="264" alt="image" src="https://github.com/user-attachments/assets/7ec0f838-c0a3-4321-ae9f-5c50f16a3c73" />

I'm watching the logs while running spotatui. 