### PR TITLE
Void Linux installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ yay -S spotatui-bin
 
 # Arch Linux (AUR) - build from source
 yay -S spotatui
+
+# Void Linux (Unoffical Repo)
+echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
+sudo xbps-install -S spotatui
 ```
 ```nix
 # NixOS (Flake)


### PR DESCRIPTION
Added commands to install spotatui on Void Linux.

It uses unofficial package repo ([Blackhole-vl](https://github.com/Event-Horizon-VL/blackhole-vl))