### PR TITLE
Fails to compile without the `streaming` feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,17 +66,20 @@ use rspotify::{
   prelude::*,
   {AuthCodePkceSpotify, Config, Credentials, OAuth, Token},
 };
+#[cfg(feature = "streaming")]
+use std::time::{Duration, Instant};
 use std::{
   cmp::{max, min},
   fs,
   io::{self, stdout, Write},
   panic,
   path::{Path, PathBuf},
-  sync::{atomic::{AtomicU64, Ordering}, Arc},
+  sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+  },
   time::SystemTime,
 };
-#[cfg(feature = "streaming")]
-use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 #[cfg(feature = "discord-rpc")]


### PR DESCRIPTION
Hi! I just tried building this crate from source without any features and got the following error:
```
spotatui>    Compiling spotatui v0.37.0 (/build/source)
spotatui> error[E0433]: failed to resolve: use of undeclared type `Ordering`
spotatui>     --> src/main.rs:2523:40
spotatui>      |
spotatui> 2523 |             let position_ms = pos.load(Ordering::Relaxed);
spotatui>      |                                        ^^^^^^^^ use of undeclared type `Ordering`
spotatui>      |
spotatui> note: found an item that was configured out
spotatui>     --> src/main.rs:80:17
spotatui>      |
spotatui>   78 | #[cfg(feature = "streaming")]
spotatui>      |       --------------------- the item is gated behind the `streaming` feature
spotatui>   79 | use std::{
spotatui>   80 |   sync::atomic::Ordering,
spotatui>      |                 ^^^^^^^^
spotatui> help: consider importing one of these enums
spotatui>      |
spotatui>   33 + use std::cmp::Ordering;
spotatui>      |
spotatui>   33 + use std::sync::atomic::Ordering;
spotatui>      |
spotatui>
```
Seems like a pretty simple fix, so I took a stab at it by moving `Ordering` out of the `#[cfg(...)]` block into the unconditional `use` above it. Worked immediately for me. Please let me know if this is your preferred solution, and thanks for this great TUI!