### PR TITLE
Feat: Prevent sleep/hibernate/suspend state during playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "objc2",
 ]
 
@@ -2726,6 +2727,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepawake"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5521b450ec179362595d5cbda7c3abd5da3af3dff58456434ad3ca33c95226b7"
+dependencies = [
+ "cfg-if",
+ "derive_builder",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,7 +3640,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "dispatch2",
  "libc",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -5366,6 +5386,7 @@ dependencies = [
  "fern",
  "futures",
  "image",
+ "keepawake",
  "librespot-connect",
  "librespot-core",
  "librespot-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ protobuf = { version = "3.7", optional = true }
 futures = "0.3.32"
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 url = "2.5"
+keepawake = "0.6"
 
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 pipewire = { version = "0.9", optional = true }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -735,6 +735,8 @@ pub struct App {
   /// Native playback state - updated by player events, used when streaming is active
   /// This is more reliable than current_playback_context.is_playing during native streaming
   pub native_is_playing: Option<bool>,
+  /// Prevent idle/sleep during playback
+  pub keepawake: Option<keepawake::KeepAwake>,
   /// Timestamp of the last native device activation
   #[allow(dead_code)]
   pub last_device_activation: Option<Instant>,
@@ -958,6 +960,7 @@ impl Default for App {
       is_streaming_active: false,
       native_device_id: None,
       native_is_playing: None,
+      keepawake: None,
       last_device_activation: None,
       native_activation_pending: false,
       // Sort menu defaults
@@ -1392,6 +1395,24 @@ impl App {
     }
 
     self.poll_current_playback();
+    let playing_now = self.user_config.behavior.keepawake_enabled
+      && self
+        .native_is_playing
+        .or_else(|| self.current_playback_context.as_ref().map(|c| c.is_playing))
+        .unwrap_or(false);
+    match (playing_now, self.keepawake.is_some()) {
+      (true, false) => {
+        self.keepawake = keepawake::Builder::default()
+          .idle(true)
+          .sleep(true)
+          .reason("Playing music")
+          .app_name("spotatui")
+          .create()
+          .ok();
+      }
+      (false, true) => self.keepawake = None,
+      _ => {}
+    }
 
     if let Some(CurrentPlaybackContext {
       item: Some(item),
@@ -2962,6 +2983,12 @@ impl App {
           value: SettingValue::Bool(self.user_config.behavior.stop_after_current_track),
         },
         SettingItem {
+          id: "behavior.keepawake_enabled".to_string(),
+          name: "Keep System Awake".to_string(),
+          description: "Prevent the system from sleeping while music is playing".to_string(),
+          value: SettingValue::Bool(self.user_config.behavior.keepawake_enabled),
+        },
+        SettingItem {
           id: "behavior.startup_behavior".to_string(),
           name: "Startup Behavior".to_string(),
           description: "Playback state when spotatui starts: continue, play, or pause".to_string(),
@@ -3397,6 +3424,11 @@ impl App {
           if let SettingValue::Cycle(v, _) = &setting.value {
             self.user_config.behavior.startup_behavior =
               crate::core::user_config::StartupBehavior::from_name(v);
+          }
+        }
+        "behavior.keepawake_enabled" => {
+          if let SettingValue::Bool(v) = &setting.value {
+            self.user_config.behavior.keepawake_enabled = *v;
           }
         }
         "behavior.enable_announcements" => {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1405,6 +1405,7 @@ impl App {
         self.keepawake = keepawake::Builder::default()
           .idle(true)
           .sleep(true)
+          .display(true)
           .reason("Playing music")
           .app_name("spotatui")
           .create()

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -670,6 +670,7 @@ pub struct BehaviorConfigString {
   pub draw_cover_art: Option<bool>,
   #[cfg(feature = "cover-art")]
   pub draw_cover_art_forced: Option<bool>,
+  pub keepawake_enabled: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -710,6 +711,7 @@ pub struct BehaviorConfig {
   pub draw_cover_art: bool,
   #[cfg(feature = "cover-art")]
   pub draw_cover_art_forced: bool,
+  pub keepawake_enabled: bool,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -825,6 +827,7 @@ impl UserConfig {
         draw_cover_art: true,
         #[cfg(feature = "cover-art")]
         draw_cover_art_forced: false,
+        keepawake_enabled: true,
       },
       path_to_config: None,
     }
@@ -1131,7 +1134,9 @@ impl UserConfig {
     if let Some(draw_cover_art_forced) = behavior_config.draw_cover_art_forced {
       self.behavior.draw_cover_art_forced = draw_cover_art_forced;
     }
-
+    if let Some(keepawake_enabled) = behavior_config.keepawake_enabled {
+      self.behavior.keepawake_enabled = keepawake_enabled;
+    }
     Ok(())
   }
 
@@ -1214,6 +1219,7 @@ impl UserConfig {
       draw_cover_art: Some(self.behavior.draw_cover_art),
       #[cfg(feature = "cover-art")]
       draw_cover_art_forced: Some(self.behavior.draw_cover_art_forced),
+      keepawake_enabled: Some(self.behavior.keepawake_enabled),
     };
 
     // Helper to convert Key to config string


### PR DESCRIPTION
# Summary

This PR addresses issue https://github.com/LargeModGames/spotatui/issues/241

It makes use of the multi-platform [keepawake](https://crates.io/crates/keepawake) crate to implement an option in settings to enable the prevention of sleep/suspend/hibernation state during playback.

Changes:
1. Option in settings to enable the prevention of sleep/hibernate/suspend
2. Functionality to enable the prevention of sleep/hibernate/suspend

Features:
1. Enables when client is open, option is turned on and playback is running
2. Has an effect even if the client is not focused
3. Has no effect (disabled) when client is open, option is turned on but no playback is running
4. Has no effect when option is turned off

# Testing
Running `cargo fmt --all` resulted in no noise.

Running `cargo clippy --locked -- -D warnings` resulted in:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
```

Running `cargo test --locked` resulted in: 
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.33s
     Running unittests src/main.rs (target/debug/deps/spotatui-7e886e48d5a1db47)
test result: ok. 174 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
```

# Additional notes

<img width="889" height="778" alt="Screenshot from 2026-05-10 05-12-10" src="https://github.com/user-attachments/assets/372b40ea-f4bb-4550-8dc0-ca95c87f7985" />