### PR TITLE
 fix: handle mouse input on content tables fixes #249

### DIFF
--- a/src/tui/cover_art.rs
+++ b/src/tui/cover_art.rs
@@ -1,6 +1,9 @@
 use anyhow::anyhow;
 use log::{debug, info};
-use ratatui::{layout::Rect, Frame};
+use ratatui::{
+  layout::{Rect, Size},
+  Frame,
+};
 use ratatui_image::{
   picker::{Picker, ProtocolType},
   protocol::StatefulProtocol,
@@ -134,8 +137,15 @@ impl CoverArt {
 
   fn size_for_state(state: &Mutex<Option<CoverArtState>>, area: Rect) -> Option<Rect> {
     let lock = state.lock().unwrap();
-    lock
-      .as_ref()
-      .map(|sp| sp.image.size_for(Resize::Fit(None), area))
+    lock.as_ref().map(|sp| {
+      let size = sp.image.size_for(
+        Resize::Fit(None),
+        Size {
+          width: area.width,
+          height: area.height,
+        },
+      );
+      Rect::new(0, 0, size.width, size.height)
+    })
   }
 }

--- a/src/tui/handlers/common_key_events.rs
+++ b/src/tui/handlers/common_key_events.rs
@@ -82,72 +82,30 @@ pub fn on_low_press_handler<T>(selection_data: &[T]) -> usize {
   selection_data.len().saturating_sub(1)
 }
 
+pub fn content_active_block_for_route(route_id: &RouteId) -> Option<ActiveBlock> {
+  match route_id {
+    RouteId::AlbumTracks => Some(ActiveBlock::AlbumTracks),
+    RouteId::TrackTable | RouteId::Recommendations => Some(ActiveBlock::TrackTable),
+    RouteId::Podcasts => Some(ActiveBlock::Podcasts),
+    RouteId::AlbumList => Some(ActiveBlock::AlbumList),
+    RouteId::PodcastEpisodes => Some(ActiveBlock::EpisodeTable),
+    RouteId::Discover => Some(ActiveBlock::Discover),
+    RouteId::Artists => Some(ActiveBlock::Artists),
+    RouteId::RecentlyPlayed => Some(ActiveBlock::RecentlyPlayed),
+    RouteId::Search => Some(ActiveBlock::SearchResultBlock),
+    RouteId::Artist => Some(ActiveBlock::ArtistBlock),
+    RouteId::Home => Some(ActiveBlock::Home),
+    _ => None,
+  }
+}
+
 pub fn handle_right_event(app: &mut App) {
   match app.get_current_route().hovered_block {
-    ActiveBlock::MyPlaylists | ActiveBlock::Library => match app.get_current_route().id {
-      RouteId::AlbumTracks => {
-        app.set_current_route_state(
-          Some(ActiveBlock::AlbumTracks),
-          Some(ActiveBlock::AlbumTracks),
-        );
+    ActiveBlock::MyPlaylists | ActiveBlock::Library => {
+      if let Some(active_block) = content_active_block_for_route(&app.get_current_route().id) {
+        app.set_current_route_state(Some(active_block), Some(active_block));
       }
-      RouteId::TrackTable => {
-        app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
-      }
-      RouteId::Podcasts => {
-        app.set_current_route_state(Some(ActiveBlock::Podcasts), Some(ActiveBlock::Podcasts));
-      }
-      RouteId::Recommendations => {
-        app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
-      }
-      RouteId::AlbumList => {
-        app.set_current_route_state(Some(ActiveBlock::AlbumList), Some(ActiveBlock::AlbumList));
-      }
-      RouteId::PodcastEpisodes => {
-        app.set_current_route_state(
-          Some(ActiveBlock::EpisodeTable),
-          Some(ActiveBlock::EpisodeTable),
-        );
-      }
-      RouteId::Discover => {
-        app.set_current_route_state(Some(ActiveBlock::Discover), Some(ActiveBlock::Discover));
-      }
-      RouteId::Artists => {
-        app.set_current_route_state(Some(ActiveBlock::Artists), Some(ActiveBlock::Artists));
-      }
-      RouteId::RecentlyPlayed => {
-        app.set_current_route_state(
-          Some(ActiveBlock::RecentlyPlayed),
-          Some(ActiveBlock::RecentlyPlayed),
-        );
-      }
-      RouteId::Search => {
-        app.set_current_route_state(
-          Some(ActiveBlock::SearchResultBlock),
-          Some(ActiveBlock::SearchResultBlock),
-        );
-      }
-      RouteId::Artist => app.set_current_route_state(
-        Some(ActiveBlock::ArtistBlock),
-        Some(ActiveBlock::ArtistBlock),
-      ),
-      RouteId::Home => {
-        app.set_current_route_state(Some(ActiveBlock::Home), Some(ActiveBlock::Home));
-      }
-      RouteId::SelectedDevice => {}
-      RouteId::Error => {}
-      RouteId::Analysis => {}
-      RouteId::LyricsView => {}
-      RouteId::CoverArtView => {}
-      RouteId::Dialog => {}
-      RouteId::AnnouncementPrompt => {}
-      RouteId::ExitPrompt => {}
-      RouteId::Settings => {}
-      RouteId::HelpMenu => {}
-      RouteId::Queue => {}
-      RouteId::Party => {}
-      RouteId::CreatePlaylist => {}
-    },
+    }
     _ => {}
   };
 }

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -1,4 +1,7 @@
-use super::{library, playbar, playlist, settings, track_table};
+use super::{
+  album_list, album_tracks, artists, episode_table, library, playbar, playlist, podcasts,
+  recently_played, settings, track_table,
+};
 use crate::core::app::{
   ActiveBlock, App, RouteId, SettingValue, SettingsCategory, LIBRARY_OPTIONS,
 };
@@ -82,10 +85,8 @@ pub fn handler(mouse: MouseEvent, app: &mut App) {
     return;
   }
 
-  if current_route_id == RouteId::TrackTable
-    && rect_contains(areas.content, mouse.column, mouse.row)
-  {
-    handle_song_table_mouse(mouse, areas.content, app);
+  if rect_contains(areas.content, mouse.column, mouse.row) {
+    handle_content_table_mouse(mouse, areas.content, current_route_id, app);
   }
 }
 
@@ -142,6 +143,42 @@ fn handle_song_table_mouse(mouse: MouseEvent, table_area: Rect, app: &mut App) {
     MouseEventKind::Down(MouseButton::Left) => {
       focus_song_table(app);
       select_clicked_song(mouse.row, table_area, app);
+    }
+    _ => {}
+  }
+}
+
+fn handle_content_table_mouse(
+  mouse: MouseEvent,
+  table_area: Rect,
+  route_id: RouteId,
+  app: &mut App,
+) {
+  let Some(table) = ContentTable::for_route(route_id) else {
+    return;
+  };
+
+  if table == ContentTable::TrackTable {
+    handle_song_table_mouse(mouse, table_area, app);
+    return;
+  }
+
+  if content_table_item_count(table, app) == 0 {
+    return;
+  }
+
+  match mouse.kind {
+    MouseEventKind::ScrollDown => {
+      focus_content_table(table, app);
+      handle_content_table_key(table, Key::Down, app);
+    }
+    MouseEventKind::ScrollUp => {
+      focus_content_table(table, app);
+      handle_content_table_key(table, Key::Up, app);
+    }
+    MouseEventKind::Down(MouseButton::Left) => {
+      focus_content_table(table, app);
+      select_clicked_content_table_item(table, mouse.row, table_area, app);
     }
     _ => {}
   }
@@ -367,6 +404,11 @@ fn focus_song_table(app: &mut App) {
   app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
 }
 
+fn focus_content_table(table: ContentTable, app: &mut App) {
+  let active_block = table.active_block();
+  app.set_current_route_state(Some(active_block), Some(active_block));
+}
+
 fn focus_playbar(block: ActiveBlock, app: &mut App) {
   app.set_current_route_state(Some(block), Some(block));
 }
@@ -459,6 +501,164 @@ fn select_clicked_song(mouse_row: u16, table_area: Rect, app: &mut App) {
   track_table::handler(Key::Enter, app);
 }
 
+fn select_clicked_content_table_item(
+  table: ContentTable,
+  mouse_row: u16,
+  table_area: Rect,
+  app: &mut App,
+) {
+  let item_count = content_table_item_count(table, app);
+  let selected_index = content_table_selected_index(table, app).min(item_count.saturating_sub(1));
+
+  let Some(clicked_index) =
+    table_item_index_from_click(table_area, mouse_row, selected_index, item_count)
+  else {
+    return;
+  };
+
+  let was_selected = content_table_selected_index(table, app) == clicked_index;
+  set_content_table_selected_index(table, clicked_index, app);
+  if was_selected {
+    handle_content_table_key(table, Key::Enter, app);
+  }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ContentTable {
+  TrackTable,
+  AlbumList,
+  AlbumTracks,
+  RecentlyPlayed,
+  Artists,
+  Podcasts,
+  EpisodeTable,
+}
+
+impl ContentTable {
+  fn for_route(route_id: RouteId) -> Option<Self> {
+    match route_id {
+      RouteId::TrackTable | RouteId::Recommendations => Some(Self::TrackTable),
+      RouteId::AlbumList => Some(Self::AlbumList),
+      RouteId::AlbumTracks => Some(Self::AlbumTracks),
+      RouteId::RecentlyPlayed => Some(Self::RecentlyPlayed),
+      RouteId::Artists => Some(Self::Artists),
+      RouteId::Podcasts => Some(Self::Podcasts),
+      RouteId::PodcastEpisodes => Some(Self::EpisodeTable),
+      _ => None,
+    }
+  }
+
+  fn active_block(self) -> ActiveBlock {
+    match self {
+      Self::TrackTable => ActiveBlock::TrackTable,
+      Self::AlbumList => ActiveBlock::AlbumList,
+      Self::AlbumTracks => ActiveBlock::AlbumTracks,
+      Self::RecentlyPlayed => ActiveBlock::RecentlyPlayed,
+      Self::Artists => ActiveBlock::Artists,
+      Self::Podcasts => ActiveBlock::Podcasts,
+      Self::EpisodeTable => ActiveBlock::EpisodeTable,
+    }
+  }
+}
+
+fn content_table_item_count(table: ContentTable, app: &App) -> usize {
+  match table {
+    ContentTable::TrackTable => app.track_table.tracks.len(),
+    ContentTable::AlbumList => app
+      .library
+      .saved_albums
+      .get_results(None)
+      .map(|albums| albums.items.len())
+      .unwrap_or(0),
+    ContentTable::AlbumTracks => match app.album_table_context {
+      crate::core::app::AlbumTableContext::Full => app
+        .selected_album_full
+        .as_ref()
+        .map(|album| album.album.tracks.items.len())
+        .unwrap_or(0),
+      crate::core::app::AlbumTableContext::Simplified => app
+        .selected_album_simplified
+        .as_ref()
+        .map(|album| album.tracks.items.len())
+        .unwrap_or(0),
+    },
+    ContentTable::RecentlyPlayed => app
+      .recently_played
+      .result
+      .as_ref()
+      .map(|recently_played| recently_played.items.len())
+      .unwrap_or(0),
+    ContentTable::Artists => app
+      .library
+      .saved_artists
+      .get_results(None)
+      .map(|artists| artists.items.len())
+      .unwrap_or(0),
+    ContentTable::Podcasts => app
+      .library
+      .saved_shows
+      .get_results(None)
+      .map(|shows| shows.items.len())
+      .unwrap_or(0),
+    ContentTable::EpisodeTable => app
+      .library
+      .show_episodes
+      .get_results(None)
+      .map(|episodes| episodes.items.len())
+      .unwrap_or(0),
+  }
+}
+
+fn content_table_selected_index(table: ContentTable, app: &App) -> usize {
+  match table {
+    ContentTable::TrackTable => app.track_table.selected_index,
+    ContentTable::AlbumList => app.album_list_index,
+    ContentTable::AlbumTracks => match app.album_table_context {
+      crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index,
+      crate::core::app::AlbumTableContext::Simplified => app
+        .selected_album_simplified
+        .as_ref()
+        .map(|album| album.selected_index)
+        .unwrap_or(0),
+    },
+    ContentTable::RecentlyPlayed => app.recently_played.index,
+    ContentTable::Artists => app.artists_list_index,
+    ContentTable::Podcasts => app.shows_list_index,
+    ContentTable::EpisodeTable => app.episode_list_index,
+  }
+}
+
+fn set_content_table_selected_index(table: ContentTable, index: usize, app: &mut App) {
+  match table {
+    ContentTable::TrackTable => app.track_table.selected_index = index,
+    ContentTable::AlbumList => app.album_list_index = index,
+    ContentTable::AlbumTracks => match app.album_table_context {
+      crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index = index,
+      crate::core::app::AlbumTableContext::Simplified => {
+        if let Some(album) = &mut app.selected_album_simplified {
+          album.selected_index = index;
+        }
+      }
+    },
+    ContentTable::RecentlyPlayed => app.recently_played.index = index,
+    ContentTable::Artists => app.artists_list_index = index,
+    ContentTable::Podcasts => app.shows_list_index = index,
+    ContentTable::EpisodeTable => app.episode_list_index = index,
+  }
+}
+
+fn handle_content_table_key(table: ContentTable, key: Key, app: &mut App) {
+  match table {
+    ContentTable::TrackTable => track_table::handler(key, app),
+    ContentTable::AlbumList => album_list::handler(key, app),
+    ContentTable::AlbumTracks => album_tracks::handler(key, app),
+    ContentTable::RecentlyPlayed => recently_played::handler(key, app),
+    ContentTable::Artists => artists::handler(key, app),
+    ContentTable::Podcasts => podcasts::handler(key, app),
+    ContentTable::EpisodeTable => episode_table::handler(key, app),
+  }
+}
+
 fn list_item_index_from_click(
   list_area: Rect,
   mouse_row: u16,
@@ -516,12 +716,7 @@ fn table_item_index_from_click(
     return None;
   }
 
-  let offset = table_area
-    .height
-    .checked_sub(5)
-    .map(|height| height as usize)
-    .map(|visible_rows| (selected_index / visible_rows) * visible_rows)
-    .unwrap_or(0);
+  let offset = table_scroll_offset(selected_index, visible_rows);
 
   let row_index = (mouse_row - first_data_row) as usize;
   let row_index = row_index.min(visible_rows.saturating_sub(1));
@@ -827,6 +1022,14 @@ fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
   x >= rect.x && x < right && y >= rect.y && y < bottom
 }
 
+fn table_scroll_offset(selected_index: usize, visible_rows: usize) -> usize {
+  if visible_rows == 0 {
+    return 0;
+  }
+
+  selected_index.saturating_sub(visible_rows.saturating_sub(1))
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -838,7 +1041,8 @@ mod tests {
   use rspotify::model::context::{Actions, CurrentPlaybackContext};
   use rspotify::model::enums::{DeviceType, RepeatState};
   use rspotify::model::{
-    CurrentlyPlayingType, Device, FullTrack, PlayableItem, SimplifiedAlbum, SimplifiedArtist,
+    AlbumId, AlbumType, CurrentlyPlayingType, DatePrecision, Device, FullAlbum, FullTrack, Page,
+    PlayableItem, SavedAlbum, SimplifiedAlbum, SimplifiedArtist, SimplifiedTrack,
   };
   use std::collections::HashMap;
 
@@ -866,6 +1070,55 @@ mod tests {
         current_id: 0,
       },
     ];
+  }
+
+  #[allow(deprecated)]
+  fn saved_album(index: usize) -> SavedAlbum {
+    let id = format!("{index:0>22}");
+    SavedAlbum {
+      added_at: Utc::now(),
+      album: FullAlbum {
+        artists: vec![SimplifiedArtist {
+          name: format!("Artist {index}"),
+          ..Default::default()
+        }],
+        album_type: AlbumType::Album,
+        available_markets: None,
+        copyrights: vec![],
+        external_ids: HashMap::new(),
+        external_urls: HashMap::new(),
+        genres: vec![],
+        href: format!("https://example.com/albums/{id}"),
+        id: AlbumId::from_id(&id).expect("valid album id").into_static(),
+        images: vec![],
+        name: format!("Album {index}"),
+        popularity: 0,
+        release_date: "2026-01-01".to_string(),
+        release_date_precision: DatePrecision::Day,
+        tracks: Page {
+          href: format!("https://example.com/albums/{id}/tracks"),
+          items: Vec::<SimplifiedTrack>::new(),
+          limit: 0,
+          next: None,
+          offset: 0,
+          previous: None,
+          total: 0,
+        },
+        label: None,
+      },
+    }
+  }
+
+  fn with_saved_albums(app: &mut App, count: usize) {
+    app.library.saved_albums.add_pages(Page {
+      href: "https://example.com/me/albums".to_string(),
+      items: (0..count).map(saved_album).collect(),
+      limit: count as u32,
+      next: None,
+      offset: 0,
+      previous: None,
+      total: count as u32,
+    });
   }
 
   fn open_settings(app: &mut App) {
@@ -1426,6 +1679,56 @@ mod tests {
   }
 
   #[test]
+  fn click_in_saved_albums_selects_row() {
+    let mut app = App::default();
+    app.size = Size {
+      width: 160,
+      height: 50,
+    };
+    app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
+    with_saved_albums(&mut app, 3);
+    app.album_list_index = 0;
+
+    let areas = main_layout_areas(&app).expect("layout areas");
+    let x = areas.content.x + 1;
+    let y = areas.content.y + 3;
+
+    handler(
+      mouse_event(MouseEventKind::Down(MouseButton::Left), x, y),
+      &mut app,
+    );
+
+    assert_eq!(app.album_list_index, 1);
+    let current_route = app.get_current_route();
+    assert_eq!(current_route.active_block, ActiveBlock::AlbumList);
+  }
+
+  #[test]
+  fn scroll_over_saved_albums_changes_selection() {
+    let mut app = App::default();
+    app.size = Size {
+      width: 160,
+      height: 50,
+    };
+    app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
+    with_saved_albums(&mut app, 3);
+    app.album_list_index = 0;
+
+    let areas = main_layout_areas(&app).expect("layout areas");
+    let x = areas.content.x + 1;
+    let y = areas.content.y + 2;
+
+    handler(mouse_event(MouseEventKind::ScrollDown, x, y), &mut app);
+    assert_eq!(app.album_list_index, 1);
+
+    handler(mouse_event(MouseEventKind::ScrollUp, x, y), &mut app);
+    assert_eq!(app.album_list_index, 0);
+
+    let current_route = app.get_current_route();
+    assert_eq!(current_route.active_block, ActiveBlock::AlbumList);
+  }
+
+  #[test]
   fn click_outside_playlist_is_ignored() {
     let mut app = App::default();
     app.size = Size {
@@ -1489,7 +1792,7 @@ mod tests {
     let first = table_item_index_from_click(area, 2, selected_index, item_count);
     let second = table_item_index_from_click(area, 3, selected_index, item_count);
 
-    assert_eq!(first, Some(14));
-    assert_eq!(second, Some(15));
+    assert_eq!(first, Some(9));
+    assert_eq!(second, Some(10));
   }
 }

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -1,7 +1,4 @@
-use super::{
-  album_list, album_tracks, artists, episode_table, library, playbar, playlist, podcasts,
-  recently_played, settings, track_table,
-};
+use super::{common_key_events, library, playbar, playlist, settings, track_table};
 use crate::core::app::{
   ActiveBlock, App, RouteId, SettingValue, SettingsCategory, LIBRARY_OPTIONS,
 };
@@ -10,6 +7,7 @@ use crate::core::layout::{
 };
 use crate::tui::event::Key;
 use crate::tui::ui::player::playbar_control_at;
+use crate::tui::ui::tables::table_scroll_offset;
 use crate::tui::ui::util::{get_main_layout_margin, SMALL_TERMINAL_WIDTH};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -154,31 +152,39 @@ fn handle_content_table_mouse(
   route_id: RouteId,
   app: &mut App,
 ) {
-  let Some(table) = ContentTable::for_route(route_id) else {
+  let Some(active_block) = common_key_events::content_active_block_for_route(&route_id) else {
     return;
   };
 
-  if table == ContentTable::TrackTable {
+  if active_block == ActiveBlock::TrackTable {
     handle_song_table_mouse(mouse, table_area, app);
     return;
   }
 
-  if content_table_item_count(table, app) == 0 {
+  if !matches!(
+    mouse.kind,
+    MouseEventKind::ScrollDown | MouseEventKind::ScrollUp | MouseEventKind::Down(MouseButton::Left)
+  ) {
+    return;
+  }
+
+  let item_count = content_table_item_count(active_block, app);
+  if item_count == 0 {
     return;
   }
 
   match mouse.kind {
     MouseEventKind::ScrollDown => {
-      focus_content_table(table, app);
-      handle_content_table_key(table, Key::Down, app);
+      focus_content_table(active_block, app);
+      super::handle_block_events(Key::Down, app);
     }
     MouseEventKind::ScrollUp => {
-      focus_content_table(table, app);
-      handle_content_table_key(table, Key::Up, app);
+      focus_content_table(active_block, app);
+      super::handle_block_events(Key::Up, app);
     }
     MouseEventKind::Down(MouseButton::Left) => {
-      focus_content_table(table, app);
-      select_clicked_content_table_item(table, mouse.row, table_area, app);
+      focus_content_table(active_block, app);
+      select_clicked_content_table_item(active_block, mouse.row, table_area, item_count, app);
     }
     _ => {}
   }
@@ -404,8 +410,7 @@ fn focus_song_table(app: &mut App) {
   app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
 }
 
-fn focus_content_table(table: ContentTable, app: &mut App) {
-  let active_block = table.active_block();
+fn focus_content_table(active_block: ActiveBlock, app: &mut App) {
   app.set_current_route_state(Some(active_block), Some(active_block));
 }
 
@@ -502,13 +507,14 @@ fn select_clicked_song(mouse_row: u16, table_area: Rect, app: &mut App) {
 }
 
 fn select_clicked_content_table_item(
-  table: ContentTable,
+  active_block: ActiveBlock,
   mouse_row: u16,
   table_area: Rect,
+  item_count: usize,
   app: &mut App,
 ) {
-  let item_count = content_table_item_count(table, app);
-  let selected_index = content_table_selected_index(table, app).min(item_count.saturating_sub(1));
+  let selected_index =
+    content_table_selected_index(active_block, app).min(item_count.saturating_sub(1));
 
   let Some(clicked_index) =
     table_item_index_from_click(table_area, mouse_row, selected_index, item_count)
@@ -516,61 +522,22 @@ fn select_clicked_content_table_item(
     return;
   };
 
-  let was_selected = content_table_selected_index(table, app) == clicked_index;
-  set_content_table_selected_index(table, clicked_index, app);
+  let was_selected = content_table_selected_index(active_block, app) == clicked_index;
+  set_content_table_selected_index(active_block, clicked_index, app);
   if was_selected {
-    handle_content_table_key(table, Key::Enter, app);
+    super::handle_block_events(Key::Enter, app);
   }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ContentTable {
-  TrackTable,
-  AlbumList,
-  AlbumTracks,
-  RecentlyPlayed,
-  Artists,
-  Podcasts,
-  EpisodeTable,
-}
-
-impl ContentTable {
-  fn for_route(route_id: RouteId) -> Option<Self> {
-    match route_id {
-      RouteId::TrackTable | RouteId::Recommendations => Some(Self::TrackTable),
-      RouteId::AlbumList => Some(Self::AlbumList),
-      RouteId::AlbumTracks => Some(Self::AlbumTracks),
-      RouteId::RecentlyPlayed => Some(Self::RecentlyPlayed),
-      RouteId::Artists => Some(Self::Artists),
-      RouteId::Podcasts => Some(Self::Podcasts),
-      RouteId::PodcastEpisodes => Some(Self::EpisodeTable),
-      _ => None,
-    }
-  }
-
-  fn active_block(self) -> ActiveBlock {
-    match self {
-      Self::TrackTable => ActiveBlock::TrackTable,
-      Self::AlbumList => ActiveBlock::AlbumList,
-      Self::AlbumTracks => ActiveBlock::AlbumTracks,
-      Self::RecentlyPlayed => ActiveBlock::RecentlyPlayed,
-      Self::Artists => ActiveBlock::Artists,
-      Self::Podcasts => ActiveBlock::Podcasts,
-      Self::EpisodeTable => ActiveBlock::EpisodeTable,
-    }
-  }
-}
-
-fn content_table_item_count(table: ContentTable, app: &App) -> usize {
-  match table {
-    ContentTable::TrackTable => app.track_table.tracks.len(),
-    ContentTable::AlbumList => app
+fn content_table_item_count(active_block: ActiveBlock, app: &App) -> usize {
+  match active_block {
+    ActiveBlock::AlbumList => app
       .library
       .saved_albums
       .get_results(None)
       .map(|albums| albums.items.len())
       .unwrap_or(0),
-    ContentTable::AlbumTracks => match app.album_table_context {
+    ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app
         .selected_album_full
         .as_ref()
@@ -582,38 +549,38 @@ fn content_table_item_count(table: ContentTable, app: &App) -> usize {
         .map(|album| album.tracks.items.len())
         .unwrap_or(0),
     },
-    ContentTable::RecentlyPlayed => app
+    ActiveBlock::RecentlyPlayed => app
       .recently_played
       .result
       .as_ref()
       .map(|recently_played| recently_played.items.len())
       .unwrap_or(0),
-    ContentTable::Artists => app
+    ActiveBlock::Artists => app
       .library
       .saved_artists
       .get_results(None)
       .map(|artists| artists.items.len())
       .unwrap_or(0),
-    ContentTable::Podcasts => app
+    ActiveBlock::Podcasts => app
       .library
       .saved_shows
       .get_results(None)
       .map(|shows| shows.items.len())
       .unwrap_or(0),
-    ContentTable::EpisodeTable => app
+    ActiveBlock::EpisodeTable => app
       .library
       .show_episodes
       .get_results(None)
       .map(|episodes| episodes.items.len())
       .unwrap_or(0),
+    _ => 0,
   }
 }
 
-fn content_table_selected_index(table: ContentTable, app: &App) -> usize {
-  match table {
-    ContentTable::TrackTable => app.track_table.selected_index,
-    ContentTable::AlbumList => app.album_list_index,
-    ContentTable::AlbumTracks => match app.album_table_context {
+fn content_table_selected_index(active_block: ActiveBlock, app: &App) -> usize {
+  match active_block {
+    ActiveBlock::AlbumList => app.album_list_index,
+    ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index,
       crate::core::app::AlbumTableContext::Simplified => app
         .selected_album_simplified
@@ -621,18 +588,18 @@ fn content_table_selected_index(table: ContentTable, app: &App) -> usize {
         .map(|album| album.selected_index)
         .unwrap_or(0),
     },
-    ContentTable::RecentlyPlayed => app.recently_played.index,
-    ContentTable::Artists => app.artists_list_index,
-    ContentTable::Podcasts => app.shows_list_index,
-    ContentTable::EpisodeTable => app.episode_list_index,
+    ActiveBlock::RecentlyPlayed => app.recently_played.index,
+    ActiveBlock::Artists => app.artists_list_index,
+    ActiveBlock::Podcasts => app.shows_list_index,
+    ActiveBlock::EpisodeTable => app.episode_list_index,
+    _ => 0,
   }
 }
 
-fn set_content_table_selected_index(table: ContentTable, index: usize, app: &mut App) {
-  match table {
-    ContentTable::TrackTable => app.track_table.selected_index = index,
-    ContentTable::AlbumList => app.album_list_index = index,
-    ContentTable::AlbumTracks => match app.album_table_context {
+fn set_content_table_selected_index(active_block: ActiveBlock, index: usize, app: &mut App) {
+  match active_block {
+    ActiveBlock::AlbumList => app.album_list_index = index,
+    ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index = index,
       crate::core::app::AlbumTableContext::Simplified => {
         if let Some(album) = &mut app.selected_album_simplified {
@@ -640,22 +607,11 @@ fn set_content_table_selected_index(table: ContentTable, index: usize, app: &mut
         }
       }
     },
-    ContentTable::RecentlyPlayed => app.recently_played.index = index,
-    ContentTable::Artists => app.artists_list_index = index,
-    ContentTable::Podcasts => app.shows_list_index = index,
-    ContentTable::EpisodeTable => app.episode_list_index = index,
-  }
-}
-
-fn handle_content_table_key(table: ContentTable, key: Key, app: &mut App) {
-  match table {
-    ContentTable::TrackTable => track_table::handler(key, app),
-    ContentTable::AlbumList => album_list::handler(key, app),
-    ContentTable::AlbumTracks => album_tracks::handler(key, app),
-    ContentTable::RecentlyPlayed => recently_played::handler(key, app),
-    ContentTable::Artists => artists::handler(key, app),
-    ContentTable::Podcasts => podcasts::handler(key, app),
-    ContentTable::EpisodeTable => episode_table::handler(key, app),
+    ActiveBlock::RecentlyPlayed => app.recently_played.index = index,
+    ActiveBlock::Artists => app.artists_list_index = index,
+    ActiveBlock::Podcasts => app.shows_list_index = index,
+    ActiveBlock::EpisodeTable => app.episode_list_index = index,
+    _ => {}
   }
 }
 
@@ -1022,18 +978,12 @@ fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
   x >= rect.x && x < right && y >= rect.y && y < bottom
 }
 
-fn table_scroll_offset(selected_index: usize, visible_rows: usize) -> usize {
-  if visible_rows == 0 {
-    return 0;
-  }
-
-  selected_index.saturating_sub(visible_rows.saturating_sub(1))
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::core::app::{PlaylistFolderItem, RouteId, SettingValue, SettingsCategory};
+  use crate::core::app::{
+    AlbumTableContext, PlaylistFolderItem, RouteId, SelectedAlbum, SettingValue, SettingsCategory,
+  };
   use crate::tui::ui::player::PlaybarControl;
   use chrono::{Duration, Utc};
   use crossterm::event::{KeyModifiers, MouseEvent};
@@ -1726,6 +1676,87 @@ mod tests {
 
     let current_route = app.get_current_route();
     assert_eq!(current_route.active_block, ActiveBlock::AlbumList);
+  }
+
+  #[test]
+  fn content_table_selection_helpers_cover_supported_blocks() {
+    let mut app = App::default();
+    app.album_list_index = 2;
+    app.saved_album_tracks_index = 3;
+    app.recently_played.index = 4;
+    app.artists_list_index = 5;
+    app.shows_list_index = 6;
+    app.episode_list_index = 7;
+
+    assert_eq!(
+      content_table_selected_index(ActiveBlock::AlbumList, &app),
+      2
+    );
+    assert_eq!(
+      content_table_selected_index(ActiveBlock::AlbumTracks, &app),
+      3
+    );
+    assert_eq!(
+      content_table_selected_index(ActiveBlock::RecentlyPlayed, &app),
+      4
+    );
+    assert_eq!(content_table_selected_index(ActiveBlock::Artists, &app), 5);
+    assert_eq!(content_table_selected_index(ActiveBlock::Podcasts, &app), 6);
+    assert_eq!(
+      content_table_selected_index(ActiveBlock::EpisodeTable, &app),
+      7
+    );
+
+    set_content_table_selected_index(ActiveBlock::AlbumList, 8, &mut app);
+    set_content_table_selected_index(ActiveBlock::AlbumTracks, 9, &mut app);
+    set_content_table_selected_index(ActiveBlock::RecentlyPlayed, 10, &mut app);
+    set_content_table_selected_index(ActiveBlock::Artists, 11, &mut app);
+    set_content_table_selected_index(ActiveBlock::Podcasts, 12, &mut app);
+    set_content_table_selected_index(ActiveBlock::EpisodeTable, 13, &mut app);
+
+    assert_eq!(app.album_list_index, 8);
+    assert_eq!(app.saved_album_tracks_index, 9);
+    assert_eq!(app.recently_played.index, 10);
+    assert_eq!(app.artists_list_index, 11);
+    assert_eq!(app.shows_list_index, 12);
+    assert_eq!(app.episode_list_index, 13);
+  }
+
+  #[test]
+  fn content_table_selection_helpers_update_simplified_album_tracks() {
+    let mut app = App::default();
+    app.album_table_context = AlbumTableContext::Simplified;
+    app.selected_album_simplified = Some(SelectedAlbum {
+      album: SimplifiedAlbum {
+        name: "Album".to_string(),
+        ..Default::default()
+      },
+      tracks: Page {
+        href: "https://example.com/albums/1/tracks".to_string(),
+        items: Vec::<SimplifiedTrack>::new(),
+        limit: 0,
+        next: None,
+        offset: 0,
+        previous: None,
+        total: 0,
+      },
+      selected_index: 1,
+    });
+
+    assert_eq!(
+      content_table_selected_index(ActiveBlock::AlbumTracks, &app),
+      1
+    );
+
+    set_content_table_selected_index(ActiveBlock::AlbumTracks, 2, &mut app);
+
+    assert_eq!(
+      app
+        .selected_album_simplified
+        .as_ref()
+        .map(|album| album.selected_index),
+      Some(2)
+    );
   }
 
   #[test]

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -788,7 +788,7 @@ fn draw_table(
   f.render_widget(table, layout_chunk);
 }
 
-fn table_scroll_offset(selected_index: usize, visible_rows: usize) -> usize {
+pub fn table_scroll_offset(selected_index: usize, visible_rows: usize) -> usize {
   if visible_rows == 0 {
     return 0;
   }


### PR DESCRIPTION
This pull request significantly expands and generalizes mouse interaction support across multiple content tables in the TUI, moving beyond just the track table. It introduces a unified system for handling mouse clicks and scrolls in album lists, album tracks, recently played, artists, podcasts, and episode tables, making the user experience more consistent and maintainable. The changes also include utility refactoring, improved test coverage for new mouse behaviors, and minor adjustments for correctness.

**Generalized mouse handling for content tables:**

* Introduced a `ContentTable` enum and associated logic to abstract mouse interactions (click, scroll) for different table-like UI components, such as album lists, album tracks, recently played, artists, podcasts, and episode tables. This replaces the previous track-table-specific logic with a unified handler (`handle_content_table_mouse`) and supporting functions for selection, focus, and key handling. [[1]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5L85-R89) [[2]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5R151-R186) [[3]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5R407-R411) [[4]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5R504-R661)

* Updated the main mouse event handler to route content area mouse events to the new generalized handler, enabling consistent behavior across all supported content tables.

**Refactoring and utility improvements:**

* Added a utility function `table_scroll_offset` to standardize scroll offset calculations for tables, and refactored `table_item_index_from_click` to use this logic. [[1]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5L519-R719) [[2]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5R1025-R1032)

* Updated imports and code organization to support the new structure and ensure all relevant modules are included.

**Testing enhancements:**

* Added helper functions and test data generators (such as `saved_album` and `with_saved_albums`) to facilitate robust testing of album list mouse interactions. [[1]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5L841-R1045) [[2]](diffhunk://#diff-4f1bbeb879ee71ffd0d5a99b97a7a745179edcccef1a04dd64432625d4a6b5b5R1075-R1123)

* Added new tests to verify mouse click and scroll behavior in the album list, ensuring correct row selection and focus management.

* Adjusted existing tests to account for the new scroll offset calculation logic.

**Cover art rendering update:**

* Updated the cover art rendering logic to use the new `Size` struct from `ratatui`, improving compatibility and correctness in image sizing. [[1]](diffhunk://#diff-e2c4df7d90dbf07d8ca21ab79639aadc79e65f32146e237b66adbb0e2bd9daa9L3-R6) [[2]](diffhunk://#diff-e2c4df7d90dbf07d8ca21ab79639aadc79e65f32146e237b66adbb0e2bd9daa9L137-R149)