### PR TITLE
Fix: Themes preset editing and persistence and display of theme item values

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3737,6 +3737,28 @@ impl App {
       }
     }
   }
+
+  /// Updates the colour RGB entries when switching through the presets in themes
+  pub fn sync_theme_color_settings(&mut self, theme: &crate::core::user_config::Theme) {
+    let mappings: [(&str, ratatui::style::Color); 11] = [
+      ("theme.active", theme.active),
+      ("theme.banner", theme.banner),
+      ("theme.hint", theme.hint),
+      ("theme.hovered", theme.hovered),
+      ("theme.selected", theme.selected),
+      ("theme.inactive", theme.inactive),
+      ("theme.text", theme.text),
+      ("theme.error_text", theme.error_text),
+      ("theme.playbar_background", theme.playbar_background),
+      ("theme.playbar_progress", theme.playbar_progress),
+      ("theme.highlighted_lyrics", theme.highlighted_lyrics),
+    ];
+    for setting in &mut self.settings_items {
+      if let Some((_, color)) = mappings.iter().find(|(id, _)| *id == setting.id) {
+        setting.value = SettingValue::Color(color_to_string(*color));
+      }
+    }
+  }
 }
 
 #[cfg(test)]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3280,6 +3280,12 @@ impl App {
             value: SettingValue::Color(color_to_string(self.user_config.theme.error_text)),
           },
           SettingItem {
+            id: "theme.error_border".to_string(),
+            name: "Error Border Color".to_string(),
+            description: "Border color for error messages".to_string(),
+            value: SettingValue::Color(color_to_string(self.user_config.theme.error_border)),
+          },
+          SettingItem {
             id: "theme.playbar_background".to_string(),
             name: "Playbar Background".to_string(),
             description: "Background color for playbar".to_string(),
@@ -3292,10 +3298,34 @@ impl App {
             value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_progress)),
           },
           SettingItem {
+            id: "theme.playbar_progress_text".to_string(),
+            name: "Playbar Progress Text".to_string(),
+            description: "Color for playbar progress text".to_string(),
+            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_progress_text)),
+          },
+          SettingItem {
+            id: "theme.playbar_text".to_string(),
+            name: "Playbar Text".to_string(),
+            description: "Color for playbar text".to_string(),
+            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_text)),
+          },
+          SettingItem {
             id: "theme.highlighted_lyrics".to_string(),
             name: "Lyrics Highlight".to_string(),
             description: "Color for current lyrics line".to_string(),
             value: SettingValue::Color(color_to_string(self.user_config.theme.highlighted_lyrics)),
+          },
+          SettingItem {
+            id: "theme.background".to_string(),
+            name: "Background".to_string(),
+            description: "Color for the background".to_string(),
+            value: SettingValue::Color(color_to_string(self.user_config.theme.background)),
+          },
+          SettingItem {
+            id: "theme.header".to_string(),
+            name: "Header".to_string(),
+            description: "Color for the header".to_string(),
+            value: SettingValue::Color(color_to_string(self.user_config.theme.header)),
           },
         ]
       }
@@ -3709,6 +3739,14 @@ impl App {
             }
           }
         }
+        "theme.error_border" if self.user_config.current_preset == ThemePreset::Custom => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = parse_theme_item(v) {
+              self.user_config.theme.error_border= c;
+              self.user_config.custom_theme.error_border= c;
+            }
+          }
+        }
         "theme.playbar_background" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
@@ -3725,11 +3763,43 @@ impl App {
             }
           }
         }
+        "theme.playbar_progress_text" if self.user_config.current_preset == ThemePreset::Custom => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = parse_theme_item(v) {
+              self.user_config.theme.playbar_progress_text = c;
+              self.user_config.custom_theme.playbar_progress_text = c;
+            }
+          }
+        }
+        "theme.playbar_text" if self.user_config.current_preset == ThemePreset::Custom => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = parse_theme_item(v) {
+              self.user_config.theme.playbar_text= c;
+              self.user_config.custom_theme.playbar_text= c;
+            }
+          }
+        }
         "theme.highlighted_lyrics" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.highlighted_lyrics = c;
               self.user_config.custom_theme.highlighted_lyrics = c;
+            }
+          }
+        }
+        "theme.background" if self.user_config.current_preset == ThemePreset::Custom => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = parse_theme_item(v) {
+              self.user_config.theme.background= c;
+              self.user_config.custom_theme.background= c;
+            }
+          }
+        }
+        "theme.header" if self.user_config.current_preset == ThemePreset::Custom => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = parse_theme_item(v) {
+              self.user_config.theme.header= c;
+              self.user_config.custom_theme.header= c;
             }
           }
         }
@@ -3740,7 +3810,7 @@ impl App {
 
   /// Updates the colour RGB entries when switching through the presets in themes
   pub fn sync_theme_color_settings(&mut self, theme: &crate::core::user_config::Theme) {
-    let mappings: [(&str, ratatui::style::Color); 11] = [
+    let mappings: [(&str, ratatui::style::Color); 16] = [
       ("theme.active", theme.active),
       ("theme.banner", theme.banner),
       ("theme.hint", theme.hint),
@@ -3749,9 +3819,14 @@ impl App {
       ("theme.inactive", theme.inactive),
       ("theme.text", theme.text),
       ("theme.error_text", theme.error_text),
+      ("theme.error_border", theme.error_border),
       ("theme.playbar_background", theme.playbar_background),
       ("theme.playbar_progress", theme.playbar_progress),
+      ("theme.playbar_progress_text", theme.playbar_progress_text),
+      ("theme.playbar_text", theme.playbar_text),
       ("theme.highlighted_lyrics", theme.highlighted_lyrics),
+      ("theme.background", theme.background),
+      ("theme.header", theme.header),
     ];
     for setting in &mut self.settings_items {
       if let Some((_, color)) = mappings.iter().find(|(id, _)| *id == setting.id) {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3742,8 +3742,8 @@ impl App {
         "theme.error_border" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
-              self.user_config.theme.error_border= c;
-              self.user_config.custom_theme.error_border= c;
+              self.user_config.theme.error_border = c;
+              self.user_config.custom_theme.error_border = c;
             }
           }
         }
@@ -3774,8 +3774,8 @@ impl App {
         "theme.playbar_text" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
-              self.user_config.theme.playbar_text= c;
-              self.user_config.custom_theme.playbar_text= c;
+              self.user_config.theme.playbar_text = c;
+              self.user_config.custom_theme.playbar_text = c;
             }
           }
         }
@@ -3790,16 +3790,16 @@ impl App {
         "theme.background" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
-              self.user_config.theme.background= c;
-              self.user_config.custom_theme.background= c;
+              self.user_config.theme.background = c;
+              self.user_config.custom_theme.background = c;
             }
           }
         }
         "theme.header" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
             if let Ok(c) = parse_theme_item(v) {
-              self.user_config.theme.header= c;
-              self.user_config.custom_theme.header= c;
+              self.user_config.theme.header = c;
+              self.user_config.custom_theme.header = c;
             }
           }
         }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,5 +1,5 @@
 use crate::core::sort::{SortContext, SortState};
-use crate::core::user_config::UserConfig;
+use crate::core::user_config::{ UserConfig, color_to_string };
 use crate::infra::network::sync::{PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
@@ -3224,36 +3224,12 @@ impl App {
         },
       ],
       SettingsCategory::Theme => {
-        fn color_to_string(color: ratatui::style::Color) -> String {
-          match color {
-            ratatui::style::Color::Rgb(r, g, b) => format!("{},{},{}", r, g, b),
-            ratatui::style::Color::Reset => "Reset".to_string(),
-            ratatui::style::Color::Black => "Black".to_string(),
-            ratatui::style::Color::Red => "Red".to_string(),
-            ratatui::style::Color::Green => "Green".to_string(),
-            ratatui::style::Color::Yellow => "Yellow".to_string(),
-            ratatui::style::Color::Blue => "Blue".to_string(),
-            ratatui::style::Color::Magenta => "Magenta".to_string(),
-            ratatui::style::Color::Cyan => "Cyan".to_string(),
-            ratatui::style::Color::Gray => "Gray".to_string(),
-            ratatui::style::Color::DarkGray => "DarkGray".to_string(),
-            ratatui::style::Color::LightRed => "LightRed".to_string(),
-            ratatui::style::Color::LightGreen => "LightGreen".to_string(),
-            ratatui::style::Color::LightYellow => "LightYellow".to_string(),
-            ratatui::style::Color::LightBlue => "LightBlue".to_string(),
-            ratatui::style::Color::LightMagenta => "LightMagenta".to_string(),
-            ratatui::style::Color::LightCyan => "LightCyan".to_string(),
-            ratatui::style::Color::White => "White".to_string(),
-            _ => "Unknown".to_string(),
-          }
-        }
-
         vec![
           SettingItem {
             id: "theme.preset".to_string(),
             name: "Theme Preset".to_string(),
             description: "Choose a preset theme or customize below".to_string(),
-            value: SettingValue::Preset("Default (Cyan)".to_string()), // Default preset
+            value: SettingValue::Preset(self.user_config.current_preset.name().to_string()),
           },
           SettingItem {
             id: "theme.active".to_string(),
@@ -3330,8 +3306,10 @@ impl App {
     self.settings_unsaved_prompt_save_selected = true;
   }
 
-  /// Apply changes from settings_items back to user_config
+  // Apply changes from settings_items back to user_config
   pub fn apply_settings_changes(&mut self) {
+    use crate::core::user_config::{parse_theme_item, ThemePreset};
+
     for setting in &self.settings_items {
       match setting.id.as_str() {
         // Behavior settings
@@ -3653,92 +3631,105 @@ impl App {
             }
           }
         }
-        // Theme preset - applies all colors at once
+        // Decides whether the per-color changes following will apply.
+        // A named preset takes priority; the user's custom_theme is preserved
+        // so they can return to it later by selecting Custom.
         "theme.preset" => {
-          if let SettingValue::Preset(preset_name) = &setting.value {
-            use crate::core::user_config::ThemePreset;
-            let preset = ThemePreset::from_name(preset_name);
+          if let SettingValue::Preset(name) = &setting.value {
+            let preset = ThemePreset::from_name(name);
+            self.user_config.current_preset = preset;
             if preset != ThemePreset::Custom {
-              // Apply the preset's theme colors
               self.user_config.theme = preset.to_theme();
             }
           }
         }
-        // Individual theme color overrides
-        "theme.active" => {
+        // Individual theme color overrides only apply when on Custom; they
+        // update both the active theme and the persisted custom_theme.
+        "theme.active" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.active = c;
+              self.user_config.custom_theme.active = c;
             }
           }
         }
-        "theme.banner" => {
+        "theme.banner" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.banner = c;
+              self.user_config.custom_theme.banner = c;
             }
           }
         }
-        "theme.hint" => {
+        "theme.hint" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.hint = c;
+              self.user_config.custom_theme.hint = c;
             }
           }
         }
-        "theme.hovered" => {
+        "theme.hovered" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.hovered = c;
+              self.user_config.custom_theme.hovered = c;
             }
           }
         }
-        "theme.selected" => {
+        "theme.selected" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.selected = c;
+              self.user_config.custom_theme.selected = c;
             }
           }
         }
-        "theme.inactive" => {
+        "theme.inactive" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.inactive = c;
+              self.user_config.custom_theme.inactive = c;
             }
           }
         }
-        "theme.text" => {
+        "theme.text" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.text = c;
+              self.user_config.custom_theme.text = c;
             }
           }
         }
-        "theme.error_text" => {
+        "theme.error_text" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.error_text = c;
+              self.user_config.custom_theme.error_text = c;
             }
           }
         }
-        "theme.playbar_background" => {
+        "theme.playbar_background" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.playbar_background = c;
+              self.user_config.custom_theme.playbar_background = c;
             }
           }
         }
-        "theme.playbar_progress" => {
+        "theme.playbar_progress" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.playbar_progress = c;
+              self.user_config.custom_theme.playbar_progress = c;
             }
           }
         }
-        "theme.highlighted_lyrics" => {
+        "theme.highlighted_lyrics" if self.user_config.current_preset == ThemePreset::Custom => {
           if let SettingValue::Color(v) = &setting.value {
-            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+            if let Ok(c) = parse_theme_item(v) {
               self.user_config.theme.highlighted_lyrics = c;
+              self.user_config.custom_theme.highlighted_lyrics = c;
             }
           }
         }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,5 +1,5 @@
 use crate::core::sort::{SortContext, SortState};
-use crate::core::user_config::{ UserConfig, color_to_string };
+use crate::core::user_config::{color_to_string, UserConfig};
 use crate::infra::network::sync::{PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3664,8 +3664,84 @@ impl App {
             }
           }
         }
-        // Note: Individual color changes and keybindings require more complex parsing
-        // and may need restart to take full effect
+        // Individual theme color overrides
+        "theme.active" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.active = c;
+            }
+          }
+        }
+        "theme.banner" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.banner = c;
+            }
+          }
+        }
+        "theme.hint" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.hint = c;
+            }
+          }
+        }
+        "theme.hovered" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.hovered = c;
+            }
+          }
+        }
+        "theme.selected" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.selected = c;
+            }
+          }
+        }
+        "theme.inactive" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.inactive = c;
+            }
+          }
+        }
+        "theme.text" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.text = c;
+            }
+          }
+        }
+        "theme.error_text" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.error_text = c;
+            }
+          }
+        }
+        "theme.playbar_background" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.playbar_background = c;
+            }
+          }
+        }
+        "theme.playbar_progress" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.playbar_progress = c;
+            }
+          }
+        }
+        "theme.highlighted_lyrics" => {
+          if let SettingValue::Color(v) = &setting.value {
+            if let Ok(c) = crate::core::user_config::parse_theme_item(v) {
+              self.user_config.theme.highlighted_lyrics = c;
+            }
+          }
+        }
         _ => {}
       }
     }

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -913,6 +913,23 @@ impl UserConfig {
         }
       };
     }
+    // Check if any colour values exist in config already`
+    let has_color_values = theme.active.is_some()
+      || theme.banner.is_some()
+      || theme.error_border.is_some()
+      || theme.error_text.is_some()
+      || theme.hint.is_some()
+      || theme.hovered.is_some()
+      || theme.inactive.is_some()
+      || theme.playbar_background.is_some()
+      || theme.playbar_progress.is_some()
+      || theme.playbar_progress_text.is_some()
+      || theme.playbar_text.is_some()
+      || theme.selected.is_some()
+      || theme.text.is_some()
+      || theme.background.is_some()
+      || theme.header.is_some()
+      || theme.highlighted_lyrics.is_some();
 
     to_theme_item!(active);
     to_theme_item!(banner);
@@ -931,8 +948,15 @@ impl UserConfig {
     to_theme_item!(header);
     to_theme_item!(highlighted_lyrics);
 
+    // If the preset value exists in the config, we load it
     if let Some(preset_name) = theme.preset {
       self.current_preset = ThemePreset::from_name(&preset_name);
+    } else if has_color_values {
+      // If there is no preset value, or it is malformed,
+      // and if the config exists and has some theme colours set:
+      // we handle backwards compatibility for old theme configs.
+      // Set to Custom on first load after the upgrade.
+      self.current_preset = ThemePreset::Custom;
     }
 
     self.theme = match self.current_preset {

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -13,6 +13,7 @@ const APP_CONFIG_DIR: &str = "spotatui";
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct UserTheme {
+  pub preset: Option<String>,
   pub active: Option<String>,
   pub banner: Option<String>,
   pub error_border: Option<String>,
@@ -122,6 +123,7 @@ impl ThemePreset {
       ThemePreset::Gruvbox,
       ThemePreset::GruvboxLight,
       ThemePreset::CatppuccinMocha,
+      ThemePreset::Custom,
     ]
   }
 
@@ -721,6 +723,8 @@ pub struct UserConfigString {
 pub struct UserConfig {
   pub keys: KeyBindings,
   pub theme: Theme,
+  pub current_preset: ThemePreset,
+  pub custom_theme: Theme,
   pub behavior: BehaviorConfig,
   pub path_to_config: Option<UserConfigPaths>,
 }
@@ -741,6 +745,8 @@ impl UserConfig {
 
     UserConfig {
       theme: Default::default(),
+      current_preset: ThemePreset::Default,
+      custom_theme: Default::default(),
       keys: KeyBindings {
         back: Key::Char('q'),
         next_page: Key::Ctrl('d'),
@@ -898,10 +904,12 @@ impl UserConfig {
   }
 
   pub fn load_theme(&mut self, theme: UserTheme) -> Result<()> {
+    // Individual color fields populate the custom_theme — they only
+    // become the active theme when current_preset is Custom.
     macro_rules! to_theme_item {
       ($name: ident) => {
         if let Some(theme_item) = theme.$name {
-          self.theme.$name = parse_theme_item(&theme_item)?;
+          self.custom_theme.$name = parse_theme_item(&theme_item)?;
         }
       };
     }
@@ -922,6 +930,16 @@ impl UserConfig {
     to_theme_item!(background);
     to_theme_item!(header);
     to_theme_item!(highlighted_lyrics);
+
+    if let Some(preset_name) = theme.preset {
+      self.current_preset = ThemePreset::from_name(&preset_name);
+    }
+
+    self.theme = match self.current_preset {
+      ThemePreset::Custom => self.custom_theme,
+      preset => preset.to_theme(),
+    };
+
     Ok(())
   }
 
@@ -1251,22 +1269,23 @@ impl UserConfig {
 
     // Helper to build theme config from current values
     let build_theme = || UserTheme {
-      active: Some(color_to_string(self.theme.active)),
-      banner: Some(color_to_string(self.theme.banner)),
-      error_border: Some(color_to_string(self.theme.error_border)),
-      error_text: Some(color_to_string(self.theme.error_text)),
-      hint: Some(color_to_string(self.theme.hint)),
-      hovered: Some(color_to_string(self.theme.hovered)),
-      inactive: Some(color_to_string(self.theme.inactive)),
-      playbar_background: Some(color_to_string(self.theme.playbar_background)),
-      playbar_progress: Some(color_to_string(self.theme.playbar_progress)),
-      playbar_progress_text: Some(color_to_string(self.theme.playbar_progress_text)),
-      playbar_text: Some(color_to_string(self.theme.playbar_text)),
-      selected: Some(color_to_string(self.theme.selected)),
-      text: Some(color_to_string(self.theme.text)),
-      background: Some(color_to_string(self.theme.background)),
-      header: Some(color_to_string(self.theme.header)),
-      highlighted_lyrics: Some(color_to_string(self.theme.highlighted_lyrics)),
+      preset: Some(self.current_preset.name().to_string()),
+      active: Some(color_to_string(self.custom_theme.active)),
+      banner: Some(color_to_string(self.custom_theme.banner)),
+      error_border: Some(color_to_string(self.custom_theme.error_border)),
+      error_text: Some(color_to_string(self.custom_theme.error_text)),
+      hint: Some(color_to_string(self.custom_theme.hint)),
+      hovered: Some(color_to_string(self.custom_theme.hovered)),
+      inactive: Some(color_to_string(self.custom_theme.inactive)),
+      playbar_background: Some(color_to_string(self.custom_theme.playbar_background)),
+      playbar_progress: Some(color_to_string(self.custom_theme.playbar_progress)),
+      playbar_progress_text: Some(color_to_string(self.custom_theme.playbar_progress_text)),
+      playbar_text: Some(color_to_string(self.custom_theme.playbar_text)),
+      selected: Some(color_to_string(self.custom_theme.selected)),
+      text: Some(color_to_string(self.custom_theme.text)),
+      background: Some(color_to_string(self.custom_theme.background)),
+      header: Some(color_to_string(self.custom_theme.header)),
+      highlighted_lyrics: Some(color_to_string(self.custom_theme.highlighted_lyrics)),
     };
 
     // If the file exists, try to read it first to preserve keybindings
@@ -1364,7 +1383,7 @@ pub fn parse_theme_item(theme_item: &str) -> Result<Color> {
   Ok(color)
 }
 
-fn color_to_string(color: Color) -> String {
+pub fn color_to_string(color: Color) -> String {
   match color {
     Color::Reset => "Reset".to_string(),
     Color::Black => "Black".to_string(),

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -1327,7 +1327,7 @@ impl UserConfig {
   }
 }
 
-fn parse_theme_item(theme_item: &str) -> Result<Color> {
+pub fn parse_theme_item(theme_item: &str) -> Result<Color> {
   let color = match theme_item {
     "Reset" => Color::Reset,
     "Black" => Color::Black,

--- a/src/tui/handlers/settings.rs
+++ b/src/tui/handlers/settings.rs
@@ -403,6 +403,11 @@ fn enter_edit_mode(app: &mut App) {
       if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
         setting_mut.value = SettingValue::Preset(next.name().to_string());
       }
+      let preview_theme = match next {
+        ThemePreset::Custom => app.user_config.custom_theme,
+        p => p.to_theme(),
+      };
+      app.sync_theme_color_settings(&preview_theme);
       return;
     }
 
@@ -439,47 +444,35 @@ fn cycle_next(current: &str, options: &[&str]) -> String {
 fn handle_preset_edit(key: Key, app: &mut App) {
   use crate::core::user_config::ThemePreset;
 
+  fn cycle(app: &mut App, forward: bool) {
+    if let Some(setting) = app.settings_items.get(app.settings_selected_index) {
+      if let SettingValue::Preset(ref preset_name) = setting.value {
+        let current = ThemePreset::from_name(preset_name);
+        let next = if forward { current.next() } else { current.prev() };
+        if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
+          setting_mut.value = SettingValue::Preset(next.name().to_string());
+        }
+        // Update theme item values when cycling through presets so that
+        // values can be previewed in real time
+        let preview_theme = match next {
+          ThemePreset::Custom => app.user_config.custom_theme,
+          p => p.to_theme(),
+        };
+        app.sync_theme_color_settings(&preview_theme);
+      }
+    }
+  }
+
   match key {
     Key::Enter | Key::Char(' ') => {
-      // Cycle to next preset
-      if let Some(setting) = app.settings_items.get(app.settings_selected_index) {
-        if let SettingValue::Preset(ref preset_name) = setting.value {
-          let current = ThemePreset::from_name(preset_name);
-          let next = current.next();
-          if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
-            setting_mut.value = SettingValue::Preset(next.name().to_string());
-          }
-        }
-      }
+      cycle(app, true);
       app.settings_edit_mode = false;
     }
     Key::Esc => {
       app.settings_edit_mode = false;
     }
-    key if right_event(key) => {
-      // Next preset
-      if let Some(setting) = app.settings_items.get(app.settings_selected_index) {
-        if let SettingValue::Preset(ref preset_name) = setting.value {
-          let current = ThemePreset::from_name(preset_name);
-          let next = current.next();
-          if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
-            setting_mut.value = SettingValue::Preset(next.name().to_string());
-          }
-        }
-      }
-    }
-    key if left_event(key) => {
-      // Previous preset
-      if let Some(setting) = app.settings_items.get(app.settings_selected_index) {
-        if let SettingValue::Preset(ref preset_name) = setting.value {
-          let current = ThemePreset::from_name(preset_name);
-          let prev = current.prev();
-          if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
-            setting_mut.value = SettingValue::Preset(prev.name().to_string());
-          }
-        }
-      }
-    }
+    key if right_event(key) => cycle(app, true),
+    key if left_event(key) => cycle(app, false),
     _ => {}
   }
 }

--- a/src/tui/handlers/settings.rs
+++ b/src/tui/handlers/settings.rs
@@ -191,6 +191,7 @@ fn handle_string_edit(key: Key, app: &mut App) {
           }
         }
 
+        let is_color_edit = matches!(setting.value, SettingValue::Color(_));
         match &setting.value {
           SettingValue::String(_) => {
             setting.value = SettingValue::String(new_value);
@@ -199,6 +200,16 @@ fn handle_string_edit(key: Key, app: &mut App) {
             setting.value = SettingValue::Color(new_value);
           }
           _ => {}
+        }
+        // Editing an individual color switches the theme to Custom
+        if is_color_edit {
+          if let Some(preset_setting) =
+            app.settings_items.iter_mut().find(|s| s.id == "theme.preset")
+          {
+            if let SettingValue::Preset(name) = &mut preset_setting.value {
+              *name = "Custom".to_string();
+            }
+          }
         }
       }
       app.settings_edit_mode = false;

--- a/src/tui/handlers/settings.rs
+++ b/src/tui/handlers/settings.rs
@@ -203,8 +203,10 @@ fn handle_string_edit(key: Key, app: &mut App) {
         }
         // Editing an individual color switches the theme to Custom
         if is_color_edit {
-          if let Some(preset_setting) =
-            app.settings_items.iter_mut().find(|s| s.id == "theme.preset")
+          if let Some(preset_setting) = app
+            .settings_items
+            .iter_mut()
+            .find(|s| s.id == "theme.preset")
           {
             if let SettingValue::Preset(name) = &mut preset_setting.value {
               *name = "Custom".to_string();
@@ -448,7 +450,11 @@ fn handle_preset_edit(key: Key, app: &mut App) {
     if let Some(setting) = app.settings_items.get(app.settings_selected_index) {
       if let SettingValue::Preset(ref preset_name) = setting.value {
         let current = ThemePreset::from_name(preset_name);
-        let next = if forward { current.next() } else { current.prev() };
+        let next = if forward {
+          current.next()
+        } else {
+          current.prev()
+        };
         if let Some(setting_mut) = app.settings_items.get_mut(app.settings_selected_index) {
           setting_mut.value = SettingValue::Preset(next.name().to_string());
         }


### PR DESCRIPTION
# Summary

This pull request addresses the issues in #230 and #231.

It adds a new theme preset called Custom which gets activated whenever the RGB values are edited. This means that editing the RGB values of a theme item now has an effect.  After editing a preset, the currently selected preset changes to Custom. The Custom setting becomes populated with the values of the edited preset along with the edits that make it customised. Whenever the user cycles through the presets, they can reload the preset and then come back to the Custom settings they changed earlier. This is saved using the existing values in the config.
Currently selected presets, not just the RGB values for the items, are now tracked in the config. 
Cycling through the theme presets when pressing enter now shows the RGB values that correspond to the in focus preset. 
Exiting the themes settings and re-entering, the active preset is seen right away which helps the user understand that it is in use. 

# Testing
Running `cargo fmt --all` resulted in no noise.

Running `cargo clippy --locked -- -D warnings` resulted in:
```Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.36s```

Running `cargo test --locked` resulted in: 
```Resume this session with:                                   │test result: ok. 165 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s```


# Additional notes
<img width="725" height="441" alt="Screenshot From 2026-04-29 20-00-14" src="https://github.com/user-attachments/assets/8ecc3aab-76e8-4e45-b996-d60c1ed9d18d" />
