### PR TITLE
Mallformed request and asks for auth on every startup

### DIFF
--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -392,7 +392,13 @@ impl StreamingPlayer {
 
       match timeout(Duration::from_secs(init_timeout_secs), spirc_new).await {
         Ok(Ok(result)) => break result,
-        Ok(Err(e)) if used_cached_credentials && !retried_with_fresh_credentials => {
+        Ok(Err(e))
+          if should_retry_with_fresh_credentials(
+            true,
+            used_cached_credentials,
+            retried_with_fresh_credentials,
+          ) =>
+        {
           warn!(
             "Cached streaming credentials failed ({:?}); retrying with a fresh OAuth login",
             e
@@ -613,74 +619,48 @@ impl StreamingPlayer {
 // Re-export PlayerEvent for use in other modules
 pub use librespot_playback::player::PlayerEvent;
 
+/// Returns true when a Spirc init failure should be retried with fresh OAuth
+/// credentials instead of cached ones.
+fn should_retry_with_fresh_credentials(
+  auth_error: bool,
+  used_cached: bool,
+  already_retried: bool,
+) -> bool {
+  auth_error && used_cached && !already_retried
+}
+
 #[cfg(test)]
 mod tests {
-  enum SpircOutcome {
-    Success,
-    AuthFailure(String),
-    Timeout,
-  }
-
-  fn should_retry_with_fresh_credentials(
-    outcome: &SpircOutcome,
-    used_cached: bool,
-    already_retried: bool,
-  ) -> bool {
-    matches!(outcome, SpircOutcome::AuthFailure(_)) && used_cached && !already_retried
-  }
+  use super::should_retry_with_fresh_credentials;
 
   #[test]
   fn auth_failure_with_cached_creds_triggers_retry() {
-    assert!(should_retry_with_fresh_credentials(
-      &SpircOutcome::AuthFailure("bad token".into()),
-      true,
-      false,
-    ));
+    assert!(should_retry_with_fresh_credentials(true, true, false));
   }
 
   #[test]
   fn timeout_with_cached_creds_does_not_trigger_retry() {
-    assert!(!should_retry_with_fresh_credentials(
-      &SpircOutcome::Timeout,
-      true,
-      false,
-    ));
+    assert!(!should_retry_with_fresh_credentials(false, true, false));
   }
 
   #[test]
   fn auth_failure_with_fresh_creds_does_not_trigger_retry() {
-    assert!(!should_retry_with_fresh_credentials(
-      &SpircOutcome::AuthFailure("bad token".into()),
-      false,
-      false,
-    ));
+    assert!(!should_retry_with_fresh_credentials(true, false, false));
   }
 
   #[test]
   fn timeout_with_fresh_creds_does_not_trigger_retry() {
-    assert!(!should_retry_with_fresh_credentials(
-      &SpircOutcome::Timeout,
-      false,
-      false,
-    ));
+    assert!(!should_retry_with_fresh_credentials(false, false, false));
   }
 
   #[test]
   fn auth_failure_already_retried_does_not_trigger_second_retry() {
-    assert!(!should_retry_with_fresh_credentials(
-      &SpircOutcome::AuthFailure("bad token".into()),
-      true,
-      true,
-    ));
+    assert!(!should_retry_with_fresh_credentials(true, true, true));
   }
 
   #[test]
   fn success_never_triggers_retry() {
-    assert!(!should_retry_with_fresh_credentials(
-      &SpircOutcome::Success,
-      true,
-      false,
-    ));
+    assert!(!should_retry_with_fresh_credentials(false, true, false));
   }
 }
 

--- a/src/infra/redirect_uri.rs
+++ b/src/infra/redirect_uri.rs
@@ -43,6 +43,13 @@ fn handle_connection(mut stream: TcpStream) -> Option<String> {
         // Extract the path from the HTTP request (e.g., "/callback?code=...&state=...")
         let path = split[1];
 
+        // Only accept requests that contain a `code` query parameter — the OAuth callback.
+        // Ignore browser noise like /favicon.ico, pre-flight requests, etc.
+        if !path.contains("code=") {
+          send_error_response("Not a callback request".to_string(), stream);
+          return None;
+        }
+
         // Parse the host header to build the full URL
         let host = request
           .lines()
@@ -152,6 +159,20 @@ mod tests {
   fn preflight_single_token_returns_none() {
     // A single token (no path) also triggers the malformed branch → None, no panic
     let result = send_to_handle_connection(b"GET");
+    assert!(result.is_none());
+  }
+
+  #[test]
+  fn favicon_request_returns_none() {
+    let request = b"GET /favicon.ico HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
+    let result = send_to_handle_connection(request);
+    assert!(result.is_none());
+  }
+
+  #[test]
+  fn root_request_returns_none() {
+    let request = b"GET / HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
+    let result = send_to_handle_connection(request);
     assert!(result.is_none());
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1209,11 +1209,12 @@ of the app. Beware that this comes at a CPU cost!",
         .and_then(|v| v.parse().ok())
         .filter(|&v: &u64| v > 0)
         .unwrap_or(30);
-      let outer_timeout = Duration::from_secs(internal_timeout_secs + 15);
+      let outer_timeout = Duration::from_secs(internal_timeout_secs.saturating_add(15));
 
       let init_task = tokio::spawn(async move {
         player::StreamingPlayer::new(&client_id, &redirect_uri, streaming_config).await
       });
+      let abort_handle = init_task.abort_handle();
 
       match tokio::time::timeout(outer_timeout, init_task).await {
         Ok(Ok(Ok(p))) => {
@@ -1240,6 +1241,7 @@ of the app. Beware that this comes at a CPU cost!",
           None
         }
         Err(_) => {
+          abort_handle.abort();
           warn!(
             "streaming initialization hung unexpectedly (outer timeout {}s) - falling back to web api",
             outer_timeout.as_secs()


### PR DESCRIPTION
This pull request improves error handling and reliability in streaming player initialization and OAuth redirect handling, and adds comprehensive tests for both areas. The main focus is on making timeouts and authentication failures more robust and user-friendly, while also ensuring that the application falls back gracefully to the web API when streaming fails. Additionally, the codebase is made more testable and logging is improved for better debugging.

**Streaming player initialization improvements:**

- Changed error handling in `StreamingPlayer`: now, timeouts during streaming initialization do not clear cached credentials or trigger retries with fresh credentials, as a timeout is likely due to network issues, not bad credentials. This prevents unnecessary credential refreshes and improves reliability. [[1]](diffhunk://#diff-80c47452dc8c55fb4cb11f5c29fce07eb834e84791386be686f38bd333ce6f57L396-R396) [[2]](diffhunk://#diff-80c47452dc8c55fb4cb11f5c29fce07eb834e84791386be686f38bd333ce6f57L406-R415)
- Improved logging by replacing `println!` with `warn!` for errors and timeouts, ensuring better integration with the application's logging system. [[1]](diffhunk://#diff-80c47452dc8c55fb4cb11f5c29fce07eb834e84791386be686f38bd333ce6f57L396-R396) [[2]](diffhunk://#diff-80c47452dc8c55fb4cb11f5c29fce07eb834e84791386be686f38bd333ce6f57L406-R415) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR68-R69)
- Refined the main initialization logic in `main.rs` to use a two-level timeout: an internal timeout for Spirc (streaming backend) and an outer timeout to catch hangs outside Spirc initialization, with clear, user-facing log messages for each failure mode. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1201-R1219) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1229-R1246)

**Testing and code quality:**

- Added unit tests for the logic that decides when to retry with fresh credentials after a streaming initialization failure, ensuring correct behavior for all combinations of outcomes and credential states.
- Added integration-style tests for the OAuth redirect URI handler, covering valid callbacks, malformed requests, and browser pre-flight scenarios, improving robustness and maintainability.

**OAuth redirect handler improvements:**

- Improved handling of malformed HTTP requests in the OAuth redirect handler: such requests are now handled silently (as they are often browser pre-flight checks), and error responses are sent without unnecessary logging. The error response function was renamed for clarity and made more robust. [[1]](diffhunk://#diff-09d06ba2083b43a881bfa560a06028a0b60644bbf96058215714f6eb06c6b0c1L61-R68) [[2]](diffhunk://#diff-09d06ba2083b43a881bfa560a06028a0b60644bbf96058215714f6eb06c6b0c1L86-R157)Fixes #170

