### PR TITLE
fix: make continue startup behavious passive. Fixes #254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Playbar cover art sizing**: Added configurable playbar cover art sizing and improved layout handling so the image, controls, and progress bar scale cleanly in the playbar ([#253](https://github.com/LargeModGames/spotatui/issues/253)).
 - **Mouse song selection**: Changed song-table left clicks so the first click highlights a row and a second click on the highlighted row selects/plays it, matching arrow-key plus Enter behavior ([#258](https://github.com/LargeModGames/spotatui/issues/258)).
+- **Startup playback hijacking**: Made the default `Continue` startup behavior passive so launching spotatui discovers devices without transferring playback to the native Spotatui Connect device ([#254](https://github.com/LargeModGames/spotatui/issues/254)).
 
 ## [v0.38.2] - 2026-05-10
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -178,6 +178,127 @@ async fn account_supports_native_streaming(
   }
 }
 
+#[cfg(any(feature = "streaming", test))]
+#[derive(Debug, PartialEq, Eq)]
+enum StartupDeviceEvent {
+  Transfer {
+    device_id: String,
+    persist_device_id: bool,
+  },
+  AutoSelectStreaming {
+    device_name: String,
+    persist_device_id: bool,
+  },
+}
+
+#[cfg(any(feature = "streaming", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct StartupDeviceDecision {
+  event: Option<StartupDeviceEvent>,
+  status_message: Option<String>,
+}
+
+#[cfg(feature = "streaming")]
+impl StartupDeviceEvent {
+  fn into_io_event(self) -> IoEvent {
+    match self {
+      StartupDeviceEvent::Transfer {
+        device_id,
+        persist_device_id,
+      } => IoEvent::TransferPlaybackToDevice(device_id, persist_device_id),
+      StartupDeviceEvent::AutoSelectStreaming {
+        device_name,
+        persist_device_id,
+      } => IoEvent::AutoSelectStreamingDevice(device_name, persist_device_id),
+    }
+  }
+}
+
+#[cfg(any(feature = "streaming", test))]
+fn startup_device_decision(
+  startup_behavior: StartupBehavior,
+  saved_device_id: Option<String>,
+  devices_snapshot: Option<&[rspotify::model::device::Device]>,
+  native_device_name: &str,
+) -> StartupDeviceDecision {
+  if startup_behavior != StartupBehavior::Play {
+    return StartupDeviceDecision {
+      event: None,
+      status_message: None,
+    };
+  }
+
+  let event = match saved_device_id {
+    Some(saved_device_id) => {
+      if let Some(devices) = devices_snapshot {
+        let mut saved_device_available = false;
+        let mut native_device_id = None;
+
+        for device in devices {
+          if device.id.as_ref() == Some(&saved_device_id) {
+            saved_device_available = true;
+            break;
+          }
+
+          if native_device_id.is_none() && device.name.eq_ignore_ascii_case(native_device_name) {
+            native_device_id = device.id.clone();
+          }
+        }
+
+        if saved_device_available {
+          Some(StartupDeviceEvent::Transfer {
+            device_id: saved_device_id,
+            persist_device_id: true,
+          })
+        } else {
+          native_device_id.map_or_else(
+            || {
+              Some(StartupDeviceEvent::AutoSelectStreaming {
+                device_name: native_device_name.to_string(),
+                persist_device_id: false,
+              })
+            },
+            |device_id| {
+              Some(StartupDeviceEvent::Transfer {
+                device_id,
+                persist_device_id: false,
+              })
+            },
+          )
+        }
+      } else {
+        Some(StartupDeviceEvent::Transfer {
+          device_id: saved_device_id,
+          persist_device_id: true,
+        })
+      }
+    }
+    None => Some(StartupDeviceEvent::AutoSelectStreaming {
+      device_name: native_device_name.to_string(),
+      persist_device_id: true,
+    }),
+  };
+
+  let status_message = matches!(
+    event,
+    Some(
+      StartupDeviceEvent::Transfer {
+        persist_device_id: false,
+        ..
+      } | StartupDeviceEvent::AutoSelectStreaming {
+        persist_device_id: false,
+        ..
+      }
+    )
+  )
+  .then(|| format!("Saved device unavailable; using {}", native_device_name));
+
+  StartupDeviceDecision {
+    event,
+    status_message,
+  }
+}
+
 #[cfg(all(target_os = "linux", feature = "streaming"))]
 fn init_audio_backend() {
   alsa_silence::suppress_alsa_errors();
@@ -917,60 +1038,31 @@ of the app. Beware that this comes at a CPU cost!",
           devices_snapshot = Some(devices_vec);
         }
 
-        let mut status_message = None;
-        let startup_event = match saved_device_id {
-          Some(saved_device_id) => {
-            if let Some(devices_vec) = devices_snapshot.as_ref() {
-              if devices_vec
-                .iter()
-                .any(|device| device.id.as_ref() == Some(&saved_device_id))
-              {
-                Some(IoEvent::TransferPlaybackToDevice(saved_device_id, true))
-              } else {
-                status_message = Some(format!("Saved device unavailable; using {}", device_name));
-                let native_device_id = devices_vec
-                  .iter()
-                  .find(|device| device.name.eq_ignore_ascii_case(&device_name))
-                  .and_then(|device| device.id.clone());
-                if let Some(native_device_id) = native_device_id {
-                  Some(IoEvent::TransferPlaybackToDevice(native_device_id, false))
-                } else {
-                  Some(IoEvent::AutoSelectStreamingDevice(
-                    device_name.clone(),
-                    false,
-                  ))
-                }
-              }
-            } else {
-              Some(IoEvent::TransferPlaybackToDevice(saved_device_id, true))
-            }
-          }
-          None => Some(IoEvent::AutoSelectStreamingDevice(
-            device_name.clone(),
-            true,
-          )),
-        };
+        let startup_decision = startup_device_decision(
+          initial_startup_behavior,
+          saved_device_id,
+          devices_snapshot.as_deref(),
+          &device_name,
+        );
 
-        if let Some(message) = status_message {
+        if let Some(message) = startup_decision.status_message {
           let mut app = network.app.lock().await;
-          app.status_message = Some(message);
-          app.status_message_expires_at = Some(Instant::now() + Duration::from_secs(5));
+          app.set_status_message(message, 5);
         }
 
-        if let Some(event) = startup_event {
-          network.handle_network_event(event).await;
+        if let Some(event) = startup_decision.event {
+          network.handle_network_event(event.into_io_event()).await;
         }
       }
 
-      // Apply saved shuffle preference on startup
-      network
-        .handle_network_event(IoEvent::Shuffle(initial_shuffle_enabled))
-        .await;
-
-      // Apply configured startup play behavior
+      // Apply configured startup play behavior. Continue is passive and must not
+      // transfer devices, change shuffle, or otherwise activate Spotatui.
       match initial_startup_behavior {
         StartupBehavior::Continue => {}
         StartupBehavior::Play => {
+          network
+            .handle_network_event(IoEvent::Shuffle(initial_shuffle_enabled))
+            .await;
           network
             .handle_network_event(IoEvent::StartPlayback(None, None, None))
             .await;
@@ -1260,5 +1352,198 @@ async fn handle_macos_media_events(
         player.stop();
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{startup_device_decision, StartupDeviceEvent};
+  use crate::core::user_config::StartupBehavior;
+  use rspotify::model::{device::Device, DeviceType};
+
+  const NATIVE_NAME: &str = "spotatui";
+  const NATIVE_ID: &str = "native-device";
+  const EXTERNAL_ID: &str = "phone-device";
+
+  #[allow(deprecated)]
+  fn device(id: &str, name: &str) -> Device {
+    Device {
+      id: Some(id.to_string()),
+      is_active: false,
+      is_private_session: false,
+      is_restricted: false,
+      name: name.to_string(),
+      _type: DeviceType::Computer,
+      volume_percent: Some(50),
+    }
+  }
+
+  fn startup_device_event(
+    startup_behavior: StartupBehavior,
+    saved_device_id: Option<String>,
+    devices_snapshot: Option<&[Device]>,
+  ) -> Option<StartupDeviceEvent> {
+    startup_device_decision(
+      startup_behavior,
+      saved_device_id,
+      devices_snapshot,
+      NATIVE_NAME,
+    )
+    .event
+  }
+
+  #[test]
+  fn continue_without_saved_device_does_not_transfer() {
+    let devices = vec![device(NATIVE_ID, NATIVE_NAME)];
+
+    assert_eq!(
+      startup_device_event(StartupBehavior::Continue, None, Some(&devices)),
+      None
+    );
+  }
+
+  #[test]
+  fn continue_with_saved_native_device_does_not_transfer() {
+    let devices = vec![device(NATIVE_ID, NATIVE_NAME)];
+
+    assert_eq!(
+      startup_device_event(
+        StartupBehavior::Continue,
+        Some(NATIVE_ID.to_string()),
+        Some(&devices),
+      ),
+      None
+    );
+  }
+
+  #[test]
+  fn continue_with_saved_external_device_does_not_transfer() {
+    let devices = vec![
+      device(EXTERNAL_ID, "Jay's phone"),
+      device(NATIVE_ID, NATIVE_NAME),
+    ];
+
+    assert_eq!(
+      startup_device_event(
+        StartupBehavior::Continue,
+        Some(EXTERNAL_ID.to_string()),
+        Some(&devices),
+      ),
+      None
+    );
+  }
+
+  #[test]
+  fn play_with_saved_available_device_transfers_to_saved_device() {
+    let devices = vec![
+      device(EXTERNAL_ID, "Jay's phone"),
+      device(NATIVE_ID, NATIVE_NAME),
+    ];
+
+    assert_eq!(
+      startup_device_event(
+        StartupBehavior::Play,
+        Some(EXTERNAL_ID.to_string()),
+        Some(&devices),
+      ),
+      Some(StartupDeviceEvent::Transfer {
+        device_id: EXTERNAL_ID.to_string(),
+        persist_device_id: true,
+      })
+    );
+  }
+
+  #[test]
+  fn play_without_saved_device_auto_selects_native_fallback() {
+    let devices = vec![device(NATIVE_ID, NATIVE_NAME)];
+
+    assert_eq!(
+      startup_device_event(StartupBehavior::Play, None, Some(&devices)),
+      Some(StartupDeviceEvent::AutoSelectStreaming {
+        device_name: NATIVE_NAME.to_string(),
+        persist_device_id: true,
+      })
+    );
+  }
+
+  #[test]
+  fn continue_with_unavailable_saved_device_does_not_fall_back_to_native() {
+    let devices = vec![device(NATIVE_ID, NATIVE_NAME)];
+
+    assert_eq!(
+      startup_device_event(
+        StartupBehavior::Continue,
+        Some(EXTERNAL_ID.to_string()),
+        Some(&devices),
+      ),
+      None
+    );
+  }
+
+  #[test]
+  fn play_with_unavailable_saved_device_transfers_to_native_without_persisting() {
+    let devices = vec![device(NATIVE_ID, NATIVE_NAME)];
+
+    let decision = startup_device_decision(
+      StartupBehavior::Play,
+      Some(EXTERNAL_ID.to_string()),
+      Some(&devices),
+      NATIVE_NAME,
+    );
+
+    assert_eq!(
+      decision.event,
+      Some(StartupDeviceEvent::Transfer {
+        device_id: NATIVE_ID.to_string(),
+        persist_device_id: false,
+      })
+    );
+    assert_eq!(
+      decision.status_message,
+      Some(format!("Saved device unavailable; using {}", NATIVE_NAME))
+    );
+  }
+
+  #[test]
+  fn play_with_unavailable_saved_device_auto_selects_native_without_persisting() {
+    let devices = vec![device("other-device", "Other speaker")];
+
+    let decision = startup_device_decision(
+      StartupBehavior::Play,
+      Some(EXTERNAL_ID.to_string()),
+      Some(&devices),
+      NATIVE_NAME,
+    );
+
+    assert_eq!(
+      decision.event,
+      Some(StartupDeviceEvent::AutoSelectStreaming {
+        device_name: NATIVE_NAME.to_string(),
+        persist_device_id: false,
+      })
+    );
+    assert_eq!(
+      decision.status_message,
+      Some(format!("Saved device unavailable; using {}", NATIVE_NAME))
+    );
+  }
+
+  #[test]
+  fn play_with_saved_device_and_no_snapshot_transfers_to_saved_device() {
+    let decision = startup_device_decision(
+      StartupBehavior::Play,
+      Some(EXTERNAL_ID.to_string()),
+      None,
+      NATIVE_NAME,
+    );
+
+    assert_eq!(
+      decision.event,
+      Some(StartupDeviceEvent::Transfer {
+        device_id: EXTERNAL_ID.to_string(),
+        persist_device_id: true,
+      })
+    );
+    assert_eq!(decision.status_message, None);
   }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -53,7 +53,7 @@ use rspotify::prelude::*;
 #[cfg(feature = "streaming")]
 use rspotify::AuthCodePkceSpotify;
 #[cfg(feature = "streaming")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{
   fs,
   io::{self, Write},


### PR DESCRIPTION
 # Summary

  Makes the default `Continue` startup behavior passive so launching spotatui no longer
  transfers playback to the native Spotatui Connect device. Device transfer, shuffle, and
  playback start now only run for `Play` startup behavior, with focused tests covering
  the startup device decision paths.

  Fixes #254 

  # Testing

  - `cargo fmt --all`
  - `cargo test --no-default-features --features telemetry runtime::tests`
    - 9 passed; 0 failed
  - `cargo clippy --no-default-features --features telemetry -- -D warnings`
  - `cargo test --no-default-features --features telemetry`
    - 182 passed; 0 failed

  # Additional notes

  No screenshots needed; this is startup/runtime behavior only.