### PR TITLE
Fix UI freeze

### DIFF
--- a/src/infra/network/recommend.rs
+++ b/src/infra/network/recommend.rs
@@ -1,6 +1,7 @@
 use super::Network;
 use crate::core::app::{ActiveBlock, RouteId, TrackTableContext};
 use anyhow::anyhow;
+use futures::future;
 use rspotify::model::{
   enums::Country,
   idtypes::{ArtistId, TrackId},
@@ -62,14 +63,10 @@ impl RecommendationNetwork for Network {
           .filter_map(|t| t.id.clone())
           .collect();
 
-        let mut full_tracks = Vec::new();
-        if !track_ids.is_empty() {
-          for id in &track_ids {
-            if let Ok(track) = self.spotify.track(id.clone(), None).await {
-              full_tracks.push(track);
-            }
-          }
-        }
+        let fetch_futures = track_ids.into_iter().map(|id| self.spotify.track(id, None));
+
+        let results = future::join_all(fetch_futures).await;
+        let full_tracks: Vec<_> = results.into_iter().filter_map(|res| res.ok()).collect();
 
         let mut app = self.app.lock().await;
         app.track_table.tracks = full_tracks;

--- a/src/infra/network/recommend.rs
+++ b/src/infra/network/recommend.rs
@@ -48,7 +48,6 @@ impl RecommendationNetwork for Network {
       .await
     {
       Ok(recommendations) => {
-        let mut app = self.app.lock().await;
         // Convert SimplifiedTrack to FullTrack (best effort)
         // SimplifiedTrack doesn't have album field which FullTrack needs.
         // This is tricky. Recommendations usually return SimplifiedTracks.
@@ -72,6 +71,7 @@ impl RecommendationNetwork for Network {
           }
         }
 
+        let mut app = self.app.lock().await;
         app.track_table.tracks = full_tracks;
 
         // Prepend the seed track if available so user knows context


### PR DESCRIPTION
# Summary
Fixes Issue #238  

- Taking app lock before fetching recommended songs was freezing the UI, so moved it after the fetch.
- Sequentially fetching tracks was causing **N+1** problem resulting in approx 10s latency. Using `tracks` endpoint was reducing the latency from 10s to 2s. But since it was deprecated, I used `future::join_all()` to fetch tracks concurrently, reducing the *10s** latency to approx **4s**.

# Testing

```bash
cargo fmt --all
cargo clippy --locked -- -D warnings
cargo test --locked
```
```bash
test result: ok. 174 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
```
