### PR TITLE
chore: clean up nix flake version handling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,12 +14,14 @@
         pkgs = import nixpkgs {
           inherit system;
         };
+        cargoVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+        commitHash = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "dirty");
       in {
         # Build dependencies for rust
         packages = rec {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "spotatui";
-            version = "${(builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version}-${self.shortRev or "dirty"}";
+            version = "${cargoVersion}-${commitHash}";
             src = self;
 
             cargoLock = {


### PR DESCRIPTION
# Summary

Cleans up how the version handling is done. Doesn't really matter but makes maintaining/readability slightly better

I would have pointed this out before if github never rage baited me by never telling me you responded to my follow up so i just mentioned assuming you didn't se my follow up

<!-- What does this PR change and why? Keep it short. -->

# Testing

<!-- List the commands you ran and their output. Example:
- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked
-->

# Additional notes

<!-- Screenshots for UI changes, breaking change callouts, or follow-up work. -->
