### PR TITLE
fix: followed artists list display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- **Followed Artists list appears empty**: Fixed Artists veiw in Library to correctly display followed artists ([#219](https://github.com/LargeModGames/spotatui/issues/219)).
 - **Hidden fullscreen cover-art centering**: Fixed the fullscreen cover art image rendering slightly off-center when the playbar was completely hidden.
 - **Volume display glitch on rapid changes**: Fixed the volume percentage briefly reverting to an old value after the user changed it, especially noticeable when spamming volume up/down. The UI now always shows the user's intended volume until Spotify's API confirms it matches.
 

--- a/src/tui/handlers/artists.rs
+++ b/src/tui/handlers/artists.rs
@@ -40,36 +40,36 @@ pub fn handler(key: Key, app: &mut App) {
       }
     }
     Key::Enter => {
-      let artists = app.artists.to_owned();
-      if !artists.is_empty() {
-        let artist = &artists[app.artists_list_index];
-        app.get_artist(artist.id.as_ref().into_static(), artist.name.clone());
+      if let Some(artists) = app.library.saved_artists.get_results(None) {
+        if let Some(artist) = artists.items.get(app.artists_list_index) {
+          app.get_artist(artist.id.as_ref().into_static(), artist.name.clone());
+        }
       }
     }
     Key::Char('D') => app.user_unfollow_artists(ActiveBlock::AlbumList),
     Key::Char('e') => {
-      let artists = app.artists.to_owned();
-      let artist = artists.get(app.artists_list_index);
-      if let Some(artist) = artist {
-        app.dispatch(IoEvent::StartPlayback(
-          Some(rspotify::model::PlayContextId::Artist(
-            artist.id.clone().into_static(),
-          )),
-          None,
-          None,
-        ));
+      if let Some(artists) = app.library.saved_artists.get_results(None) {
+        if let Some(artist) = artists.items.get(app.artists_list_index) {
+          app.dispatch(IoEvent::StartPlayback(
+            Some(rspotify::model::PlayContextId::Artist(
+              artist.id.clone().into_static(),
+            )),
+            None,
+            None,
+          ));
+        }
       }
     }
     Key::Char('r') => {
-      let artists = app.artists.to_owned();
-      let artist = artists.get(app.artists_list_index);
-      if let Some(artist) = artist {
-        let artist_name = artist.name.clone();
-        let artist_id_list: Option<Vec<String>> = Some(vec![artist.id.id().to_string()]);
+      if let Some(artists) = app.library.saved_artists.get_results(None) {
+        if let Some(artist) = artists.items.get(app.artists_list_index) {
+          let artist_name = artist.name.clone();
+          let artist_id_list: Option<Vec<String>> = Some(vec![artist.id.id().to_string()]);
 
-        app.recommendations_context = Some(RecommendationsContext::Artist);
-        app.recommendations_seed = artist_name;
-        app.get_recommendations_for_seed(artist_id_list, None, None);
+          app.recommendations_context = Some(RecommendationsContext::Artist);
+          app.recommendations_seed = artist_name;
+          app.get_recommendations_for_seed(artist_id_list, None, None);
+        }
       }
     }
     k if k == app.user_config.keys.next_page => app.get_current_user_saved_artists_next(),

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -77,24 +77,37 @@ pub fn draw_artist_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     current_route.active_block == ActiveBlock::Artists,
     current_route.hovered_block == ActiveBlock::Artists,
   );
-  let items = app
-    .artists
-    .iter()
-    .map(|item| TableItem {
-      id: item.id.id().to_string(),
-      format: vec![item.name.to_owned()],
-    })
-    .collect::<Vec<TableItem>>();
 
-  draw_table(
-    f,
-    app,
-    layout_chunk,
-    ("Artists", &header),
-    &items,
-    app.artists_list_index,
-    highlight_state,
-  )
+  if let Some(saved_artists) = app.library.saved_artists.get_results(None) {
+    let items = saved_artists
+      .items
+      .iter()
+      .map(|item| TableItem {
+        id: item.id.id().to_string(),
+        format: vec![item.name.to_owned()],
+      })
+      .collect::<Vec<TableItem>>();
+
+    draw_table(
+      f,
+      app,
+      layout_chunk,
+      ("Artists", &header),
+      &items,
+      app.artists_list_index,
+      highlight_state,
+    )
+  } else {
+    draw_table(
+      f,
+      app,
+      layout_chunk,
+      ("Artists", &header),
+      &[],
+      app.artists_list_index,
+      highlight_state,
+    )
+  }
 }
 
 pub fn draw_podcast_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {


### PR DESCRIPTION
# Summary

Fixes #219 empty followed artists list in Library view. The API response was stored in `app.library.saved_artists` but the UI and action handlers were reading from the unused `app.artists` field.

# Testing

- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked

All passed

# Additional notes

The list is now rendered properly, no screenshot to not disappoint you with my musical taste :D
Build and test locally takes 1 min
