### PR TITLE
Fix issue #139 playback drift and stabilize paged caches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# Full build (native streaming + audio visualization)
+cargo run
+
+# Slim build — no librespot/audio; fastest iteration, used by CI
+cargo run --no-default-features --features telemetry
+```
+
+## CI Checks (run before opening a PR)
+
+```bash
+cargo fmt --all
+cargo clippy --no-default-features --features telemetry -- -D warnings
+cargo test --no-default-features --features telemetry
+```
+
+## Run a Single Test
+
+```bash
+cargo test --no-default-features --features telemetry <test_name>
+# Example:
+cargo test --no-default-features --features telemetry global_shift_w_adds_current_track_from_anywhere
+```
+
+## Architecture
+
+The codebase is split into four top-level modules under `src/`:
+
+| Module | Role |
+|--------|------|
+| `core/` | Business logic & centralized state (`App`, `UserConfig`, `SortState`) |
+| `infra/` | Infrastructure: Spotify API (`network/`), audio capture/viz (`audio/`), native streaming (`player/`), OS integrations (Discord RPC, MPRIS, macOS media keys) |
+| `tui/` | Terminal UI: rendering (`ui/`), per-screen input handlers (`handlers/`), event loop (`event/`) |
+| `cli/` | CLI argument parsing and self-update logic |
+
+### Data flow
+
+```
+Key event → tui/event/ → tui/handlers/handle_app()
+                           ↓ global keybindings
+                           ↓ handle_block_events() dispatches to per-screen handler
+                           ↓ app.dispatch(IoEvent::…) sends async work
+                        infra/network/ fetches from Spotify API
+                           ↓ mutates App state
+                        tui/ui/ re-renders from App state
+```
+
+### Navigation / routing
+
+`App` holds a navigation stack of `Route` values. Each `Route` contains:
+- `RouteId` — which screen to render (Home, Search, Artist, AlbumTracks, Queue, Settings, Party, …)
+- `ActiveBlock` — which block currently has keyboard focus
+- `HoveredBlock` — which block the cursor is hovering
+
+Use `app.push_navigation_stack(RouteId::X, ActiveBlock::X)` to navigate and `app.pop_navigation_stack()` to go back.
+
+### Listening Party / sync
+
+The Party feature (`src/infra/network/sync.rs`) connects host and guests via WebSocket relay using `SyncMessage` enums. `IoEvent::StartParty`, `JoinParty`, `SyncPlayback`, and `LeaveParty` drive the party lifecycle from handlers.
+
+## Key Conventions
+
+### Adding a new screen / feature
+
+1. Add a variant to `RouteId` and `ActiveBlock` in `src/core/app.rs`.
+2. Create `src/tui/handlers/<screen>.rs` with a `pub fn handler(key: Key, app: &mut App)` function and register it in `src/tui/handlers/mod.rs` (`handle_block_events` match arm).
+3. Create `src/tui/ui/<screen>.rs` with a draw function and wire it into `src/tui/ui/mod.rs`.
+4. Add any new Spotify API calls as `IoEvent` variants in `src/infra/network/mod.rs` and implement them in the appropriate `src/infra/network/<concern>.rs` file.
+
+### Dispatching network calls
+
+Call `app.dispatch(IoEvent::SomeVariant)` from a handler — never call async Spotify code directly from handlers or UI code.
+
+### Paginated results
+
+Use `ScrollableResultPages<T>` (defined in `src/core/app.rs`) for any data that comes back page-by-page from the Spotify API.
+
+For `ScrollableResultPages<Page<T>>` caches specifically:
+- key and dedupe cached pages by `page.offset`, not by insertion order
+- preserve the active visible page by offset when inserting new cached pages
+- treat sparse caches as valid; next/previous page logic must target adjacent offsets, not cache index +/- 1
+- keep visible table state separate from cache state; background prefetch must not append directly into `track_table.tracks`
+- guard background prefetch with a generation/session value so stale tasks cannot write into a reloaded view
+- when a page is already cached, prefer rendering it synchronously from app state instead of routing through another async event
+- for playlist track tables, use `playlist_track_table_id` as the current table identity; `active_playlist_index` is sidebar selection state only
+
+### Status messages
+
+Show feedback with `app.show_status_message(msg, ttl_ms)`. Do not write directly to `app.status_message`.
+
+### Dialog state cleanup
+
+When closing a dialog, always call `app.clear_playlist_track_dialog_state()` alongside `app.dialog = None` and `app.confirm = false`.
+
+### User-configurable keybindings
+
+Always check `app.user_config.keys.<action>` instead of hard-coding key literals when matching global actions (see `handle_app` in `src/tui/handlers/mod.rs`).
+
+### Feature flags
+
+- Default features include `streaming` (librespot) and audio visualization backends.
+- `--no-default-features --features telemetry` is the minimal build used for CI and fast iteration.
+- Platform-specific audio backends (ALSA, PipeWire, PortAudio, Rodio) are gated behind their own features.
+- `cover-art` feature enables album art rendering via `ratatui-image`.
+
+### Native streaming playback
+
+- For native streaming (`spotatui` as the active playback device), URI-list playback without a Spotify context should stay on the direct native `player.load(...)` path in `src/infra/network/playback.rs`.
+- Do not reroute liked songs / saved-track playback on the active native device through Spotify Web API `start_uris_playback(..., device_id=native_device)` as a recovery strategy. That path regressed first-track startup in manual testing even when the UI showed playback starting.
+- If native playback behavior is being changed, verify it with the full `cargo run` build, not only the slim telemetry build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Liked Songs playback/paging drift**: Fixed saved-track playback starting the wrong song, prevented rows from reordering while pages load, stabilized background prefetch around the current page, and made liked hearts render immediately when opening Liked Songs ([#139](https://github.com/LargeModGames/spotatui/issues/139)).
+- **Native playback resume after Enter**: Fixed native streaming loads that could update the playbar to `Playing` without actually resuming audio until play/pause was toggled again.
+- **Playlist paging duplication/reordering**: Fixed playlist tracks duplicating or shuffling while additional pages load by switching playlists to a stable offset-keyed page cache and bounded lookahead prefetch model.
+- **Sparse playlist page navigation**: Fixed playlist next/previous navigation so it now targets the logical adjacent page offset instead of jumping between whatever sparse cached pages happen to exist.
+- **Playlist table identity drift**: Fixed playlist sort/fetch actions so they target the currently open playlist table via `playlist_track_table_id` instead of stale sidebar selection state.
+
 ## [0.37.3] - 2026-03-06
 
 
@@ -1096,4 +1106,3 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -77,10 +77,55 @@ impl<T> ScrollableResultPages<T> {
     self.pages.get_mut(at_index.unwrap_or(self.index))
   }
 
+  pub fn clear(&mut self) {
+    self.index = 0;
+    self.pages.clear();
+  }
+
   pub fn add_pages(&mut self, new_pages: T) {
     self.pages.push(new_pages);
     // Whenever a new page is added, set the active index to the end of the vector
     self.index = self.pages.len() - 1;
+  }
+}
+
+// Offset-keyed page caches are always kept sorted by page.offset, but the cache can be sparse.
+// Visible-page identity must be derived from page.offset, not raw cache index adjacency.
+impl<T> ScrollableResultPages<Page<T>> {
+  pub fn page_index_for_offset(&self, offset: u32) -> Option<usize> {
+    self
+      .pages
+      .binary_search_by_key(&offset, |page| page.offset)
+      .ok()
+  }
+
+  pub fn upsert_page_by_offset(&mut self, new_page: Page<T>) -> usize {
+    let active_page_offset = self.pages.get(self.index).map(|page| page.offset);
+    let new_page_offset = new_page.offset;
+
+    match self
+      .pages
+      .binary_search_by_key(&new_page.offset, |page| page.offset)
+    {
+      Ok(index) => {
+        self.pages[index] = new_page;
+      }
+      Err(index) => {
+        self.pages.insert(index, new_page);
+      }
+    };
+
+    if let Some(active_page_offset) = active_page_offset {
+      if let Some(active_page_index) = self.page_index_for_offset(active_page_offset) {
+        self.index = active_page_index;
+      }
+    } else if !self.pages.is_empty() {
+      self.index = 0;
+    }
+
+    self
+      .page_index_for_offset(new_page_offset)
+      .expect("upserted page offset must exist in cache")
   }
 }
 
@@ -585,6 +630,8 @@ pub struct App {
   pub library: Library,
   pub playlist_offset: u32,
   pub playlist_tracks: Option<Page<PlaylistItem>>,
+  pub playlist_track_pages: ScrollableResultPages<Page<PlaylistItem>>,
+  pub playlist_track_table_id: Option<PlaylistId<'static>>,
   pub playlists: Option<Page<SimplifiedPlaylist>>,
   pub recently_played: SpotifyResultAndSelectedIndex<Option<CursorBasedPage<PlayHistory>>>,
   pub recommendations_seed: String,
@@ -725,6 +772,10 @@ pub struct App {
   pub current_playlist_folder_id: usize,
   /// Incremented every time playlists are refreshed to guard stale background tasks
   pub _playlist_refresh_generation: u64,
+  /// Incremented every time the saved tracks view is reloaded to guard stale prefetch tasks
+  pub saved_tracks_prefetch_generation: u64,
+  /// Incremented every time the playlist track table is reloaded to guard stale prefetch tasks
+  pub playlist_tracks_prefetch_generation: u64,
   /// Reference to the native streaming player for direct control (bypasses event channel)
   #[cfg(feature = "streaming")]
   pub streaming_player: Option<Arc<crate::player::StreamingPlayer>>,
@@ -791,6 +842,8 @@ impl Default for App {
       input_scroll_offset: Cell::new(0),
       playlist_offset: 0,
       playlist_tracks: None,
+      playlist_track_pages: ScrollableResultPages::new(),
+      playlist_track_table_id: None,
       playlists: None,
       recommendations_context: None,
       recommendations_seed: "".to_string(),
@@ -887,6 +940,8 @@ impl Default for App {
       playlist_folder_items: Vec::new(),
       current_playlist_folder_id: 0,
       _playlist_refresh_generation: 0,
+      saved_tracks_prefetch_generation: 0,
+      playlist_tracks_prefetch_generation: 0,
       #[cfg(feature = "streaming")]
       streaming_player: None,
       #[cfg(all(feature = "mpris", target_os = "linux"))]
@@ -1914,14 +1969,195 @@ impl App {
   }
 
   pub fn set_saved_tracks_to_table(&mut self, saved_track_page: &Page<SavedTrack>) {
-    self.dispatch(IoEvent::SetTracksToTable(
+    self.replace_track_table_tracks(
       saved_track_page
         .items
-        .clone()
-        .into_iter()
-        .map(|item| item.track)
+        .iter()
+        .map(|item| item.track.clone())
         .collect::<Vec<FullTrack>>(),
-    ));
+    );
+    self.track_table.context = Some(TrackTableContext::SavedTracks);
+  }
+
+  pub fn set_playlist_tracks_to_table(&mut self, playlist_track_page: &Page<PlaylistItem>) {
+    let mut tracks: Vec<FullTrack> = Vec::new();
+    let mut track_ids: Vec<TrackId<'static>> = Vec::new();
+    let mut positions: Vec<usize> = Vec::new();
+
+    for (idx, item) in playlist_track_page.items.iter().enumerate() {
+      if let Some(PlayableItem::Track(full_track)) = item.track.as_ref() {
+        tracks.push(full_track.clone());
+        if let Some(track_id) = full_track.id.as_ref() {
+          track_ids.push(track_id.clone().into_static());
+        }
+        positions.push(playlist_track_page.offset as usize + idx);
+      }
+    }
+
+    self.replace_track_table_tracks(tracks);
+    self.playlist_track_positions = Some(positions);
+    self.dispatch(IoEvent::CurrentUserSavedTracksContains(track_ids));
+  }
+
+  pub fn reset_saved_tracks_view(&mut self) {
+    self.saved_tracks_prefetch_generation = self.saved_tracks_prefetch_generation.wrapping_add(1);
+    self.library.saved_tracks.clear();
+    self.pending_track_table_selection = None;
+    self.track_table.selected_index = 0;
+    self.track_table.tracks.clear();
+    self.track_table.context = Some(TrackTableContext::SavedTracks);
+  }
+
+  pub fn reset_playlist_tracks_view(
+    &mut self,
+    playlist_id: PlaylistId<'static>,
+    context: TrackTableContext,
+  ) {
+    self.playlist_tracks_prefetch_generation =
+      self.playlist_tracks_prefetch_generation.wrapping_add(1);
+    self.playlist_track_table_id = Some(playlist_id);
+    self.playlist_track_pages.clear();
+    self.playlist_tracks = None;
+    self.playlist_offset = 0;
+    self.pending_track_table_selection = None;
+    self.track_table.selected_index = 0;
+    self.track_table.tracks.clear();
+    self.track_table.context = Some(context);
+    self.playlist_track_positions = None;
+  }
+
+  pub fn replace_track_table_tracks(&mut self, tracks: Vec<FullTrack>) {
+    self.playlist_track_positions = None;
+
+    let track_count = tracks.len();
+    if track_count > 0 {
+      if let Some(pending) = self.pending_track_table_selection.take() {
+        self.track_table.selected_index = match pending {
+          PendingTrackSelection::First => 0,
+          PendingTrackSelection::Last => track_count.saturating_sub(1),
+        };
+      } else {
+        let max_index = track_count.saturating_sub(1);
+        if self.track_table.selected_index > max_index {
+          self.track_table.selected_index = max_index;
+        }
+      }
+    } else {
+      self.track_table.selected_index = 0;
+    }
+
+    self.track_table.tracks = tracks;
+  }
+
+  pub fn is_playlist_track_table_context(&self) -> bool {
+    matches!(
+      self.track_table.context,
+      Some(TrackTableContext::MyPlaylists) | Some(TrackTableContext::PlaylistSearch)
+    )
+  }
+
+  pub fn current_playlist_track_table_id(&self) -> Option<PlaylistId<'static>> {
+    self
+      .is_playlist_track_table_context()
+      .then_some(self.playlist_track_table_id.clone())
+      .flatten()
+  }
+
+  pub fn current_playlist_track_total(&self) -> Option<u32> {
+    self.current_playlist_track_table_id()?;
+    self
+      .playlist_tracks
+      .as_ref()
+      .map(|playlist_tracks| playlist_tracks.total)
+  }
+
+  pub fn current_playlist_track_page(&self) -> Option<&Page<PlaylistItem>> {
+    self.current_playlist_track_table_id()?;
+    self.playlist_tracks.as_ref()
+  }
+
+  pub fn is_playlist_track_table_active_for(&self, playlist_id: &PlaylistId<'_>) -> bool {
+    self
+      .current_playlist_track_table_id()
+      .as_ref()
+      .is_some_and(|current_playlist_id| current_playlist_id.id() == playlist_id.id())
+  }
+
+  pub fn show_saved_tracks_page_at_index(&mut self, page_index: usize) {
+    let Some(saved_tracks_page) = self
+      .library
+      .saved_tracks
+      .get_results(Some(page_index))
+      .cloned()
+    else {
+      return;
+    };
+
+    self.library.saved_tracks.index = page_index;
+    self.set_saved_tracks_to_table(&saved_tracks_page);
+  }
+
+  pub fn show_playlist_tracks_page_at_index(&mut self, page_index: usize) {
+    let Some(playlist_tracks_page) = self
+      .playlist_track_pages
+      .get_results(Some(page_index))
+      .cloned()
+    else {
+      return;
+    };
+
+    self.playlist_track_pages.index = page_index;
+    self.playlist_offset = playlist_tracks_page.offset;
+    self.playlist_tracks = Some(playlist_tracks_page.clone());
+    self.set_playlist_tracks_to_table(&playlist_tracks_page);
+  }
+
+  pub fn show_playlist_tracks_page_at_offset(&mut self, offset: u32) -> Option<usize> {
+    let page_index = self.playlist_track_pages.page_index_for_offset(offset)?;
+    self.show_playlist_tracks_page_at_index(page_index);
+    Some(page_index)
+  }
+
+  pub fn next_missing_saved_tracks_offset(&self, page_index: usize) -> Option<u32> {
+    let saved_tracks_page = self.library.saved_tracks.get_results(Some(page_index))?;
+    saved_tracks_page.next.as_ref()?;
+
+    let next_offset = saved_tracks_page.offset + saved_tracks_page.limit;
+    self
+      .library
+      .saved_tracks
+      .page_index_for_offset(next_offset)
+      .is_none()
+      .then_some(next_offset)
+  }
+
+  pub fn next_missing_playlist_tracks_offset(&self, page_index: usize) -> Option<u32> {
+    let playlist_tracks_page = self.playlist_track_pages.get_results(Some(page_index))?;
+    playlist_tracks_page.next.as_ref()?;
+
+    let next_offset = playlist_tracks_page.offset + playlist_tracks_page.limit;
+    self
+      .playlist_track_pages
+      .page_index_for_offset(next_offset)
+      .is_none()
+      .then_some(next_offset)
+  }
+
+  pub fn dispatch_saved_tracks_prefetch(&mut self, offset: u32) {
+    self.dispatch(IoEvent::PreFetchSavedTracksPage {
+      offset,
+      generation: self.saved_tracks_prefetch_generation,
+    });
+  }
+
+  pub fn dispatch_playlist_tracks_prefetch(&mut self, offset: u32) {
+    if let Some(playlist_id) = self.current_playlist_track_table_id() {
+      self.dispatch(IoEvent::PreFetchPlaylistTracksPage {
+        playlist_id,
+        offset,
+        generation: self.playlist_tracks_prefetch_generation,
+      });
+    }
   }
 
   pub fn set_saved_artists_to_table(&mut self, saved_artists_page: &CursorBasedPage<FullArtist>) {
@@ -1969,15 +2205,13 @@ impl App {
 
   pub fn get_current_user_saved_tracks_next(&mut self) {
     // Before fetching the next tracks, check if we have already fetched them
-    match self
-      .library
-      .saved_tracks
-      .get_results(Some(self.library.saved_tracks.index + 1))
-      .cloned()
-    {
-      Some(saved_tracks) => {
-        self.set_saved_tracks_to_table(&saved_tracks);
-        self.library.saved_tracks.index += 1
+    let next_index = self.library.saved_tracks.index + 1;
+    match self.library.saved_tracks.get_results(Some(next_index)) {
+      Some(_) => {
+        self.show_saved_tracks_page_at_index(next_index);
+        if let Some(offset) = self.next_missing_saved_tracks_offset(next_index) {
+          self.dispatch_saved_tracks_prefetch(offset);
+        }
       }
       None => {
         if let Some(saved_tracks) = &self.library.saved_tracks.get_results(None) {
@@ -1989,13 +2223,80 @@ impl App {
   }
 
   pub fn get_current_user_saved_tracks_previous(&mut self) {
-    if self.library.saved_tracks.index > 0 {
-      self.library.saved_tracks.index -= 1;
+    if self.library.saved_tracks.index == 0 {
+      return;
     }
 
-    if let Some(saved_tracks) = &self.library.saved_tracks.get_results(None).cloned() {
-      self.set_saved_tracks_to_table(saved_tracks);
+    let previous_index = self.library.saved_tracks.index - 1;
+    self.show_saved_tracks_page_at_index(previous_index);
+    if let Some(offset) = self.next_missing_saved_tracks_offset(previous_index) {
+      self.dispatch_saved_tracks_prefetch(offset);
     }
+  }
+
+  pub fn get_playlist_tracks_next(&mut self) {
+    let Some(playlist_tracks) = self.current_playlist_track_page().cloned() else {
+      return;
+    };
+    let Some(playlist_id) = self.current_playlist_track_table_id() else {
+      return;
+    };
+    let Some(next_offset) = playlist_tracks
+      .next
+      .as_ref()
+      .map(|_| playlist_tracks.offset + playlist_tracks.limit)
+    else {
+      return;
+    };
+
+    match self.show_playlist_tracks_page_at_offset(next_offset) {
+      Some(page_index) => {
+        if let Some(offset) = self.next_missing_playlist_tracks_offset(page_index) {
+          self.dispatch_playlist_tracks_prefetch(offset);
+        }
+      }
+      None => {
+        self.dispatch(IoEvent::GetPlaylistItems(playlist_id, next_offset));
+      }
+    }
+  }
+
+  pub fn get_playlist_tracks_previous(&mut self) {
+    let Some(playlist_tracks) = self.current_playlist_track_page().cloned() else {
+      return;
+    };
+    let Some(playlist_id) = self.current_playlist_track_table_id() else {
+      return;
+    };
+    if playlist_tracks.offset == 0 {
+      return;
+    }
+
+    let previous_offset = playlist_tracks.offset.saturating_sub(playlist_tracks.limit);
+    match self.show_playlist_tracks_page_at_offset(previous_offset) {
+      Some(page_index) => {
+        if let Some(offset) = self.next_missing_playlist_tracks_offset(page_index) {
+          self.dispatch_playlist_tracks_prefetch(offset);
+        }
+      }
+      None => {
+        self.dispatch(IoEvent::GetPlaylistItems(playlist_id, previous_offset));
+      }
+    }
+  }
+
+  pub fn apply_sorted_playlist_tracks_if_current(
+    &mut self,
+    playlist_id: &PlaylistId<'_>,
+    tracks: Vec<FullTrack>,
+  ) -> bool {
+    if !self.is_playlist_track_table_active_for(playlist_id) {
+      return false;
+    }
+
+    self.replace_track_table_tracks(tracks);
+    self.track_table.selected_index = 0;
+    true
   }
 
   pub fn shuffle(&mut self) {
@@ -3182,5 +3483,361 @@ impl App {
         _ => {}
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{Duration as ChronoDuration, Utc};
+  use rspotify::model::artist::SimplifiedArtist;
+  use rspotify::prelude::Id;
+  use std::collections::HashMap;
+  use std::sync::mpsc::channel;
+
+  fn full_track(id: &str, name: &str) -> FullTrack {
+    FullTrack {
+      album: SimplifiedAlbum {
+        name: format!("{name} Album"),
+        ..Default::default()
+      },
+      artists: vec![SimplifiedArtist {
+        name: "Artist".to_string(),
+        ..Default::default()
+      }],
+      available_markets: Vec::new(),
+      disc_number: 1,
+      duration: ChronoDuration::milliseconds(180_000),
+      explicit: false,
+      external_ids: HashMap::new(),
+      external_urls: HashMap::new(),
+      href: None,
+      id: Some(TrackId::from_id(id).unwrap().into_static()),
+      is_local: false,
+      is_playable: Some(true),
+      linked_from: None,
+      restrictions: None,
+      name: name.to_string(),
+      popularity: 50,
+      preview_url: None,
+      track_number: 1,
+    }
+  }
+
+  fn saved_track(id: &str, name: &str) -> SavedTrack {
+    SavedTrack {
+      added_at: Utc::now(),
+      track: full_track(id, name),
+    }
+  }
+
+  fn saved_tracks_page(offset: u32, total: u32, ids: &[&str], has_next: bool) -> Page<SavedTrack> {
+    Page {
+      href: "https://example.com/me/tracks".to_string(),
+      items: ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| saved_track(id, &format!("Track {offset}-{index}")))
+        .collect(),
+      limit: ids.len() as u32,
+      next: has_next.then(|| "https://example.com/me/tracks?next".to_string()),
+      offset,
+      previous: None,
+      total,
+    }
+  }
+
+  fn empty_playlist_page(
+    offset: u32,
+    total: u32,
+    limit: u32,
+    has_next: bool,
+  ) -> Page<PlaylistItem> {
+    Page {
+      href: "https://example.com/playlists/test/items".to_string(),
+      items: vec![],
+      limit,
+      next: has_next.then(|| "https://example.com/playlists/test/items?next".to_string()),
+      offset,
+      previous: None,
+      total,
+    }
+  }
+
+  fn playlist_id(id: &str) -> PlaylistId<'static> {
+    PlaylistId::from_id(id).unwrap().into_static()
+  }
+
+  #[test]
+  fn upsert_page_by_offset_preserves_active_index() {
+    let mut pages = ScrollableResultPages::new();
+    pages.add_pages(saved_tracks_page(
+      0,
+      4,
+      &["0000000000000000000001", "0000000000000000000002"],
+      true,
+    ));
+
+    let inserted_index = pages.upsert_page_by_offset(saved_tracks_page(
+      2,
+      4,
+      &["0000000000000000000003", "0000000000000000000004"],
+      false,
+    ));
+
+    assert_eq!(inserted_index, 1);
+    assert_eq!(pages.index, 0);
+    assert_eq!(pages.pages.len(), 2);
+  }
+
+  #[test]
+  fn upsert_page_by_offset_replaces_duplicate_page() {
+    let mut pages = ScrollableResultPages::new();
+    pages.add_pages(saved_tracks_page(
+      0,
+      2,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    ));
+
+    let replaced_index = pages.upsert_page_by_offset(saved_tracks_page(
+      0,
+      2,
+      &["0000000000000000000003", "0000000000000000000004"],
+      false,
+    ));
+
+    assert_eq!(replaced_index, 0);
+    assert_eq!(pages.pages.len(), 1);
+    assert_eq!(
+      pages.pages[0].items[0].track.id.as_ref().unwrap().id(),
+      "0000000000000000000003"
+    );
+  }
+
+  #[test]
+  fn upsert_page_by_offset_keeps_active_page_when_inserting_before_it() {
+    let mut pages = ScrollableResultPages::new();
+    pages.add_pages(saved_tracks_page(
+      0,
+      6,
+      &["0000000000000000000001", "0000000000000000000002"],
+      true,
+    ));
+    pages.add_pages(saved_tracks_page(
+      4,
+      6,
+      &["0000000000000000000005", "0000000000000000000006"],
+      false,
+    ));
+    pages.index = 1;
+
+    let inserted_index = pages.upsert_page_by_offset(saved_tracks_page(
+      2,
+      6,
+      &["0000000000000000000003", "0000000000000000000004"],
+      true,
+    ));
+
+    assert_eq!(inserted_index, 1);
+    assert_eq!(pages.index, 2);
+    assert_eq!(pages.pages[pages.index].offset, 4);
+  }
+
+  #[test]
+  fn reset_saved_tracks_view_clears_cached_pages_and_bumps_generation() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    app.saved_tracks_prefetch_generation = 7;
+    app.library.saved_tracks.add_pages(saved_tracks_page(
+      0,
+      2,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    ));
+    app.track_table.tracks = vec![
+      full_track("0000000000000000000001", "Track 1"),
+      full_track("0000000000000000000002", "Track 2"),
+    ];
+    app.track_table.selected_index = 1;
+
+    app.reset_saved_tracks_view();
+
+    assert_eq!(app.saved_tracks_prefetch_generation, 8);
+    assert!(app.library.saved_tracks.pages.is_empty());
+    assert!(app.track_table.tracks.is_empty());
+    assert_eq!(app.track_table.selected_index, 0);
+    assert_eq!(
+      app.track_table.context,
+      Some(TrackTableContext::SavedTracks)
+    );
+  }
+
+  #[test]
+  fn reset_playlist_tracks_view_clears_cached_pages_and_bumps_generation() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DXcBWIGoYBM5M")
+      .unwrap()
+      .into_static();
+    app.playlist_tracks_prefetch_generation = 4;
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app
+      .playlist_track_pages
+      .add_pages(empty_playlist_page(0, 40, 20, true));
+    app.playlist_tracks = Some(empty_playlist_page(0, 40, 20, true));
+    app.playlist_offset = 20;
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = vec![
+      full_track("0000000000000000000001", "Track 1"),
+      full_track("0000000000000000000002", "Track 2"),
+    ];
+
+    app.reset_playlist_tracks_view(playlist_id.clone(), TrackTableContext::MyPlaylists);
+
+    assert_eq!(app.playlist_tracks_prefetch_generation, 5);
+    assert_eq!(app.playlist_track_table_id, Some(playlist_id));
+    assert!(app.playlist_track_pages.pages.is_empty());
+    assert!(app.playlist_tracks.is_none());
+    assert_eq!(app.playlist_offset, 0);
+    assert!(app.track_table.tracks.is_empty());
+    assert_eq!(app.track_table.selected_index, 0);
+    assert_eq!(
+      app.track_table.context,
+      Some(TrackTableContext::MyPlaylists)
+    );
+  }
+
+  #[test]
+  fn playlist_next_requests_adjacent_offset_when_cache_is_sparse() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = playlist_id("37i9dQZF1DXcBWIGoYBM5M");
+    let first_page = empty_playlist_page(0, 100, 20, true);
+    let last_page = empty_playlist_page(80, 100, 20, false);
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app
+      .playlist_track_pages
+      .upsert_page_by_offset(first_page.clone());
+    app.playlist_track_pages.upsert_page_by_offset(last_page);
+    app.playlist_tracks = Some(first_page);
+    app.playlist_offset = 0;
+
+    app.get_playlist_tracks_next();
+
+    match rx.recv().unwrap() {
+      IoEvent::GetPlaylistItems(id, offset) => {
+        assert_eq!(id.id(), playlist_id.id());
+        assert_eq!(offset, 20);
+      }
+      _ => panic!("unexpected event"),
+    }
+  }
+
+  #[test]
+  fn playlist_previous_requests_adjacent_offset_when_cache_is_sparse() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = playlist_id("37i9dQZF1DX4WYpdgoIcn6");
+    let first_page = empty_playlist_page(0, 100, 20, true);
+    let last_page = empty_playlist_page(80, 100, 20, false);
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app.playlist_track_pages.upsert_page_by_offset(first_page);
+    app
+      .playlist_track_pages
+      .upsert_page_by_offset(last_page.clone());
+    app.playlist_tracks = Some(last_page);
+    app.playlist_offset = 80;
+
+    app.get_playlist_tracks_previous();
+
+    match rx.recv().unwrap() {
+      IoEvent::GetPlaylistItems(id, offset) => {
+        assert_eq!(id.id(), playlist_id.id());
+        assert_eq!(offset, 60);
+      }
+      _ => panic!("unexpected event"),
+    }
+  }
+
+  #[test]
+  fn playlist_next_uses_cached_adjacent_page_before_fetching() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = playlist_id("37i9dQZF1DX4WYpdgoIcn6");
+    let first_page = empty_playlist_page(0, 60, 20, true);
+    let second_page = empty_playlist_page(20, 60, 20, true);
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app
+      .playlist_track_pages
+      .upsert_page_by_offset(first_page.clone());
+    app
+      .playlist_track_pages
+      .upsert_page_by_offset(second_page.clone());
+    app.playlist_tracks = Some(first_page);
+    app.playlist_offset = 0;
+
+    app.get_playlist_tracks_next();
+
+    assert_eq!(app.playlist_offset, 20);
+    assert_eq!(
+      app.playlist_tracks.as_ref().map(|page| page.offset),
+      Some(20)
+    );
+    match rx.recv().unwrap() {
+      IoEvent::CurrentUserSavedTracksContains(track_ids) => {
+        assert!(track_ids.is_empty());
+      }
+      _ => panic!("unexpected event"),
+    }
+    match rx.recv().unwrap() {
+      IoEvent::PreFetchPlaylistTracksPage {
+        playlist_id: id,
+        offset,
+        ..
+      } => {
+        assert_eq!(id.id(), playlist_id.id());
+        assert_eq!(offset, 40);
+      }
+      _ => panic!("unexpected event"),
+    }
+  }
+
+  #[test]
+  fn apply_sorted_playlist_tracks_if_current_requires_matching_playlist_identity_and_context() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let sidebar_playlist_id = playlist_id("37i9dQZF1DXcBWIGoYBM5M");
+    let active_playlist_id = playlist_id("37i9dQZF1DX4WYpdgoIcn6");
+    let original_track = full_track("0000000000000000000001", "Original");
+
+    app.track_table.tracks = vec![original_track.clone()];
+    app.track_table.context = Some(TrackTableContext::PlaylistSearch);
+    app.playlist_track_table_id = Some(active_playlist_id.clone());
+
+    assert!(!app.apply_sorted_playlist_tracks_if_current(
+      &sidebar_playlist_id,
+      vec![full_track("0000000000000000000002", "Wrong Playlist")],
+    ));
+    assert_eq!(
+      app.track_table.tracks[0].id.as_ref().unwrap().id(),
+      original_track.id.as_ref().unwrap().id()
+    );
+
+    app.track_table.context = Some(TrackTableContext::SavedTracks);
+    assert!(!app.apply_sorted_playlist_tracks_if_current(
+      &active_playlist_id,
+      vec![full_track("0000000000000000000003", "Wrong Context")],
+    ));
+    assert_eq!(
+      app.track_table.tracks[0].id.as_ref().unwrap().id(),
+      original_track.id.as_ref().unwrap().id()
+    );
   }
 }

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -2,7 +2,7 @@ use super::requests::{spotify_api_request_json_for, spotify_get_typed_compat_for
 use super::Network;
 use crate::core::app::{
   ActiveBlock, App, PlaylistFolder, PlaylistFolderItem, PlaylistFolderNode, PlaylistFolderNodeType,
-  RouteId, TrackTableContext,
+  RouteId,
 };
 use anyhow::anyhow;
 use reqwest::Method;
@@ -10,7 +10,7 @@ use rspotify::model::{
   idtypes::{AlbumId, PlaylistId, ShowId, TrackId, UserId},
   page::Page,
   playlist::PlaylistItem,
-  track::FullTrack,
+  track::SavedTrack,
   PlayableItem,
 };
 use rspotify::{prelude::*, AuthCodePkceSpotify};
@@ -22,109 +22,114 @@ use tokio::sync::Mutex;
 #[cfg(feature = "streaming")]
 use crate::infra::player::StreamingPlayer;
 
-pub async fn prefetch_all_saved_tracks_task(
-  spotify: AuthCodePkceSpotify,
-  app: Arc<Mutex<App>>,
-  limit: u32,
+const LIBRARY_CONTAINS_MAX_URIS: usize = 50;
+
+#[cfg(test)]
+fn next_saved_tracks_offset(page: &Page<SavedTrack>) -> Option<u32> {
+  page.next.as_ref().map(|_| page.offset + page.limit)
+}
+
+fn uri_batches(uris: &[String]) -> impl Iterator<Item = &[String]> {
+  uris.chunks(LIBRARY_CONTAINS_MAX_URIS)
+}
+
+fn populate_liked_song_ids_from_saved_tracks(
+  liked_song_ids_set: &mut std::collections::HashSet<String>,
+  page: &Page<SavedTrack>,
 ) {
-  let mut offset = 0u32;
-  loop {
-    // Check if stopped
-    {
-      let app = app.lock().await;
-      if !app.is_loading {
-        // Simple heuristic: if loading stopped globally, maybe stop prefetch?
-        // Actually we want prefetch to run in background.
-        // But we should check if user quit.
-      }
-    }
-
-    let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
-    match spotify_get_typed_compat_for::<Page<rspotify::model::SavedTrack>>(
-      &spotify,
-      "me/tracks",
-      &query,
-    )
-    .await
-    {
-      Ok(page) => {
-        if page.items.is_empty() {
-          break;
-        }
-
-        let mut app_guard = app.lock().await;
-        app_guard.library.saved_tracks.add_pages(page.clone());
-
-        // Also update track table if we are currently viewing saved tracks
-        if let Some(TrackTableContext::SavedTracks) = app_guard.track_table.context {
-          // Append to track table
-          let new_tracks: Vec<FullTrack> = page.items.into_iter().map(|item| item.track).collect();
-          app_guard.track_table.tracks.extend(new_tracks);
-        }
-
-        if page.next.is_none() {
-          break;
-        }
-        offset += limit;
-      }
-      Err(_) => break,
+  for item in &page.items {
+    if let Some(track_id) = &item.track.id {
+      liked_song_ids_set.insert(track_id.id().to_string());
     }
   }
 }
 
-pub async fn prefetch_all_playlist_tracks_task(
+pub async fn prefetch_saved_tracks_page_task(
+  spotify: AuthCodePkceSpotify,
+  app: Arc<Mutex<App>>,
+  limit: u32,
+  offset: u32,
+  generation: u64,
+) {
+  let should_fetch = {
+    let app = app.lock().await;
+    app.saved_tracks_prefetch_generation == generation
+      && app
+        .library
+        .saved_tracks
+        .page_index_for_offset(offset)
+        .is_none()
+  };
+
+  if !should_fetch {
+    return;
+  }
+
+  let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+  let Ok(page) = spotify_get_typed_compat_for::<Page<rspotify::model::SavedTrack>>(
+    &spotify,
+    "me/tracks",
+    &query,
+  )
+  .await
+  else {
+    return;
+  };
+
+  if page.items.is_empty() {
+    return;
+  }
+
+  let mut app_guard = app.lock().await;
+  if app_guard.saved_tracks_prefetch_generation != generation {
+    return;
+  }
+
+  populate_liked_song_ids_from_saved_tracks(&mut app_guard.liked_song_ids_set, &page);
+  app_guard.library.saved_tracks.upsert_page_by_offset(page);
+}
+
+pub async fn prefetch_playlist_tracks_page_task(
   spotify: AuthCodePkceSpotify,
   app: Arc<Mutex<App>>,
   limit: u32,
   playlist_id: PlaylistId<'static>,
+  offset: u32,
+  generation: u64,
 ) {
-  let mut offset = 0u32;
-  let path = format!("playlists/{}/items", playlist_id.id());
+  let should_fetch = {
+    let app = app.lock().await;
+    app.playlist_tracks_prefetch_generation == generation
+      && app.is_playlist_track_table_active_for(&playlist_id)
+      && app
+        .playlist_track_pages
+        .page_index_for_offset(offset)
+        .is_none()
+  };
 
-  loop {
-    let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
-    match spotify_get_typed_compat_for::<Page<PlaylistItem>>(&spotify, &path, &query).await {
-      Ok(page) => {
-        if page.items.is_empty() {
-          break;
-        }
-
-        let mut tracks: Vec<FullTrack> = Vec::new();
-        for item in &page.items {
-          if let Some(PlayableItem::Track(full_track)) = item.track.as_ref() {
-            tracks.push(full_track.clone());
-          }
-        }
-
-        let mut app_guard = app.lock().await;
-        // append to playlist_tracks if needed or cache
-        // For now, we update the app state directly if this is the active playlist
-        // But we don't have a check for "active playlist ID".
-        // We just update the track table if context matches.
-
-        // NOTE: The original implementation logic was complex here.
-        // For this refactor, we just fetch and maybe store in a cache if we had one.
-        // Since `playlist_tracks` in App is a single Page, it doesn't support full prefetch well yet.
-        // We will just break loop for now to avoid logic error, effectively disabling full prefetch until feature is fully implemented.
-        // The user asked to split files, not fix logic bugs, but I should try to preserve behavior.
-
-        // Assuming we just want to load them into the track table:
-        if let Some(positions) = &mut app_guard.playlist_track_positions {
-          // Append
-          let start = positions.len();
-          let count = tracks.len();
-          positions.extend(start..start + count);
-        }
-        app_guard.track_table.tracks.extend(tracks);
-
-        if page.next.is_none() {
-          break;
-        }
-        offset += limit;
-      }
-      Err(_) => break,
-    }
+  if !should_fetch {
+    return;
   }
+
+  let path = format!("playlists/{}/items", playlist_id.id());
+  let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+  let Ok(page) = spotify_get_typed_compat_for::<Page<PlaylistItem>>(&spotify, &path, &query).await
+  else {
+    return;
+  };
+
+  if page.items.is_empty() {
+    return;
+  }
+
+  let mut app_guard = app.lock().await;
+  if app_guard.playlist_tracks_prefetch_generation != generation
+    || !app_guard.is_playlist_track_table_active_for(&playlist_id)
+  {
+    return;
+  }
+
+  app_guard.playlist_track_pages.upsert_page_by_offset(page);
 }
 
 pub trait LibraryNetwork {
@@ -164,9 +169,6 @@ pub trait LibraryNetwork {
   async fn toggle_save_track(&mut self, track_id: rspotify::model::idtypes::PlayableId<'static>);
   async fn current_user_saved_tracks_contains(&mut self, ids: Vec<TrackId<'static>>);
   async fn fetch_all_playlist_tracks_and_sort(&mut self, playlist_id: PlaylistId<'static>);
-
-  // Helpers exposed via trait if needed, or kept private if only used internally
-  async fn set_tracks_to_table(&mut self, tracks: Vec<FullTrack>);
 }
 
 // Private helper methods
@@ -176,12 +178,18 @@ impl Network {
       return Ok(Vec::new());
     }
 
-    spotify_get_typed_compat_for(
-      &self.spotify,
-      "me/library/contains",
-      &[("uris", uris.join(","))],
-    )
-    .await
+    let mut all_results = Vec::with_capacity(uris.len());
+    for batch in uri_batches(uris) {
+      let batch_results = spotify_get_typed_compat_for::<Vec<bool>>(
+        &self.spotify,
+        "me/library/contains",
+        &[("uris", batch.join(","))],
+      )
+      .await?;
+      all_results.extend(batch_results);
+    }
+
+    Ok(all_results)
   }
 
   async fn library_save_uris(&self, uris: &[String]) -> anyhow::Result<()> {
@@ -218,21 +226,35 @@ impl Network {
     Ok(())
   }
 
-  async fn set_playlist_tracks_to_table(&mut self, playlist_track_page: &Page<PlaylistItem>) {
-    let mut tracks: Vec<FullTrack> = Vec::new();
-    let mut positions: Vec<usize> = Vec::new();
+  pub fn spawn_saved_tracks_prefetch(&self, offset: u32, generation: u64) {
+    let spotify = self.spotify.clone();
+    let app = self.app.clone();
+    let large_search_limit = self.large_search_limit;
+    tokio::spawn(async move {
+      prefetch_saved_tracks_page_task(spotify, app, large_search_limit, offset, generation).await;
+    });
+  }
 
-    for (idx, item) in playlist_track_page.items.iter().enumerate() {
-      if let Some(PlayableItem::Track(full_track)) = item.track.as_ref() {
-        tracks.push(full_track.clone());
-        positions.push(playlist_track_page.offset as usize + idx);
-      }
-    }
-
-    self.set_tracks_to_table(tracks).await;
-
-    let mut app = self.app.lock().await;
-    app.playlist_track_positions = Some(positions);
+  pub fn spawn_playlist_tracks_prefetch(
+    &self,
+    playlist_id: PlaylistId<'static>,
+    offset: u32,
+    generation: u64,
+  ) {
+    let spotify = self.spotify.clone();
+    let app = self.app.clone();
+    let large_search_limit = self.large_search_limit;
+    tokio::spawn(async move {
+      prefetch_playlist_tracks_page_task(
+        spotify,
+        app,
+        large_search_limit,
+        playlist_id,
+        offset,
+        generation,
+      )
+      .await;
+    });
   }
 }
 
@@ -307,6 +329,11 @@ impl LibraryNetwork for Network {
   }
 
   async fn get_playlist_tracks(&mut self, playlist_id: PlaylistId<'static>, playlist_offset: u32) {
+    let generation = {
+      let app = self.app.lock().await;
+      app.playlist_tracks_prefetch_generation
+    };
+
     let path = format!("playlists/{}/items", playlist_id.id());
     match spotify_get_typed_compat_for::<Page<PlaylistItem>>(
       &self.spotify,
@@ -319,11 +346,26 @@ impl LibraryNetwork for Network {
     .await
     {
       Ok(playlist_tracks) => {
-        self.set_playlist_tracks_to_table(&playlist_tracks).await;
-
         let mut app = self.app.lock().await;
-        app.playlist_tracks = Some(playlist_tracks);
+        if app.playlist_tracks_prefetch_generation != generation
+          || !app.is_playlist_track_table_active_for(&playlist_id)
+        {
+          return;
+        }
+
+        let playlist_tracks_index = app
+          .playlist_track_pages
+          .upsert_page_by_offset(playlist_tracks);
+        app.show_playlist_tracks_page_at_index(playlist_tracks_index);
+
+        let next_offset = app.next_missing_playlist_tracks_offset(playlist_tracks_index);
+        let generation = app.playlist_tracks_prefetch_generation;
         app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+        drop(app);
+
+        if let Some(next_offset) = next_offset {
+          self.spawn_playlist_tracks_prefetch(playlist_id, next_offset, generation);
+        }
       }
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
@@ -332,6 +374,11 @@ impl LibraryNetwork for Network {
   }
 
   async fn get_current_user_saved_tracks(&mut self, offset: Option<u32>) {
+    let generation = {
+      let app = self.app.lock().await;
+      app.saved_tracks_prefetch_generation
+    };
+
     let mut query = vec![("limit", self.large_search_limit.to_string())];
     if let Some(offset) = offset {
       query.push(("offset", offset.to_string()));
@@ -346,32 +393,21 @@ impl LibraryNetwork for Network {
     {
       Ok(saved_tracks) => {
         let mut app = self.app.lock().await;
-        app.track_table.tracks = saved_tracks
-          .items
-          .clone()
-          .into_iter()
-          .map(|item| item.track)
-          .collect::<Vec<FullTrack>>();
-
-        saved_tracks.items.iter().for_each(|item| {
-          if let Some(track_id) = &item.track.id {
-            app.liked_song_ids_set.insert(track_id.to_string());
-          }
-        });
-
-        // Apply pending selection if set
-        let track_count = app.track_table.tracks.len();
-        if track_count > 0 {
-          if let Some(pending) = app.pending_track_table_selection.take() {
-            app.track_table.selected_index = match pending {
-              crate::core::app::PendingTrackSelection::First => 0,
-              crate::core::app::PendingTrackSelection::Last => track_count.saturating_sub(1),
-            };
-          }
+        if app.saved_tracks_prefetch_generation != generation {
+          return;
         }
 
-        app.library.saved_tracks.add_pages(saved_tracks);
-        app.track_table.context = Some(TrackTableContext::SavedTracks);
+        populate_liked_song_ids_from_saved_tracks(&mut app.liked_song_ids_set, &saved_tracks);
+        let saved_tracks_index = app.library.saved_tracks.upsert_page_by_offset(saved_tracks);
+        app.show_saved_tracks_page_at_index(saved_tracks_index);
+
+        let next_offset = app.next_missing_saved_tracks_offset(saved_tracks_index);
+        let generation = app.saved_tracks_prefetch_generation;
+        drop(app);
+
+        if let Some(next_offset) = next_offset {
+          self.spawn_saved_tracks_prefetch(next_offset, generation);
+        }
       }
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
@@ -663,39 +699,6 @@ impl LibraryNetwork for Network {
     }
   }
 
-  async fn set_tracks_to_table(&mut self, tracks: Vec<FullTrack>) {
-    let track_ids: Vec<TrackId<'static>> = tracks
-      .iter()
-      .filter_map(|item| item.id.as_ref().map(|id| id.clone().into_static()))
-      .collect();
-
-    let mut app = self.app.lock().await;
-    app.playlist_track_positions = None;
-
-    let track_count = tracks.len();
-    if track_count > 0 {
-      if let Some(pending) = app.pending_track_table_selection.take() {
-        app.track_table.selected_index = match pending {
-          crate::core::app::PendingTrackSelection::First => 0,
-          crate::core::app::PendingTrackSelection::Last => track_count.saturating_sub(1),
-        };
-      } else {
-        let max_index = track_count.saturating_sub(1);
-        if app.track_table.selected_index > max_index {
-          app.track_table.selected_index = max_index;
-        }
-      }
-    } else {
-      app.track_table.selected_index = 0;
-    }
-
-    app.track_table.tracks = tracks;
-
-    drop(app); // Release lock
-               // Dispatch event to check saved status
-    self.current_user_saved_tracks_contains(track_ids).await;
-  }
-
   async fn fetch_all_playlist_tracks_and_sort(&mut self, playlist_id: PlaylistId<'static>) {
     let mut all_tracks = Vec::new();
     let mut offset = 0u32;
@@ -731,16 +734,109 @@ impl LibraryNetwork for Network {
     // Apply sort if any
     let mut app = self.app.lock().await;
 
-    // Sort
-    use crate::core::sort::{SortContext, Sorter};
-    if let Some(SortContext::PlaylistTracks) = app.sort_context {
-      let sorter = Sorter::new(app.playlist_sort);
-      sorter.sort_tracks(&mut all_tracks);
-    }
+    use crate::core::sort::Sorter;
+    let sorter = Sorter::new(app.playlist_sort);
+    sorter.sort_tracks(&mut all_tracks);
+    let _ = app.apply_sorted_playlist_tracks_if_current(&playlist_id, all_tracks);
+  }
+}
 
-    app.track_table.tracks = all_tracks;
-    // Reset selection
-    app.track_table.selected_index = 0;
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{Duration as ChronoDuration, Utc};
+  use rspotify::model::{artist::SimplifiedArtist, track::FullTrack};
+  use std::collections::{HashMap, HashSet};
+
+  fn full_track(id: &str) -> FullTrack {
+    FullTrack {
+      album: rspotify::model::album::SimplifiedAlbum {
+        name: "Album".to_string(),
+        ..Default::default()
+      },
+      artists: vec![SimplifiedArtist {
+        name: "Artist".to_string(),
+        ..Default::default()
+      }],
+      available_markets: Vec::new(),
+      disc_number: 1,
+      duration: ChronoDuration::milliseconds(180_000),
+      explicit: false,
+      external_ids: HashMap::new(),
+      external_urls: HashMap::new(),
+      href: None,
+      id: Some(TrackId::from_id(id).unwrap().into_static()),
+      is_local: false,
+      is_playable: Some(true),
+      linked_from: None,
+      restrictions: None,
+      name: format!("Track {id}"),
+      popularity: 50,
+      preview_url: None,
+      track_number: 1,
+    }
+  }
+
+  fn saved_track(id: &str) -> SavedTrack {
+    SavedTrack {
+      added_at: Utc::now(),
+      track: full_track(id),
+    }
+  }
+
+  fn saved_tracks_page(offset: u32, limit: u32, has_next: bool) -> Page<SavedTrack> {
+    let ids = match offset {
+      0 => vec!["0000000000000000000001", "0000000000000000000002"],
+      20 => vec!["0000000000000000000003", "0000000000000000000004"],
+      40 => vec!["0000000000000000000005", "0000000000000000000006"],
+      _ => vec!["0000000000000000000007", "0000000000000000000008"],
+    };
+
+    Page {
+      href: "https://example.com/me/tracks".to_string(),
+      items: ids.into_iter().map(saved_track).collect(),
+      limit,
+      next: has_next.then(|| "https://example.com/me/tracks?next".to_string()),
+      offset,
+      previous: None,
+      total: 60,
+    }
+  }
+
+  #[test]
+  fn next_saved_tracks_offset_uses_page_limit() {
+    let page = saved_tracks_page(20, 20, true);
+    assert_eq!(next_saved_tracks_offset(&page), Some(40));
+  }
+
+  #[test]
+  fn next_saved_tracks_offset_returns_none_without_next_link() {
+    let page = saved_tracks_page(20, 20, false);
+    assert_eq!(next_saved_tracks_offset(&page), None);
+  }
+
+  #[test]
+  fn uri_batches_split_large_contains_requests() {
+    let uris = (0..120)
+      .map(|index| format!("spotify:track:{index:022}"))
+      .collect::<Vec<_>>();
+    let batches = uri_batches(&uris)
+      .map(|batch| batch.len())
+      .collect::<Vec<_>>();
+
+    assert_eq!(batches, vec![50, 50, 20]);
+  }
+
+  #[test]
+  fn populate_liked_song_ids_from_saved_tracks_uses_raw_track_ids() {
+    let page = saved_tracks_page(0, 20, false);
+    let mut liked_song_ids_set = HashSet::new();
+
+    populate_liked_song_ids_from_saved_tracks(&mut liked_song_ids_set, &page);
+
+    assert!(liked_song_ids_set.contains("0000000000000000000001"));
+    assert!(liked_song_ids_set.contains("0000000000000000000002"));
+    assert!(!liked_song_ids_set.contains("spotify:track:0000000000000000000001"));
   }
 }
 

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -50,7 +50,6 @@ pub enum IoEvent {
   GetPlaylists,
   GetDevices,
   GetSearchResults(String, Option<Country>),
-  SetTracksToTable(Vec<FullTrack>),
   GetPlaylistItems(PlaylistId<'static>, u32),
   GetCurrentSavedTracks(Option<u32>),
   StartPlayback(
@@ -111,16 +110,17 @@ pub enum IoEvent {
   FetchGlobalSongCount,
   FetchAnnouncements,
   GetLyrics(String, String, f64),
-  /// Start playback from the user's saved tracks collection (Liked Songs)
-  /// Takes the absolute position in the collection to start from
-  /// NOTE: Currently unused - Spotify Web API doesn't support collection context URI
-  /// Keeping for potential future use if Spotify adds support
-  #[allow(dead_code)]
-  StartCollectionPlayback(usize),
-  /// Pre-fetch all saved tracks pages in background for seamless playback
-  PreFetchAllSavedTracks,
-  /// Pre-fetch all tracks from a playlist in background
-  PreFetchAllPlaylistTracks(PlaylistId<'static>),
+  /// Pre-fetch the next saved tracks page in background for smoother page transitions
+  PreFetchSavedTracksPage {
+    offset: u32,
+    generation: u64,
+  },
+  /// Pre-fetch the next playlist page in background for smoother page transitions
+  PreFetchPlaylistTracksPage {
+    playlist_id: PlaylistId<'static>,
+    offset: u32,
+    generation: u64,
+  },
   /// Get user's top tracks for Discover feature (with time range)
   GetUserTopTracks(crate::core::app::DiscoverTimeRange),
   /// Get Top Artists Mix - fetches top artists and their top tracks
@@ -214,9 +214,6 @@ impl Network {
       }
       IoEvent::GetCurrentPlayback => {
         self.get_current_playback().await;
-      }
-      IoEvent::SetTracksToTable(full_tracks) => {
-        self.set_tracks_to_table(full_tracks).await;
       }
       IoEvent::GetSearchResults(search_term, country) => {
         self.get_search_results(search_term, country).await;
@@ -386,27 +383,15 @@ impl Network {
       IoEvent::GetLyrics(track, artist, duration) => {
         self.get_lyrics(track, artist, duration).await;
       }
-      IoEvent::StartCollectionPlayback(offset) => {
-        self.start_collection_playback(offset).await;
+      IoEvent::PreFetchSavedTracksPage { offset, generation } => {
+        self.spawn_saved_tracks_prefetch(offset, generation);
       }
-      IoEvent::PreFetchAllSavedTracks => {
-        // Spawn prefetch as a separate task to avoid blocking playback
-        let spotify = self.spotify.clone();
-        let app = self.app.clone();
-        let large_search_limit = self.large_search_limit;
-        tokio::spawn(async move {
-          library::prefetch_all_saved_tracks_task(spotify, app, large_search_limit).await;
-        });
-      }
-      IoEvent::PreFetchAllPlaylistTracks(playlist_id) => {
-        // Spawn prefetch as a separate task to avoid blocking playback
-        let spotify = self.spotify.clone();
-        let app = self.app.clone();
-        let large_search_limit = self.large_search_limit;
-        tokio::spawn(async move {
-          library::prefetch_all_playlist_tracks_task(spotify, app, large_search_limit, playlist_id)
-            .await;
-        });
+      IoEvent::PreFetchPlaylistTracksPage {
+        playlist_id,
+        offset,
+        generation,
+      } => {
+        self.spawn_playlist_tracks_prefetch(playlist_id, offset, generation);
       }
       IoEvent::GetUserTopTracks(time_range) => {
         self.get_user_top_tracks(time_range).await;

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, Instant};
 #[cfg(feature = "streaming")]
 use librespot_connect::{LoadRequest, LoadRequestOptions, PlayingTrack};
 
+const MAX_API_PLAYBACK_URIS: usize = 100;
+
 pub trait PlaybackNetwork {
   async fn get_current_playback(&mut self);
   async fn start_playback(
@@ -38,8 +40,33 @@ pub trait PlaybackNetwork {
   #[allow(dead_code)]
   async fn add_item_to_queue(&mut self, item: PlayableId<'static>);
   async fn get_queue(&mut self);
-  #[allow(dead_code)]
-  async fn start_collection_playback(&mut self, offset: usize);
+}
+
+fn trim_api_playback_uris(
+  track_uris: Vec<PlayableId<'static>>,
+  offset: Option<usize>,
+) -> (Vec<PlayableId<'static>>, Option<usize>) {
+  if track_uris.len() <= MAX_API_PLAYBACK_URIS {
+    return (track_uris, offset);
+  }
+
+  let selected_index = offset.unwrap_or(0).min(track_uris.len().saturating_sub(1));
+  let preferred_history = MAX_API_PLAYBACK_URIS / 5;
+  let mut start = selected_index.saturating_sub(preferred_history);
+  let end = (start + MAX_API_PLAYBACK_URIS).min(track_uris.len());
+
+  if end - start < MAX_API_PLAYBACK_URIS {
+    start = end.saturating_sub(MAX_API_PLAYBACK_URIS);
+  }
+
+  // Spotify rejects oversized URI payloads, so URI-list playback is capped
+  // to a window that still contains the selected track.
+  let trimmed_uris = track_uris[start..end]
+    .iter()
+    .map(PlayableId::clone_static)
+    .collect::<Vec<_>>();
+
+  (trimmed_uris, Some(selected_index - start))
 }
 
 #[cfg(feature = "streaming")]
@@ -320,6 +347,18 @@ impl PlaybackNetwork for Network {
     uris: Option<Vec<PlayableId<'static>>>,
     offset: Option<usize>,
   ) {
+    let (uris, offset) = if context_id.is_none() {
+      match uris {
+        Some(track_uris) => {
+          let (trimmed_uris, trimmed_offset) = trim_api_playback_uris(track_uris, offset);
+          (Some(trimmed_uris), trimmed_offset)
+        }
+        None => (None, offset),
+      }
+    } else {
+      (uris, offset)
+    };
+
     let desired_shuffle_state = {
       let app = self.app.lock().await;
       app
@@ -845,12 +884,54 @@ impl PlaybackNetwork for Network {
       }
     }
   }
+}
 
-  async fn start_collection_playback(&mut self, _offset: usize) {
-    // Placeholder - Spotify API doesn't support "My Music" as context
-    let mut app = self.app.lock().await;
-    app.status_message =
-      Some("Starting playback from Liked Songs is not yet supported via API".to_string());
-    app.status_message_expires_at = Some(Instant::now() + Duration::from_secs(5));
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use rspotify::model::idtypes::TrackId;
+  use rspotify::prelude::Id;
+
+  fn playable_track(id: &str) -> PlayableId<'static> {
+    PlayableId::Track(TrackId::from_id(id).unwrap().into_static())
+  }
+
+  #[test]
+  fn trim_api_playback_uris_leaves_small_requests_unchanged() {
+    let uris = vec![
+      playable_track("0000000000000000000001"),
+      playable_track("0000000000000000000002"),
+    ];
+
+    let (trimmed, offset) = trim_api_playback_uris(uris.clone(), Some(1));
+
+    assert_eq!(trimmed, uris);
+    assert_eq!(offset, Some(1));
+  }
+
+  #[test]
+  fn trim_api_playback_uris_keeps_selected_track_inside_window() {
+    let uris = (0..150)
+      .map(|index| playable_track(&format!("{index:022}")))
+      .collect::<Vec<_>>();
+
+    let (trimmed, offset) = trim_api_playback_uris(uris.clone(), Some(60));
+
+    assert_eq!(trimmed.len(), MAX_API_PLAYBACK_URIS);
+    assert_eq!(offset, Some(20));
+    assert_eq!(trimmed[offset.unwrap()].uri(), uris[60].uri());
+  }
+
+  #[test]
+  fn trim_api_playback_uris_slides_window_near_end() {
+    let uris = (0..150)
+      .map(|index| playable_track(&format!("{index:022}")))
+      .collect::<Vec<_>>();
+
+    let (trimmed, offset) = trim_api_playback_uris(uris.clone(), Some(149));
+
+    assert_eq!(trimmed.len(), MAX_API_PLAYBACK_URIS);
+    assert_eq!(offset, Some(99));
+    assert_eq!(trimmed[offset.unwrap()].uri(), uris[149].uri());
   }
 }

--- a/src/tui/handlers/common_key_events.rs
+++ b/src/tui/handlers/common_key_events.rs
@@ -67,6 +67,10 @@ pub fn on_high_press_handler() -> usize {
 }
 
 pub fn on_middle_press_handler<T>(selection_data: &[T]) -> usize {
+  if selection_data.is_empty() {
+    return 0;
+  }
+
   let mut index = selection_data.len() / 2;
   if selection_data.len().is_multiple_of(2) {
     index -= 1;
@@ -75,7 +79,7 @@ pub fn on_middle_press_handler<T>(selection_data: &[T]) -> usize {
 }
 
 pub fn on_low_press_handler<T>(selection_data: &[T]) -> usize {
-  selection_data.len() - 1
+  selection_data.len().saturating_sub(1)
 }
 
 pub fn handle_right_event(app: &mut App) {
@@ -183,5 +187,19 @@ mod tests {
     let index = 0;
     let next_index = on_up_press_handler(&data, Some(index));
     assert_eq!(next_index, data.len() - 1);
+  }
+
+  #[test]
+  fn test_on_middle_press_handler_empty() {
+    let data: Vec<&str> = vec![];
+    let next_index = on_middle_press_handler(&data);
+    assert_eq!(next_index, 0);
+  }
+
+  #[test]
+  fn test_on_low_press_handler_empty() {
+    let data: Vec<&str> = vec![];
+    let next_index = on_low_press_handler(&data);
+    assert_eq!(next_index, 0);
   }
 }

--- a/src/tui/handlers/library.rs
+++ b/src/tui/handlers/library.rs
@@ -43,9 +43,8 @@ pub fn handler(key: Key, app: &mut App) {
       }
       // Liked Songs,
       2 => {
+        app.reset_saved_tracks_view();
         app.dispatch(IoEvent::GetCurrentSavedTracks(None));
-        // Pre-fetch more pages in background for seamless playback
-        app.dispatch(IoEvent::PreFetchAllSavedTracks);
         app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
       }
       // Albums,

--- a/src/tui/handlers/playlist.rs
+++ b/src/tui/handlers/playlist.rs
@@ -56,15 +56,12 @@ pub fn handler(key: Key, app: &mut App) {
               // Open the playlist tracks
               if let Some(playlist) = app.all_playlists.get(*index) {
                 app.active_playlist_index = Some(*index);
-                app.track_table.context = Some(TrackTableContext::MyPlaylists);
-                app.playlist_offset = 0;
                 let playlist_id = playlist.id.clone().into_static();
+                app.reset_playlist_tracks_view(playlist_id.clone(), TrackTableContext::MyPlaylists);
                 app.dispatch(IoEvent::GetPlaylistItems(
                   playlist_id.clone(),
                   app.playlist_offset,
                 ));
-                // Pre-fetch more pages in background for seamless playback
-                app.dispatch(IoEvent::PreFetchAllPlaylistTracks(playlist_id));
               }
             }
           }
@@ -95,6 +92,60 @@ pub fn handler(key: Key, app: &mut App) {
 
 #[cfg(test)]
 mod tests {
+  use super::*;
+  use crate::core::user_config::UserConfig;
+  use rspotify::model::{
+    idtypes::{PlaylistId, UserId},
+    playlist::PlaylistTracksRef,
+    SimplifiedPlaylist,
+  };
+  use std::collections::HashMap;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn test_playlist(id: &str, name: &str) -> SimplifiedPlaylist {
+    SimplifiedPlaylist {
+      collaborative: false,
+      external_urls: HashMap::new(),
+      href: format!("https://api.spotify.com/v1/playlists/{id}"),
+      id: PlaylistId::from_id(id).unwrap().into_static(),
+      images: Vec::new(),
+      name: name.to_string(),
+      owner: rspotify::model::PublicUser {
+        display_name: Some("tester".to_string()),
+        external_urls: HashMap::new(),
+        followers: None,
+        href: "https://api.spotify.com/v1/users/spotatui-test-user".to_string(),
+        id: UserId::from_id("spotatui-test-user").unwrap().into_static(),
+        images: Vec::new(),
+      },
+      public: Some(false),
+      snapshot_id: "snapshot".to_string(),
+      tracks: PlaylistTracksRef {
+        href: "https://example.com/playlist/tracks".to_string(),
+        total: 2,
+      },
+    }
+  }
+
   #[test]
-  fn test() {}
+  fn enter_playlist_dispatches_only_visible_page_load() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    app.all_playlists = vec![test_playlist("37i9dQZF1DXcBWIGoYBM5M", "Test Playlist")];
+    app.playlist_folder_items = vec![PlaylistFolderItem::Playlist {
+      index: 0,
+      current_id: 0,
+    }];
+    app.selected_playlist_index = Some(0);
+
+    handler(Key::Enter, &mut app);
+
+    match rx.recv().unwrap() {
+      IoEvent::GetPlaylistItems(_, 0) => {}
+      _ => panic!("expected playlist page fetch"),
+    }
+
+    assert!(rx.try_recv().is_err());
+  }
 }

--- a/src/tui/handlers/search_results.rs
+++ b/src/tui/handlers/search_results.rs
@@ -326,8 +326,8 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
       ) {
         if let Some(playlist) = playlists_result.items.get(index) {
           // Go to playlist tracks table
-          app.track_table.context = Some(TrackTableContext::PlaylistSearch);
           let playlist_id = playlist.id.clone().into_static();
+          app.reset_playlist_tracks_view(playlist_id.clone(), TrackTableContext::PlaylistSearch);
           app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
         };
       }

--- a/src/tui/handlers/sort_menu.rs
+++ b/src/tui/handlers/sort_menu.rs
@@ -104,14 +104,8 @@ fn apply_sort(app: &mut App, field: SortField) {
     // Actually sort the data
     match ctx {
       SortContext::PlaylistTracks => {
-        // For playlists, dispatch network event to fetch all tracks and sort
-        // Get the current playlist ID
-        if let Some(active_playlist_index) = app.active_playlist_index {
-          if let Some(playlist) = app.all_playlists.get(active_playlist_index) {
-            let playlist_id = playlist.id.clone().into_static();
-            app
-              .dispatch(crate::infra::network::IoEvent::FetchAllPlaylistTracksAndSort(playlist_id));
-          }
+        if let Some(playlist_id) = app.current_playlist_track_table_id() {
+          app.dispatch(crate::infra::network::IoEvent::FetchAllPlaylistTracksAndSort(playlist_id));
         }
       }
       SortContext::SavedAlbums => sort_saved_albums(app),
@@ -209,4 +203,68 @@ fn sort_saved_artists(app: &mut App) {
       cmp
     }
   });
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::app::TrackTableContext;
+  use crate::core::user_config::UserConfig;
+  use crate::infra::network::IoEvent;
+  use rspotify::model::{
+    idtypes::{PlaylistId, UserId},
+    playlist::PlaylistTracksRef,
+    SimplifiedPlaylist,
+  };
+  use rspotify::prelude::Id;
+  use std::collections::HashMap;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn test_playlist(id: &str, name: &str) -> SimplifiedPlaylist {
+    SimplifiedPlaylist {
+      collaborative: false,
+      external_urls: HashMap::new(),
+      href: format!("https://api.spotify.com/v1/playlists/{id}"),
+      id: PlaylistId::from_id(id).unwrap().into_static(),
+      images: Vec::new(),
+      name: name.to_string(),
+      owner: rspotify::model::PublicUser {
+        display_name: Some("tester".to_string()),
+        external_urls: HashMap::new(),
+        followers: None,
+        href: "https://api.spotify.com/v1/users/spotatui-test-user".to_string(),
+        id: UserId::from_id("spotatui-test-user").unwrap().into_static(),
+        images: Vec::new(),
+      },
+      public: Some(false),
+      snapshot_id: "snapshot".to_string(),
+      tracks: PlaylistTracksRef {
+        href: "https://example.com/playlist/tracks".to_string(),
+        total: 2,
+      },
+    }
+  }
+
+  #[test]
+  fn playlist_sort_dispatches_for_current_playlist_table_id() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let sidebar_playlist = test_playlist("37i9dQZF1DXcBWIGoYBM5M", "Sidebar Playlist");
+    let search_playlist = test_playlist("37i9dQZF1DX4WYpdgoIcn6", "Search Playlist");
+    app.all_playlists = vec![sidebar_playlist];
+    app.active_playlist_index = Some(0);
+    app.track_table.context = Some(TrackTableContext::PlaylistSearch);
+    app.playlist_track_table_id = Some(search_playlist.id.clone());
+    app.sort_context = Some(SortContext::PlaylistTracks);
+
+    apply_sort(&mut app, SortField::Name);
+
+    match rx.recv().unwrap() {
+      IoEvent::FetchAllPlaylistTracksAndSort(playlist_id) => {
+        assert_eq!(playlist_id.id(), search_playlist.id.id());
+      }
+      _ => panic!("expected playlist sort fetch"),
+    }
+  }
 }

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -10,6 +10,8 @@ use rspotify::model::{
   idtypes::{PlayContextId, PlaylistId, TrackId},
   PlayableId,
 };
+use rspotify::prelude::Id;
+use std::collections::HashSet;
 
 pub fn handler(key: Key, app: &mut App) {
   match key {
@@ -18,21 +20,23 @@ pub fn handler(key: Key, app: &mut App) {
       let current_index = app.track_table.selected_index;
       let tracks_len = app.track_table.tracks.len();
 
+      if tracks_len == 0 {
+        return;
+      }
+
       // Check if we're at the last track and there are more tracks to load
       if current_index == tracks_len - 1 {
         match &app.track_table.context {
-          Some(TrackTableContext::MyPlaylists) => {
-            if let Some(playlist_id) = active_playlist_id_static(app) {
-              if let Some(playlist_tracks) = &app.playlist_tracks {
-                // Check if there are more tracks to fetch
-                if app.playlist_offset + app.large_search_limit < playlist_tracks.total {
-                  app.playlist_offset += app.large_search_limit;
-                  app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
-                  // Set pending selection to move to first track when new page loads
-                  app.pending_track_table_selection = Some(PendingTrackSelection::First);
-                  return;
-                }
-              }
+          Some(TrackTableContext::MyPlaylists) | Some(TrackTableContext::PlaylistSearch) => {
+            let has_next_page = app
+              .current_playlist_track_page()
+              .is_some_and(|playlist_tracks| {
+                playlist_tracks.offset + playlist_tracks.limit < playlist_tracks.total
+              });
+            if has_next_page {
+              app.pending_track_table_selection = Some(PendingTrackSelection::First);
+              app.get_playlist_tracks_next();
+              return;
             }
           }
           Some(TrackTableContext::DiscoverPlaylist) => {
@@ -45,8 +49,8 @@ pub fn handler(key: Key, app: &mut App) {
               let limit = saved_tracks.limit;
               // If there are more tracks beyond current page
               if current_offset + limit < saved_tracks.total {
-                app.get_current_user_saved_tracks_next();
                 app.pending_track_table_selection = Some(PendingTrackSelection::First);
+                app.get_current_user_saved_tracks_next();
                 return;
               }
             }
@@ -64,19 +68,23 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::up_event(k) => {
       let current_index = app.track_table.selected_index;
 
+      if app.track_table.tracks.is_empty() {
+        return;
+      }
+
       // Check if we're at the first track and there are previous tracks to load
       if current_index == 0 {
         match &app.track_table.context {
-          Some(TrackTableContext::MyPlaylists) => {
-            if app.playlist_offset > 0 {
-              if let Some(playlist_id) = active_playlist_id_static(app) {
-                app.playlist_offset = app.playlist_offset.saturating_sub(app.large_search_limit);
-                app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
-                // Set pending selection to move to last track when previous page loads
-                app.pending_track_table_selection = Some(PendingTrackSelection::Last);
-                return;
-              }
+          Some(TrackTableContext::MyPlaylists) | Some(TrackTableContext::PlaylistSearch) => {
+            if app
+              .current_playlist_track_page()
+              .is_some_and(|playlist_tracks| playlist_tracks.offset > 0)
+            {
+              app.pending_track_table_selection = Some(PendingTrackSelection::Last);
+              app.get_playlist_tracks_previous();
+              return;
             }
+            return;
           }
           Some(TrackTableContext::DiscoverPlaylist) => {
             // Discover playlists don't support pagination
@@ -84,11 +92,12 @@ pub fn handler(key: Key, app: &mut App) {
           Some(TrackTableContext::SavedTracks) => {
             // Check if there are previous saved tracks to load
             if app.library.saved_tracks.index > 0 {
-              app.get_current_user_saved_tracks_previous();
               // Set pending selection to move to last track when previous page loads
               app.pending_track_table_selection = Some(PendingTrackSelection::Last);
+              app.get_current_user_saved_tracks_previous();
               return;
             }
+            return;
           }
           _ => {}
         }
@@ -119,14 +128,14 @@ pub fn handler(key: Key, app: &mut App) {
     k if k == app.user_config.keys.next_page => {
       if let Some(context) = &app.track_table.context {
         match context {
-          TrackTableContext::MyPlaylists => {
-            if let Some(playlist_id) = active_playlist_id_static(app) {
-              if let Some(playlist_tracks) = &app.playlist_tracks {
-                if app.playlist_offset + app.large_search_limit < playlist_tracks.total {
-                  app.playlist_offset += app.large_search_limit;
-                  app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
-                }
-              }
+          TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
+            if app
+              .current_playlist_track_page()
+              .is_some_and(|playlist_tracks| {
+                playlist_tracks.offset + playlist_tracks.limit < playlist_tracks.total
+              })
+            {
+              app.get_playlist_tracks_next();
             }
           }
           TrackTableContext::RecommendedTracks => {}
@@ -134,7 +143,6 @@ pub fn handler(key: Key, app: &mut App) {
             app.get_current_user_saved_tracks_next();
           }
           TrackTableContext::AlbumSearch => {}
-          TrackTableContext::PlaylistSearch => {}
           TrackTableContext::DiscoverPlaylist => {}
         }
       };
@@ -143,20 +151,14 @@ pub fn handler(key: Key, app: &mut App) {
     k if k == app.user_config.keys.previous_page => {
       if let Some(context) = &app.track_table.context {
         match context {
-          TrackTableContext::MyPlaylists => {
-            if let Some(playlist_id) = active_playlist_id_static(app) {
-              if app.playlist_offset >= app.large_search_limit {
-                app.playlist_offset -= app.large_search_limit;
-              }
-              app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
-            }
+          TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
+            app.get_playlist_tracks_previous();
           }
           TrackTableContext::RecommendedTracks => {}
           TrackTableContext::SavedTracks => {
             app.get_current_user_saved_tracks_previous();
           }
           TrackTableContext::AlbumSearch => {}
-          TrackTableContext::PlaylistSearch => {}
           TrackTableContext::DiscoverPlaylist => {}
         }
       };
@@ -192,7 +194,7 @@ fn open_add_to_playlist_dialog(app: &mut App) {
 }
 
 fn open_remove_from_playlist_dialog(app: &mut App) {
-  let playlist_context = match active_playlist_target_for_track_table_context(app) {
+  let playlist_context = match current_playlist_target_for_track_table_context(app) {
     Some(context) => context,
     None => {
       app.set_status_message(
@@ -247,9 +249,9 @@ fn open_remove_from_playlist_dialog(app: &mut App) {
 fn play_random_song(app: &mut App) {
   if let Some(context) = &app.track_table.context {
     match context {
-      TrackTableContext::MyPlaylists => {
-        let context_id = active_playlist_context_id(app);
-        let track_json = active_playlist_total_tracks(app);
+      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
+        let context_id = current_playlist_context_id(app);
+        let track_json = current_playlist_total_tracks(app);
 
         if let Some(val) = track_json {
           app.dispatch(IoEvent::StartPlayback(
@@ -278,34 +280,6 @@ fn play_random_song(app: &mut App) {
         }
       }
       TrackTableContext::AlbumSearch => {}
-      TrackTableContext::PlaylistSearch => {
-        let (context_id, playlist_track_json) = match (
-          &app.search_results.selected_playlists_index,
-          &app.search_results.playlists,
-        ) {
-          (Some(selected_playlist_index), Some(playlist_result)) => {
-            if let Some(selected_playlist) = playlist_result
-              .items
-              .get(selected_playlist_index.to_owned())
-            {
-              (
-                Some(playlist_context_id_from_ref(&selected_playlist.id)),
-                Some(selected_playlist.tracks.total),
-              )
-            } else {
-              (None, None)
-            }
-          }
-          _ => (None, None),
-        };
-        if let Some(val) = playlist_track_json {
-          app.dispatch(IoEvent::StartPlayback(
-            context_id,
-            None,
-            Some(thread_rng().gen_range(0..val as usize)),
-          ))
-        }
-      }
       TrackTableContext::DiscoverPlaylist => {
         // Play random track from currently displayed discover playlist, but keep the full list
         // so next/previous can continue within the mix.
@@ -352,21 +326,29 @@ fn handle_recommended_tracks(app: &mut App) {
 fn jump_to_end(app: &mut App) {
   if let Some(context) = &app.track_table.context {
     match context {
-      TrackTableContext::MyPlaylists => {
+      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
         if let (Some(total_tracks), Some(playlist_id)) = (
-          active_playlist_total_tracks(app),
-          active_playlist_id_static(app),
+          current_playlist_total_tracks(app),
+          current_playlist_id_static(app),
         ) {
-          if app.large_search_limit < total_tracks {
-            app.playlist_offset = total_tracks - (total_tracks % app.large_search_limit);
-            app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
+          if total_tracks > 0 {
+            let last_page_offset =
+              ((total_tracks - 1) / app.large_search_limit) * app.large_search_limit;
+            if let Some(cached_index) = app
+              .playlist_track_pages
+              .page_index_for_offset(last_page_offset)
+            {
+              app.show_playlist_tracks_page_at_index(cached_index);
+              return;
+            }
+
+            app.dispatch(IoEvent::GetPlaylistItems(playlist_id, last_page_offset));
           }
         }
       }
       TrackTableContext::RecommendedTracks => {}
       TrackTableContext::SavedTracks => {}
       TrackTableContext::AlbumSearch => {}
-      TrackTableContext::PlaylistSearch => {}
       TrackTableContext::DiscoverPlaylist => {}
     }
   }
@@ -380,18 +362,11 @@ fn on_enter(app: &mut App) {
   } = &app.track_table;
   if let Some(context) = &context {
     match context {
-      TrackTableContext::MyPlaylists => {
+      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
         if let Some(track) = tracks.get(*selected_index) {
           // Get the track ID to play
           let track_playable_id = track_playable_id(track.id.clone());
-
-          let context_id = match &app.active_playlist_index {
-            Some(active_playlist_index) => app
-              .all_playlists
-              .get(active_playlist_index.to_owned())
-              .map(|selected_playlist| playlist_context_id_from_ref(&selected_playlist.id)),
-            _ => None,
-          };
+          let context_id = current_playlist_context_id(app);
 
           // If we have a track ID, play it directly within the context
           // This ensures the selected track plays first, even with shuffle on
@@ -433,34 +408,7 @@ fn on_enter(app: &mut App) {
         }
       }
       TrackTableContext::SavedTracks => {
-        // Collect tracks from ALL loaded pages (not just current page)
-        // This gives us a larger playback range as the user browses
-        let mut all_playable_ids: Vec<PlayableId<'static>> = Vec::new();
-        let current_page_index = app.library.saved_tracks.index;
-
-        // Iterate through all loaded pages
-        for (page_idx, page) in app.library.saved_tracks.pages.iter().enumerate() {
-          for item in &page.items {
-            if let Some(id) = track_playable_id(item.track.id.clone()) {
-              all_playable_ids.push(id);
-            }
-          }
-          // If this is the current page, calculate the absolute offset for the selected track
-          if page_idx == current_page_index {
-            // This is handled below by calculating from page sizes
-          }
-        }
-
-        if !all_playable_ids.is_empty() {
-          // Calculate absolute offset: (sum of previous page sizes) + selected index in current page
-          let mut absolute_offset = 0;
-          for page_idx in 0..current_page_index {
-            if let Some(page) = app.library.saved_tracks.pages.get(page_idx) {
-              absolute_offset += page.items.len();
-            }
-          }
-          absolute_offset += app.track_table.selected_index;
-
+        if let Some((all_playable_ids, absolute_offset)) = saved_tracks_playback_request(app) {
           app.dispatch(IoEvent::StartPlayback(
             None,
             Some(all_playable_ids),
@@ -469,31 +417,6 @@ fn on_enter(app: &mut App) {
         }
       }
       TrackTableContext::AlbumSearch => {}
-      TrackTableContext::PlaylistSearch => {
-        let TrackTable {
-          selected_index,
-          tracks,
-          ..
-        } = &app.track_table;
-        if let Some(_track) = tracks.get(*selected_index) {
-          let context_id = match (
-            &app.search_results.selected_playlists_index,
-            &app.search_results.playlists,
-          ) {
-            (Some(selected_playlist_index), Some(playlist_result)) => playlist_result
-              .items
-              .get(selected_playlist_index.to_owned())
-              .map(|selected_playlist| playlist_context_id_from_ref(&selected_playlist.id)),
-            _ => None,
-          };
-
-          app.dispatch(IoEvent::StartPlayback(
-            context_id,
-            None,
-            Some(app.track_table.selected_index),
-          ));
-        };
-      }
       TrackTableContext::DiscoverPlaylist => {
         // Play the selected track, but include the full discover list so playback can continue.
         let mut playable_ids: Vec<PlayableId<'static>> = Vec::new();
@@ -528,7 +451,7 @@ fn on_queue(app: &mut App) {
   } = &app.track_table;
   if let Some(context) = &context {
     match context {
-      TrackTableContext::MyPlaylists => {
+      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
         if let Some(track) = tracks.get(*selected_index) {
           if let Some(playable_id) = track_playable_id(track.id.clone()) {
             app.dispatch(IoEvent::AddItemToQueue(playable_id));
@@ -552,18 +475,6 @@ fn on_queue(app: &mut App) {
         }
       }
       TrackTableContext::AlbumSearch => {}
-      TrackTableContext::PlaylistSearch => {
-        let TrackTable {
-          selected_index,
-          tracks,
-          ..
-        } = &app.track_table;
-        if let Some(track) = tracks.get(*selected_index) {
-          if let Some(playable_id) = track_playable_id(track.id.clone()) {
-            app.dispatch(IoEvent::AddItemToQueue(playable_id));
-          }
-        };
-      }
       TrackTableContext::DiscoverPlaylist => {
         if let Some(track) = tracks.get(*selected_index) {
           if let Some(playable_id) = track_playable_id(track.id.clone()) {
@@ -578,63 +489,60 @@ fn on_queue(app: &mut App) {
 fn jump_to_start(app: &mut App) {
   if let Some(context) = &app.track_table.context {
     match context {
-      TrackTableContext::MyPlaylists => {
-        if let Some(playlist_id) = active_playlist_id_static(app) {
-          app.playlist_offset = 0;
-          app.dispatch(IoEvent::GetPlaylistItems(playlist_id, app.playlist_offset));
+      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
+        if let Some(cached_index) = app.playlist_track_pages.page_index_for_offset(0) {
+          app.show_playlist_tracks_page_at_index(cached_index);
+        } else if let Some(playlist_id) = current_playlist_id_static(app) {
+          app.dispatch(IoEvent::GetPlaylistItems(playlist_id, 0));
         }
       }
       TrackTableContext::RecommendedTracks => {}
       TrackTableContext::SavedTracks => {}
       TrackTableContext::AlbumSearch => {}
-      TrackTableContext::PlaylistSearch => {}
       TrackTableContext::DiscoverPlaylist => {}
     }
   }
 }
 
-fn active_playlist_id_static(app: &App) -> Option<PlaylistId<'static>> {
-  app
-    .active_playlist_index
-    .and_then(|idx| app.all_playlists.get(idx))
-    .map(|playlist| playlist.id.clone().into_static())
+fn current_playlist_id_static(app: &App) -> Option<PlaylistId<'static>> {
+  app.current_playlist_track_table_id()
 }
 
-fn active_playlist_target_for_track_table_context(
+fn current_playlist_target_for_track_table_context(
   app: &App,
 ) -> Option<(PlaylistId<'static>, String)> {
-  match app.track_table.context {
-    Some(TrackTableContext::MyPlaylists) => app
-      .active_playlist_index
-      .and_then(|idx| app.all_playlists.get(idx))
-      .map(|playlist| (playlist.id.clone().into_static(), playlist.name.clone())),
-    Some(TrackTableContext::PlaylistSearch) => app
-      .search_results
-      .selected_playlists_index
-      .and_then(|idx| {
-        app
-          .search_results
-          .playlists
-          .as_ref()
-          .and_then(|playlists| playlists.items.get(idx))
-      })
-      .map(|playlist| (playlist.id.clone().into_static(), playlist.name.clone())),
-    _ => None,
-  }
+  let playlist_id = current_playlist_id_static(app)?;
+  let playlist_name = playlist_name_for_id(app, &playlist_id)?;
+  Some((playlist_id, playlist_name))
 }
 
-fn active_playlist_context_id(app: &App) -> Option<PlayContextId<'static>> {
+fn playlist_name_for_id(app: &App, playlist_id: &PlaylistId<'_>) -> Option<String> {
   app
-    .active_playlist_index
-    .and_then(|idx| app.all_playlists.get(idx))
-    .map(|playlist| playlist_context_id_from_ref(&playlist.id))
+    .all_playlists
+    .iter()
+    .find(|playlist| playlist.id.id() == playlist_id.id())
+    .map(|playlist| playlist.name.clone())
+    .or_else(|| {
+      app
+        .search_results
+        .playlists
+        .as_ref()
+        .and_then(|playlists| {
+          playlists
+            .items
+            .iter()
+            .find(|playlist| playlist.id.id() == playlist_id.id())
+        })
+        .map(|playlist| playlist.name.clone())
+    })
 }
 
-fn active_playlist_total_tracks(app: &App) -> Option<u32> {
-  app
-    .active_playlist_index
-    .and_then(|idx| app.all_playlists.get(idx))
-    .map(|playlist| playlist.tracks.total)
+fn current_playlist_context_id(app: &App) -> Option<PlayContextId<'static>> {
+  current_playlist_id_static(app).map(|playlist_id| playlist_context_id_from_ref(&playlist_id))
+}
+
+fn current_playlist_total_tracks(app: &App) -> Option<u32> {
+  app.current_playlist_track_total()
 }
 
 fn playlist_context_id_from_ref(id: &PlaylistId<'_>) -> PlayContextId<'static> {
@@ -643,4 +551,270 @@ fn playlist_context_id_from_ref(id: &PlaylistId<'_>) -> PlayContextId<'static> {
 
 fn track_playable_id(id: Option<TrackId<'_>>) -> Option<PlayableId<'static>> {
   id.map(|track_id| PlayableId::Track(track_id.into_static()))
+}
+
+fn saved_tracks_playback_request(app: &App) -> Option<(Vec<PlayableId<'static>>, usize)> {
+  let current_page = app.library.saved_tracks.get_results(None)?;
+  let selected_row_offset = current_page.offset as usize + app.track_table.selected_index;
+  let estimated_tracks = app
+    .library
+    .saved_tracks
+    .pages
+    .iter()
+    .map(|page| page.items.len())
+    .sum();
+  let mut playable_ids = Vec::with_capacity(estimated_tracks);
+  let mut selected_playable_offset = None;
+  let mut seen_offsets = HashSet::new();
+
+  for page in &app.library.saved_tracks.pages {
+    if !seen_offsets.insert(page.offset) {
+      continue;
+    }
+
+    for (item_index, item) in page.items.iter().enumerate() {
+      if let Some(playable_id) = track_playable_id(item.track.id.clone()) {
+        if page.offset as usize + item_index == selected_row_offset {
+          selected_playable_offset = Some(playable_ids.len());
+        }
+        playable_ids.push(playable_id);
+      }
+    }
+  }
+
+  selected_playable_offset.map(|offset| (playable_ids, offset))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::user_config::UserConfig;
+  use chrono::{Duration as ChronoDuration, Utc};
+  use rspotify::model::{
+    artist::SimplifiedArtist,
+    page::Page,
+    track::{FullTrack, SavedTrack},
+  };
+  use rspotify::prelude::Id;
+  use std::collections::HashMap;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn full_track(id: &str, name: &str) -> FullTrack {
+    FullTrack {
+      album: rspotify::model::album::SimplifiedAlbum {
+        name: "Album".to_string(),
+        ..Default::default()
+      },
+      artists: vec![SimplifiedArtist {
+        name: "Artist".to_string(),
+        ..Default::default()
+      }],
+      available_markets: Vec::new(),
+      disc_number: 1,
+      duration: ChronoDuration::milliseconds(180_000),
+      explicit: false,
+      external_ids: HashMap::new(),
+      external_urls: HashMap::new(),
+      href: None,
+      id: Some(TrackId::from_id(id).unwrap().into_static()),
+      is_local: false,
+      is_playable: Some(true),
+      linked_from: None,
+      restrictions: None,
+      name: name.to_string(),
+      popularity: 50,
+      preview_url: None,
+      track_number: 1,
+    }
+  }
+
+  fn saved_track(id: &str, name: &str) -> SavedTrack {
+    SavedTrack {
+      added_at: Utc::now(),
+      track: full_track(id, name),
+    }
+  }
+
+  fn saved_tracks_page(offset: u32, ids: &[&str], has_next: bool) -> Page<SavedTrack> {
+    Page {
+      href: "https://example.com/me/tracks".to_string(),
+      items: ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| saved_track(id, &format!("Track {offset}-{index}")))
+        .collect(),
+      limit: ids.len() as u32,
+      next: has_next.then(|| "https://example.com/me/tracks?next".to_string()),
+      offset,
+      previous: None,
+      total: 4,
+    }
+  }
+
+  fn app_with_saved_tracks() -> (App, std::sync::mpsc::Receiver<IoEvent>) {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    app.track_table.context = Some(TrackTableContext::SavedTracks);
+    (app, rx)
+  }
+
+  #[test]
+  fn saved_tracks_playback_request_uses_page_zero_selection() {
+    let (mut app, _rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &[
+        "0000000000000000000001",
+        "0000000000000000000002",
+        "0000000000000000000003",
+      ],
+      false,
+    );
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = page.items.iter().map(|item| item.track.clone()).collect();
+    app.library.saved_tracks.upsert_page_by_offset(page);
+    app.library.saved_tracks.index = 0;
+
+    let (uris, offset) = saved_tracks_playback_request(&app).unwrap();
+
+    assert_eq!(offset, 1);
+    assert_eq!(uris.len(), 3);
+    assert_eq!(uris[offset].uri(), "spotify:track:0000000000000000000002");
+  }
+
+  #[test]
+  fn saved_tracks_playback_request_uses_absolute_offset_on_later_pages() {
+    let (mut app, _rx) = app_with_saved_tracks();
+    let first_page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      true,
+    );
+    let second_page = saved_tracks_page(
+      2,
+      &["0000000000000000000003", "0000000000000000000004"],
+      false,
+    );
+    app.library.saved_tracks.upsert_page_by_offset(first_page);
+    app
+      .library
+      .saved_tracks
+      .upsert_page_by_offset(second_page.clone());
+    app.library.saved_tracks.index = 1;
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = second_page
+      .items
+      .iter()
+      .map(|item| item.track.clone())
+      .collect();
+
+    let (uris, offset) = saved_tracks_playback_request(&app).unwrap();
+
+    assert_eq!(offset, 3);
+    assert_eq!(uris.len(), 4);
+    assert_eq!(uris[offset].uri(), "spotify:track:0000000000000000000004");
+  }
+
+  #[test]
+  fn enter_dispatches_saved_tracks_playback_for_selected_song() {
+    let (mut app, rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    );
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = page.items.iter().map(|item| item.track.clone()).collect();
+    app.library.saved_tracks.upsert_page_by_offset(page);
+    app.library.saved_tracks.index = 0;
+
+    handler(Key::Enter, &mut app);
+
+    match rx.recv().unwrap() {
+      IoEvent::StartPlayback(None, Some(uris), Some(offset)) => {
+        assert_eq!(offset, 1);
+        assert_eq!(uris[offset].uri(), "spotify:track:0000000000000000000002");
+      }
+      other => panic!("unexpected event: {:?}", event_name(&other)),
+    }
+  }
+
+  #[test]
+  fn empty_track_table_down_event_does_not_panic() {
+    let (mut app, _rx) = app_with_saved_tracks();
+    app.track_table.tracks.clear();
+    app.track_table.selected_index = 0;
+
+    handler(Key::Down, &mut app);
+
+    assert_eq!(app.track_table.selected_index, 0);
+  }
+
+  #[test]
+  fn up_on_first_saved_tracks_row_without_previous_page_does_not_wrap() {
+    let (mut app, _rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      true,
+    );
+    app.track_table.selected_index = 0;
+    app.track_table.tracks = page.items.iter().map(|item| item.track.clone()).collect();
+    app.library.saved_tracks.upsert_page_by_offset(page);
+    app.library.saved_tracks.index = 0;
+
+    handler(Key::Up, &mut app);
+
+    assert_eq!(app.track_table.selected_index, 0);
+  }
+
+  #[test]
+  fn up_on_first_playlist_row_without_previous_page_does_not_wrap() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.track_table.tracks = vec![
+      full_track("0000000000000000000001", "Track 1"),
+      full_track("0000000000000000000002", "Track 2"),
+    ];
+    app.track_table.selected_index = 0;
+    app.playlist_offset = 0;
+
+    handler(Key::Up, &mut app);
+
+    assert_eq!(app.track_table.selected_index, 0);
+  }
+
+  #[test]
+  fn saved_tracks_playback_request_ignores_duplicate_page_offsets() {
+    let (mut app, _rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    );
+    app.library.saved_tracks.add_pages(page.clone());
+    app.library.saved_tracks.add_pages(page);
+    app.library.saved_tracks.index = 0;
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = app.library.saved_tracks.pages[0]
+      .items
+      .iter()
+      .map(|item| item.track.clone())
+      .collect();
+
+    let (uris, offset) = saved_tracks_playback_request(&app).unwrap();
+
+    assert_eq!(offset, 1);
+    assert_eq!(uris.len(), 2);
+    assert_eq!(uris[offset].uri(), "spotify:track:0000000000000000000002");
+  }
+
+  fn event_name(event: &IoEvent) -> &'static str {
+    match event {
+      IoEvent::StartPlayback(_, _, _) => "StartPlayback",
+      _ => "other",
+    }
+  }
 }


### PR DESCRIPTION
# Summary

This PR fixes playback drift and paged collection instability by replacing append-order page handling with offset-keyed page caches, separating visible page state from background prefetch state, and binding playlist actions to the currently open track table’s playlist identity instead of transient sidebar/search selection state. This PR also makes liked hearts render immediately when opening Liked Songs. It also adds generation guards to prevent stale async page writes and fixes playback offset calculation for sparse or out-of-order cached pages.

# Testing
Ran locally and did some basic testing with Liked songs, going up and down multiple pages and playing songs, queuing songs, choosing random songs, and verifying playlists.

<!-- List the commands you ran and their output. Example:
- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked
-->

`cargo test --locked` outputted:
```
test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```

# Additional notes

- No breaking changes.
- This is mostly a behavior/stability fix rather than a visual UI change, so screenshots are probably unnecessary.
- Liked Songs now keeps the selected song aligned with the playback request, avoids row reordering while pages load, and populates liked-heart state immediately when the view opens.
- Playlist paging now navigates by adjacent offsets, works correctly with sparse cached pages, and avoids duplicate/reordered rows during background loading.
- Playlist sort, play, queue, and remove actions now resolve against `playlist_track_table_id`, which matches the playlist currently open in the track table.
- URI-list playback is trimmed to Spotify's API limits while preserving the selected track in the playback window.
- Added regression coverage for sparse cache navigation, stale prefetch guards, saved-track playback offsets, playlist identity targeting, and empty-list navigation safety.