### PR TITLE
fix: make flake build on macOS (aarch64-darwin)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,22 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-  }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
     flake-utils.lib.eachDefaultSystem (
-      system: let
+      system:
+      let
         pkgs = import nixpkgs {
           inherit system;
         };
         cargoVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
         commitHash = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "dirty");
-      in {
+      in
+      {
         # Build dependencies for rust
         packages = rec {
           default = pkgs.rustPlatform.buildRustPackage {
@@ -33,17 +36,21 @@
               llvmPackages.clang
               llvmPackages.libclang
             ];
-            buildInputs = with pkgs;
+            buildInputs =
+              with pkgs;
               [
                 openssl
+              ]
+              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
                 alsa-lib
                 dbus
                 pipewire
               ]
               # Build inputs for nix-darwin
               ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-                pkgs.darwin.apple_sdk.frameworks.Security
-                pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+                # macOS specific dependencies - use latest supported Apple SDK
+                pkgs.apple-sdk
+                pkgs.portaudio
               ];
             meta = with pkgs.lib; {
               description = "A Spotify client for the terminal written in Rust, powered by Ratatui";


### PR DESCRIPTION
# Summary

<!-- What does this PR change and why? Keep it short. -->
- Gate alsa-lib, dbus, pipewire behind isLinux conditional
- Replace removed darwin.apple_sdk stubs with pkgs.apple-sdk
- Add portaudio as macOS build dep

# Testing

<!-- List the commands you ran and their output. Example:
- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked
-->

Been using this for ~month now on macos via nix, haven't had any issues.

# Additional notes

<!-- Screenshots for UI changes, breaking change callouts, or follow-up work. -->
