### PR TITLE
chore: update nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         packages = rec {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "spotatui";
-            version = "0.37.2";
+            version = "${(builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version}-${self.shortRev or "dirty"}";
             src = self;
 
             cargoLock = {


### PR DESCRIPTION
# Summary

This change makes it so that it loads the commit from the user's flake.lock
This means that it will build of the commit that the user is on. The user can use `nix flake update spotatui` to update the commit they are on and when they next rebuild they will be put on the new version

This is relating to https://github.com/LargeModGames/spotatui/discussions/143#discussioncomment-15998939

<!-- What does this PR change and why? Keep it short. -->

# Testing

<!-- List the commands you ran and their output. Example:
- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked
-->

# Additional notes

<!-- Screenshots for UI changes, breaking change callouts, or follow-up work. -->
