### PR TITLE
fix: handle 5xx server errors with retry message in playback network

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3518,8 +3518,8 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-  use crate::core::test_helpers::{private_user, simplified_playlist};
   use super::*;
+  use crate::core::test_helpers::{private_user, simplified_playlist};
   use chrono::{Duration as ChronoDuration, Utc};
   use rspotify::model::{artist::SimplifiedArtist, idtypes::PlaylistId};
   use rspotify::prelude::Id;

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -332,6 +332,21 @@ impl PlaybackNetwork for Network {
           return;
         }
 
+        if err.to_string().contains("504")
+          || err.to_string().contains("503")
+          || err.to_string().contains("502")
+          || err.to_string().contains("Gateway Timeout")
+          || err.to_string().contains("Service Unavailable")
+          || err.to_string().contains("Bad Gateway")
+        {
+          app.status_message = Some(
+            "Spotify server temporarily unavailable (5xx); retrying automatically.".to_string(),
+          );
+          app.status_message_expires_at = Some(Instant::now() + Duration::from_secs(10));
+          app.instant_since_last_current_playback_poll = Instant::now();
+          return;
+        }
+
         app.handle_error(err);
         return;
       }


### PR DESCRIPTION
This pull request primarily improves error handling for Spotify server errors in playback networking, and makes a minor import order fix in the test module. The most significant change is the addition of user-friendly messaging and retry logic for temporary Spotify server issues.

**Playback network error handling improvements:**

* Added detection for Spotify server 5xx errors (502, 503, 504, "Gateway Timeout", "Service Unavailable", "Bad Gateway") in `Network`'s playback error handling. When such an error is detected, a clear status message is shown to the user, and polling is automatically retried after a short delay, improving user experience during transient outages.

**Test module cleanup:**

* Fixed the import order in the test module of `src/core/app.rs` by moving the `test_helpers` import to follow the module declaration, improving code organization.