### PR TITLE
fix: recommendations Enter and queue using dead recommended_tracks field

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -587,7 +587,6 @@ pub struct App {
   pub playlist_tracks: Option<Page<PlaylistItem>>,
   pub playlists: Option<Page<SimplifiedPlaylist>>,
   pub recently_played: SpotifyResultAndSelectedIndex<Option<CursorBasedPage<PlayHistory>>>,
-  pub recommended_tracks: Vec<FullTrack>,
   pub recommendations_seed: String,
   pub recommendations_context: Option<RecommendationsContext>,
   pub search_results: SearchResult,
@@ -793,7 +792,6 @@ impl Default for App {
       playlist_offset: 0,
       playlist_tracks: None,
       playlists: None,
-      recommended_tracks: vec![],
       recommendations_context: None,
       recommendations_seed: "".to_string(),
       search_results: SearchResult {

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -412,8 +412,7 @@ fn on_enter(app: &mut App) {
         };
       }
       TrackTableContext::RecommendedTracks => {
-        let playable_ids: Vec<PlayableId<'static>> = app
-          .recommended_tracks
+        let playable_ids: Vec<PlayableId<'static>> = tracks
           .iter()
           .filter_map(|track| track_playable_id(track.id.clone()))
           .collect();
@@ -421,7 +420,7 @@ fn on_enter(app: &mut App) {
           app.dispatch(IoEvent::StartPlayback(
             None,
             Some(playable_ids),
-            Some(app.track_table.selected_index),
+            Some(*selected_index),
           ));
         }
       }
@@ -529,8 +528,8 @@ fn on_queue(app: &mut App) {
         };
       }
       TrackTableContext::RecommendedTracks => {
-        if let Some(full_track) = app.recommended_tracks.get(app.track_table.selected_index) {
-          if let Some(playable_id) = track_playable_id(full_track.id.clone()) {
+        if let Some(track) = tracks.get(*selected_index) {
+          if let Some(playable_id) = track_playable_id(track.id.clone()) {
             app.dispatch(IoEvent::AddItemToQueue(playable_id));
           }
         }


### PR DESCRIPTION
## Prepared with Claude Sonnet 

## Problem

On the recommendations panel (`RouteId::Recommendations`), pressing
Enter to play or the queue key to add a track silently did nothing.

## Root Cause

`on_enter` and `on_queue` for `TrackTableContext::RecommendedTracks`
both read from `app.recommended_tracks`, but this field was **never
written to**. The network layer (`infra/network/recommend.rs`) only
ever populates `app.track_table.tracks`.

## Fix

Both handlers now read directly from `track_table.tracks`, consistent
with every other `TrackTableContext`. The now-dead `recommended_tracks`
field on `App` has been removed.

## Testing

- Navigated to a track → pressed `r` → recommendations panel loaded
- Enter plays the selected track 
- Queue key adds the selected track to queue 
- `s` (save), `w` (add to playlist), `r` (chain recommendations) still work 
- All 108 existing tests pass