### PR TITLE
fix: require second clikc for song mouse selection. Closes #258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Mouse song selection**: Changed song-table left clicks so the first click highlights a row and a second click on the highlighted row selects/plays it, matching arrow-key plus Enter behavior ([#258](https://github.com/LargeModGames/spotatui/issues/258)).
+
 ## [v0.38.2] - 2026-05-10
 
 ### Added

--- a/src/core/test_helpers.rs
+++ b/src/core/test_helpers.rs
@@ -1,10 +1,12 @@
 #![cfg(test)]
 
+use chrono::Duration;
 use rspotify::model::{
   idtypes::{PlaylistId, UserId},
   playlist::PlaylistTracksRef,
+  track::FullTrack,
   user::{PrivateUser, PublicUser},
-  SimplifiedPlaylist,
+  SimplifiedAlbum, SimplifiedArtist, SimplifiedPlaylist, TrackId,
 };
 use std::collections::HashMap;
 
@@ -59,5 +61,36 @@ pub fn simplified_playlist(
     snapshot_id: "snapshot".to_string(),
     tracks: tracks.clone(),
     items: tracks,
+  }
+}
+
+#[allow(deprecated)]
+pub fn full_track(id: &str, name: &str) -> FullTrack {
+  FullTrack {
+    album: SimplifiedAlbum {
+      name: "Test Album".to_string(),
+      ..Default::default()
+    },
+    artists: vec![SimplifiedArtist {
+      name: "Test Artist".to_string(),
+      ..Default::default()
+    }],
+    available_markets: Vec::new(),
+    disc_number: 1,
+    duration: Duration::milliseconds(180_000),
+    explicit: false,
+    external_ids: HashMap::new(),
+    external_urls: HashMap::new(),
+    href: None,
+    id: Some(TrackId::from_id(id).unwrap().into_static()),
+    is_local: false,
+    is_playable: Some(true),
+    linked_from: None,
+    restrictions: None,
+    name: name.to_string(),
+    popularity: 50,
+    preview_url: None,
+    track_number: 1,
+    r#type: rspotify::model::Type::Track,
   }
 }

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -469,47 +469,15 @@ mod tests {
   use super::*;
   #[cfg(target_os = "macos")]
   use crate::core::app::TrackTableContext;
+  use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
-  use chrono::{Duration as ChronoDuration, Utc};
+  use chrono::Utc;
   use rspotify::model::{
-    artist::SimplifiedArtist,
     context::{Actions, CurrentPlaybackContext},
     enums::{DeviceType, RepeatState},
-    idtypes::TrackId,
-    CurrentlyPlayingType, Device, FullTrack, PlayableId, PlayableItem, SimplifiedAlbum,
+    CurrentlyPlayingType, Device, PlayableId, PlayableItem,
   };
-  use std::{collections::HashMap, sync::mpsc::channel, time::SystemTime};
-
-  #[allow(deprecated)]
-  fn full_track(id: &str, name: &str) -> FullTrack {
-    FullTrack {
-      album: SimplifiedAlbum {
-        name: "Album".to_string(),
-        ..Default::default()
-      },
-      artists: vec![SimplifiedArtist {
-        name: "Artist".to_string(),
-        ..Default::default()
-      }],
-      available_markets: Vec::new(),
-      disc_number: 1,
-      duration: ChronoDuration::milliseconds(180_000),
-      explicit: false,
-      external_ids: HashMap::new(),
-      external_urls: HashMap::new(),
-      href: None,
-      id: Some(TrackId::from_id(id).unwrap().into_static()),
-      is_local: false,
-      is_playable: Some(true),
-      linked_from: None,
-      restrictions: None,
-      name: name.to_string(),
-      popularity: 50,
-      preview_url: None,
-      track_number: 1,
-      r#type: rspotify::model::Type::Track,
-    }
-  }
+  use std::{sync::mpsc::channel, time::SystemTime};
 
   #[test]
   fn global_shift_w_adds_current_track_from_anywhere() {

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -1,4 +1,4 @@
-use super::{common_key_events, library, playbar, playlist, settings, track_table};
+use super::{common_key_events, library, playbar, playlist, settings};
 use crate::core::app::{
   ActiveBlock, App, RouteId, SettingValue, SettingsCategory, LIBRARY_OPTIONS,
 };
@@ -124,28 +124,6 @@ fn handle_playlist_mouse(mouse: MouseEvent, list_area: Rect, app: &mut App) {
   }
 }
 
-fn handle_song_table_mouse(mouse: MouseEvent, table_area: Rect, app: &mut App) {
-  if app.track_table.tracks.is_empty() {
-    return;
-  }
-
-  match mouse.kind {
-    MouseEventKind::ScrollDown => {
-      focus_song_table(app);
-      track_table::handler(Key::Down, app);
-    }
-    MouseEventKind::ScrollUp => {
-      focus_song_table(app);
-      track_table::handler(Key::Up, app);
-    }
-    MouseEventKind::Down(MouseButton::Left) => {
-      focus_song_table(app);
-      select_clicked_song(mouse.row, table_area, app);
-    }
-    _ => {}
-  }
-}
-
 fn handle_content_table_mouse(
   mouse: MouseEvent,
   table_area: Rect,
@@ -155,11 +133,6 @@ fn handle_content_table_mouse(
   let Some(active_block) = common_key_events::content_active_block_for_route(&route_id) else {
     return;
   };
-
-  if active_block == ActiveBlock::TrackTable {
-    handle_song_table_mouse(mouse, table_area, app);
-    return;
-  }
 
   if !matches!(
     mouse.kind,
@@ -406,10 +379,6 @@ fn focus_library(app: &mut App) {
   app.set_current_route_state(Some(ActiveBlock::Library), Some(ActiveBlock::Library));
 }
 
-fn focus_song_table(app: &mut App) {
-  app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
-}
-
 fn focus_content_table(active_block: ActiveBlock, app: &mut App) {
   app.set_current_route_state(Some(active_block), Some(active_block));
 }
@@ -488,24 +457,6 @@ fn select_clicked_playlist(mouse_row: u16, list_area: Rect, app: &mut App) {
   }
 }
 
-fn select_clicked_song(mouse_row: u16, table_area: Rect, app: &mut App) {
-  let item_count = app.track_table.tracks.len();
-  let selected_index = app
-    .track_table
-    .selected_index
-    .min(item_count.saturating_sub(1));
-
-  let Some(clicked_index) =
-    table_item_index_from_click(table_area, mouse_row, selected_index, item_count)
-  else {
-    return;
-  };
-
-  app.track_table.selected_index = clicked_index;
-  // Song clicks should behave like immediate selection + play.
-  track_table::handler(Key::Enter, app);
-}
-
 fn select_clicked_content_table_item(
   active_block: ActiveBlock,
   mouse_row: u16,
@@ -537,6 +488,7 @@ fn content_table_item_count(active_block: ActiveBlock, app: &App) -> usize {
       .get_results(None)
       .map(|albums| albums.items.len())
       .unwrap_or(0),
+    ActiveBlock::TrackTable => app.track_table.tracks.len(),
     ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app
         .selected_album_full
@@ -580,6 +532,7 @@ fn content_table_item_count(active_block: ActiveBlock, app: &App) -> usize {
 fn content_table_selected_index(active_block: ActiveBlock, app: &App) -> usize {
   match active_block {
     ActiveBlock::AlbumList => app.album_list_index,
+    ActiveBlock::TrackTable => app.track_table.selected_index,
     ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index,
       crate::core::app::AlbumTableContext::Simplified => app
@@ -599,6 +552,7 @@ fn content_table_selected_index(active_block: ActiveBlock, app: &App) -> usize {
 fn set_content_table_selected_index(active_block: ActiveBlock, index: usize, app: &mut App) {
   match active_block {
     ActiveBlock::AlbumList => app.album_list_index = index,
+    ActiveBlock::TrackTable => app.track_table.selected_index = index,
     ActiveBlock::AlbumTracks => match app.album_table_context {
       crate::core::app::AlbumTableContext::Full => app.saved_album_tracks_index = index,
       crate::core::app::AlbumTableContext::Simplified => {
@@ -983,7 +937,9 @@ mod tests {
   use super::*;
   use crate::core::app::{
     AlbumTableContext, PlaylistFolderItem, RouteId, SelectedAlbum, SettingValue, SettingsCategory,
+    TrackTableContext,
   };
+  use crate::core::test_helpers::full_track;
   use crate::tui::ui::player::PlaybarControl;
   use chrono::{Duration, Utc};
   use crossterm::event::{KeyModifiers, MouseEvent};
@@ -1651,6 +1607,42 @@ mod tests {
     assert_eq!(app.album_list_index, 1);
     let current_route = app.get_current_route();
     assert_eq!(current_route.active_block, ActiveBlock::AlbumList);
+  }
+
+  #[test]
+  fn click_in_song_table_first_highlights_second_plays() {
+    let mut app = App::default();
+    app.size = Size {
+      width: 160,
+      height: 50,
+    };
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+    app.track_table.context = Some(TrackTableContext::RecommendedTracks);
+    app.track_table.tracks = vec![
+      full_track("0000000000000000000001", "Track 1"),
+      full_track("0000000000000000000002", "Track 2"),
+    ];
+    app.track_table.selected_index = 0;
+
+    let areas = main_layout_areas(&app).expect("layout areas");
+    let x = areas.content.x + 1;
+    let y = areas.content.y + 3;
+
+    handler(
+      mouse_event(MouseEventKind::Down(MouseButton::Left), x, y),
+      &mut app,
+    );
+
+    assert_eq!(app.track_table.selected_index, 1);
+    assert!(!app.is_loading);
+
+    handler(
+      mouse_event(MouseEventKind::Down(MouseButton::Left), x, y),
+      &mut app,
+    );
+
+    assert_eq!(app.track_table.selected_index, 1);
+    assert!(app.is_loading);
   }
 
   #[test]

--- a/src/tui/handlers/search_results.rs
+++ b/src/tui/handlers/search_results.rs
@@ -564,45 +564,11 @@ mod tests {
   use super::*;
   use crate::core::{
     app::{ActiveBlock, RouteId},
-    test_helpers::{private_user, simplified_playlist},
+    test_helpers::{full_track, private_user, simplified_playlist},
     user_config::UserConfig,
   };
-  use chrono::Duration as ChronoDuration;
-  use rspotify::model::{
-    artist::SimplifiedArtist, idtypes::TrackId, page::Page, track::FullTrack, SimplifiedAlbum,
-  };
-  use std::{collections::HashMap, sync::mpsc::channel, time::SystemTime};
-
-  #[allow(deprecated)]
-  fn full_track(id: &str, name: &str) -> FullTrack {
-    FullTrack {
-      album: SimplifiedAlbum {
-        name: "Album".to_string(),
-        ..Default::default()
-      },
-      artists: vec![SimplifiedArtist {
-        name: "Artist".to_string(),
-        ..Default::default()
-      }],
-      available_markets: Vec::new(),
-      disc_number: 1,
-      duration: ChronoDuration::milliseconds(180_000),
-      explicit: false,
-      external_ids: HashMap::new(),
-      external_urls: HashMap::new(),
-      href: None,
-      id: Some(TrackId::from_id(id).unwrap().into_static()),
-      is_local: false,
-      is_playable: Some(true),
-      linked_from: None,
-      restrictions: None,
-      name: name.to_string(),
-      popularity: 50,
-      preview_url: None,
-      track_number: 1,
-      r#type: rspotify::model::Type::Track,
-    }
-  }
+  use rspotify::model::page::Page;
+  use std::{sync::mpsc::channel, time::SystemTime};
 
   #[test]
   fn pressing_w_on_search_song_opens_add_to_playlist_picker() {

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -588,48 +588,12 @@ fn saved_tracks_playback_request(app: &App) -> Option<(Vec<PlayableId<'static>>,
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
-  use chrono::{Duration as ChronoDuration, Utc};
-  use rspotify::model::{
-    artist::SimplifiedArtist,
-    page::Page,
-    track::{FullTrack, SavedTrack},
-  };
-  use rspotify::prelude::Id;
-  use std::collections::HashMap;
+  use chrono::Utc;
+  use rspotify::model::{page::Page, track::SavedTrack};
   use std::sync::mpsc::channel;
   use std::time::SystemTime;
-
-  #[allow(deprecated)]
-  fn full_track(id: &str, name: &str) -> FullTrack {
-    FullTrack {
-      album: rspotify::model::album::SimplifiedAlbum {
-        name: "Album".to_string(),
-        ..Default::default()
-      },
-      artists: vec![SimplifiedArtist {
-        name: "Artist".to_string(),
-        ..Default::default()
-      }],
-      available_markets: Vec::new(),
-      disc_number: 1,
-      duration: ChronoDuration::milliseconds(180_000),
-      explicit: false,
-      external_ids: HashMap::new(),
-      external_urls: HashMap::new(),
-      href: None,
-      id: Some(TrackId::from_id(id).unwrap().into_static()),
-      is_local: false,
-      is_playable: Some(true),
-      linked_from: None,
-      restrictions: None,
-      name: name.to_string(),
-      popularity: 50,
-      preview_url: None,
-      track_number: 1,
-      r#type: rspotify::model::Type::Track,
-    }
-  }
 
   fn saved_track(id: &str, name: &str) -> SavedTrack {
     SavedTrack {


### PR DESCRIPTION
# Summary

Fixes song-table mouse selection so the first left click highlights a row and a second click on the highlighted row plays/selects it, matching keyboard navigation plus Enter behavior. Also simplifies the mouse handler by reusing the generic content-table click path for track tables and moves duplicated `FullTrack` test fixtures into a shared test helper.

# Testing

- `cargo fmt --all`
  - Passed.
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
  - Passed.
- `cargo test --no-default-features --features telemetry`
  - Passed: 173 passed, 0 failed, 0 ignored.

# Additional notes

- No screenshots included; this is a TUI mouse interaction change covered by unit tests.
