### PR TITLE
Adaptive tick rate. Fixes #252

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Adaptive tick rates**: Split normal UI refreshes from animation-heavy refreshes so regular screens default to a lower CPU cadence while audio visualization stays smooth, and migrate legacy saved tick-rate defaults automatically ([#252](https://github.com/LargeModGames/spotatui/issues/252)).
 - **Playbar cover art sizing**: Added configurable playbar cover art sizing and improved layout handling so the image, controls, and progress bar scale cleanly in the playbar ([#253](https://github.com/LargeModGames/spotatui/issues/253)).
 - **Mouse song selection**: Changed song-table left clicks so the first click highlights a row and a second click on the highlighted row selects/plays it, matching arrow-key plus Enter behavior ([#258](https://github.com/LargeModGames/spotatui/issues/258)).
 - **Playlist and Liked Songs infinite scroll**: Made playlist track tables and Liked Songs scroll continuously across cached pages, prefetch additional pages in the background, and wrap `Down` from the end back to the first row and `Up` from the first row back to the last loaded row.

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,5 +1,5 @@
 use crate::core::sort::{SortContext, SortState};
-use crate::core::user_config::{color_to_string, UserConfig};
+use crate::core::user_config::{color_to_string, normalize_tick_rate_milliseconds, UserConfig};
 use crate::infra::network::sync::{PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
@@ -3398,12 +3398,13 @@ impl App {
         }
         "behavior.tick_rate_milliseconds" => {
           if let SettingValue::Number(v) = &setting.value {
-            self.user_config.behavior.tick_rate_milliseconds = (*v).clamp(1, 999) as u64;
+            self.user_config.behavior.tick_rate_milliseconds = normalize_tick_rate_milliseconds(*v);
           }
         }
         "behavior.animation_tick_rate_milliseconds" => {
           if let SettingValue::Number(v) = &setting.value {
-            self.user_config.behavior.animation_tick_rate_milliseconds = (*v).clamp(1, 999) as u64;
+            self.user_config.behavior.animation_tick_rate_milliseconds =
+              normalize_tick_rate_milliseconds(*v);
           }
         }
         "behavior.enable_text_emphasis" => {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -766,8 +766,10 @@ pub struct App {
   pub artist_sort: SortState,
   /// Animation frame counter for the "Liked" heart flash effect (0-10)
   pub liked_song_animation_frame: Option<u8>,
-  /// Global animation tick counter, incremented every tick (~62 FPS)
+  /// Global animation tick counter, incremented every tick.
   pub animation_tick: u64,
+  /// Last time the listening party host broadcast playback state.
+  pub last_party_sync_at: Instant,
   /// Ephemeral status message shown in the playbar
   pub status_message: Option<String>,
   /// When to clear the status message
@@ -973,6 +975,7 @@ impl Default for App {
       artist_sort: SortState::new(),
       liked_song_animation_frame: None,
       animation_tick: 0,
+      last_party_sync_at: Instant::now(),
       status_message: None,
       status_message_expires_at: None,
       party_status: PartyStatus::default(),
@@ -1372,13 +1375,16 @@ impl App {
     }
   }
 
-  pub fn update_on_tick(&mut self) {
+  pub fn update_on_tick(&mut self, elapsed: Duration) {
     // Increment global animation tick (wraps after ~9.4 quintillion ticks, effectively never)
     self.animation_tick = self.animation_tick.wrapping_add(1);
 
-    // Periodic party sync: host broadcasts state every ~2 seconds (~125 ticks at 16ms)
+    // Periodic party sync: host broadcasts state about every 2 seconds.
     // Keep this before early-return paths so sync still happens during native-streaming fast paths.
-    if self.party_status == PartyStatus::Hosting && self.animation_tick.is_multiple_of(125) {
+    if self.party_status == PartyStatus::Hosting
+      && self.last_party_sync_at.elapsed() >= Duration::from_secs(2)
+    {
+      self.last_party_sync_at = Instant::now();
       self.dispatch(IoEvent::SyncPlayback);
     }
 
@@ -1460,14 +1466,14 @@ impl App {
           .unwrap_or(0);
       } else if *is_playing {
         // Smooth incremental updates between API polls
-        let tick_rate_ms = self.user_config.behavior.tick_rate_milliseconds as u128;
+        let elapsed_ms = elapsed.as_millis();
         let duration_ms = match item {
           PlayableItem::Track(track) => track.duration.num_milliseconds() as u128,
           PlayableItem::Episode(episode) => episode.duration.num_milliseconds() as u128,
           _ => return,
         };
 
-        self.song_progress_ms = (self.song_progress_ms + tick_rate_ms).min(duration_ms);
+        self.song_progress_ms = (self.song_progress_ms + elapsed_ms).min(duration_ms);
       }
       // When paused, keep song_progress_ms unchanged
     }
@@ -2934,6 +2940,14 @@ impl App {
           value: SettingValue::Number(self.user_config.behavior.tick_rate_milliseconds as i64),
         },
         SettingItem {
+          id: "behavior.animation_tick_rate_milliseconds".to_string(),
+          name: "Animation Tick Rate (ms)".to_string(),
+          description: "Refresh rate for animation-heavy views".to_string(),
+          value: SettingValue::Number(
+            self.user_config.behavior.animation_tick_rate_milliseconds as i64,
+          ),
+        },
+        SettingItem {
           id: "behavior.enable_text_emphasis".to_string(),
           name: "Text Emphasis".to_string(),
           description: "Enable bold/italic text styling".to_string(),
@@ -3384,7 +3398,12 @@ impl App {
         }
         "behavior.tick_rate_milliseconds" => {
           if let SettingValue::Number(v) = &setting.value {
-            self.user_config.behavior.tick_rate_milliseconds = (*v).max(1) as u64;
+            self.user_config.behavior.tick_rate_milliseconds = (*v).clamp(1, 999) as u64;
+          }
+        }
+        "behavior.animation_tick_rate_milliseconds" => {
+          if let SettingValue::Number(v) = &setting.value {
+            self.user_config.behavior.animation_tick_rate_milliseconds = (*v).clamp(1, 999) as u64;
           }
         }
         "behavior.enable_text_emphasis" => {

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -10,6 +10,9 @@ use std::{
 const FILE_NAME: &str = "config.yml";
 const CONFIG_DIR: &str = ".config";
 const APP_CONFIG_DIR: &str = "spotatui";
+pub const DEFAULT_TICK_RATE_MILLISECONDS: u64 = 250;
+pub const DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS: u64 = 16;
+pub const MAX_TICK_RATE_MILLISECONDS: u64 = 999;
 #[cfg(feature = "cover-art")]
 pub const MIN_PLAYBAR_COVER_ART_SIZE_PERCENT: u16 = 25;
 #[cfg(feature = "cover-art")]
@@ -29,6 +32,18 @@ pub fn normalize_playbar_cover_art_size_percent(value: i64) -> u16 {
     MIN_PLAYBAR_COVER_ART_SIZE_PERCENT as i64,
     MAX_PLAYBAR_COVER_ART_SIZE_PERCENT as i64,
   ) as u16
+}
+
+pub fn validate_tick_rate_milliseconds(value: u64, label: &str) -> Result<u64> {
+  if (1..=MAX_TICK_RATE_MILLISECONDS).contains(&value) {
+    Ok(value)
+  } else {
+    Err(anyhow!("{label} must be between 1 and 999 milliseconds"))
+  }
+}
+
+pub fn normalize_tick_rate_milliseconds(value: i64) -> u64 {
+  value.clamp(1, MAX_TICK_RATE_MILLISECONDS as i64) as u64
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -820,8 +835,8 @@ impl UserConfig {
         seek_milliseconds: 5 * 1000,
         volume_increment: 10,
         volume_percent: 100,
-        tick_rate_milliseconds: 250,
-        animation_tick_rate_milliseconds: 16,
+        tick_rate_milliseconds: DEFAULT_TICK_RATE_MILLISECONDS,
+        animation_tick_rate_milliseconds: DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
         enable_text_emphasis: true,
         show_loading_indicator: true,
         enforce_wide_search_bar: false,
@@ -1022,31 +1037,28 @@ impl UserConfig {
     let loaded_animation_tick_rate = behavior_config.animation_tick_rate_milliseconds;
 
     if let Some(tick_rate) = loaded_tick_rate {
-      if tick_rate >= 1000 {
-        return Err(anyhow!("Tick rate must be below 1000"));
+      let tick_rate = validate_tick_rate_milliseconds(tick_rate, "Tick rate")?;
+      // Before animation ticks existed, save_config wrote the old 16ms default
+      // into user configs. Treat the legacy 16ms normal tick as the old default
+      // when animation ticks are absent or still equal to the animation default,
+      // so upgraded users get the new normal UI cadence without manual edits.
+      self.behavior.tick_rate_milliseconds = if tick_rate
+        == DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS
+        && loaded_animation_tick_rate
+          .map(|animation_tick_rate| {
+            animation_tick_rate == DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS
+          })
+          .unwrap_or(true)
+      {
+        DEFAULT_TICK_RATE_MILLISECONDS
       } else {
-        // Before animation ticks existed, save_config wrote the old 16ms default
-        // into user configs. Treat the legacy 16ms normal tick as the old default
-        // when animation ticks are absent or still equal to the animation default,
-        // so upgraded users get the new normal UI cadence without manual edits.
-        self.behavior.tick_rate_milliseconds = if tick_rate == 16
-          && loaded_animation_tick_rate
-            .map(|animation_tick_rate| animation_tick_rate == 16)
-            .unwrap_or(true)
-        {
-          250
-        } else {
-          tick_rate
-        };
-      }
+        tick_rate
+      };
     }
 
     if let Some(tick_rate) = loaded_animation_tick_rate {
-      if tick_rate >= 1000 {
-        return Err(anyhow!("Animation tick rate must be below 1000"));
-      } else {
-        self.behavior.animation_tick_rate_milliseconds = tick_rate;
-      }
+      self.behavior.animation_tick_rate_milliseconds =
+        validate_tick_rate_milliseconds(tick_rate, "Animation tick rate")?;
     }
 
     if let Some(text_emphasis) = behavior_config.enable_text_emphasis {
@@ -1592,69 +1604,64 @@ mod tests {
   }
 
   #[test]
-  fn missing_tick_rates_keep_defaults() {
-    use super::{BehaviorConfigString, UserConfig};
+  fn tick_rates_load_defaults_explicit_values_and_legacy_defaults() {
+    use super::{
+      BehaviorConfigString, UserConfig, DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
+      DEFAULT_TICK_RATE_MILLISECONDS,
+    };
 
-    let behavior: BehaviorConfigString = serde_yaml::from_str("{}").unwrap();
-    let mut config = UserConfig::new();
-    config.load_behaviorconfig(behavior).unwrap();
+    for (yaml, expected_tick_rate, expected_animation_tick_rate) in [
+      (
+        "",
+        DEFAULT_TICK_RATE_MILLISECONDS,
+        DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
+      ),
+      (
+        "tick_rate_milliseconds: 500\nanimation_tick_rate_milliseconds: 20",
+        500,
+        20,
+      ),
+      (
+        "tick_rate_milliseconds: 100",
+        100,
+        DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
+      ),
+      (
+        "tick_rate_milliseconds: 16",
+        DEFAULT_TICK_RATE_MILLISECONDS,
+        DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
+      ),
+      (
+        "tick_rate_milliseconds: 16\nanimation_tick_rate_milliseconds: 16",
+        DEFAULT_TICK_RATE_MILLISECONDS,
+        DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS,
+      ),
+    ] {
+      let behavior: BehaviorConfigString = serde_yaml::from_str(yaml).unwrap();
+      let mut config = UserConfig::new();
+      config.load_behaviorconfig(behavior).unwrap();
 
-    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
-    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
+      assert_eq!(config.behavior.tick_rate_milliseconds, expected_tick_rate);
+      assert_eq!(
+        config.behavior.animation_tick_rate_milliseconds,
+        expected_animation_tick_rate
+      );
+    }
   }
 
   #[test]
-  fn explicit_tick_rates_load_from_yaml() {
+  fn zero_tick_rates_are_rejected() {
     use super::{BehaviorConfigString, UserConfig};
 
-    let behavior: BehaviorConfigString =
-      serde_yaml::from_str("tick_rate_milliseconds: 500\nanimation_tick_rate_milliseconds: 20")
-        .unwrap();
-    let mut config = UserConfig::new();
-    config.load_behaviorconfig(behavior).unwrap();
+    for yaml in [
+      "tick_rate_milliseconds: 0",
+      "animation_tick_rate_milliseconds: 0",
+    ] {
+      let behavior: BehaviorConfigString = serde_yaml::from_str(yaml).unwrap();
+      let mut config = UserConfig::new();
 
-    assert_eq!(config.behavior.tick_rate_milliseconds, 500);
-    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 20);
-  }
-
-  #[test]
-  fn explicit_normal_tick_rate_is_preserved_without_animation_tick_rate() {
-    use super::{BehaviorConfigString, UserConfig};
-
-    let behavior: BehaviorConfigString =
-      serde_yaml::from_str("tick_rate_milliseconds: 100").unwrap();
-    let mut config = UserConfig::new();
-    config.load_behaviorconfig(behavior).unwrap();
-
-    assert_eq!(config.behavior.tick_rate_milliseconds, 100);
-    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
-  }
-
-  #[test]
-  fn legacy_saved_default_tick_rate_migrates_to_normal_default() {
-    use super::{BehaviorConfigString, UserConfig};
-
-    let behavior: BehaviorConfigString =
-      serde_yaml::from_str("tick_rate_milliseconds: 16").unwrap();
-    let mut config = UserConfig::new();
-    config.load_behaviorconfig(behavior).unwrap();
-
-    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
-    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
-  }
-
-  #[test]
-  fn legacy_saved_dual_default_tick_rates_migrate_normal_tick() {
-    use super::{BehaviorConfigString, UserConfig};
-
-    let behavior: BehaviorConfigString =
-      serde_yaml::from_str("tick_rate_milliseconds: 16\nanimation_tick_rate_milliseconds: 16")
-        .unwrap();
-    let mut config = UserConfig::new();
-    config.load_behaviorconfig(behavior).unwrap();
-
-    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
-    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
+      assert!(config.load_behaviorconfig(behavior).is_err());
+    }
   }
 
   #[cfg(feature = "cover-art")]

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -658,6 +658,7 @@ pub struct BehaviorConfigString {
   pub volume_increment: Option<u8>,
   pub volume_percent: Option<u8>,
   pub tick_rate_milliseconds: Option<u64>,
+  pub animation_tick_rate_milliseconds: Option<u64>,
   pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
   pub enforce_wide_search_bar: Option<bool>,
@@ -701,6 +702,7 @@ pub struct BehaviorConfig {
   pub volume_increment: u8,
   pub volume_percent: u8,
   pub tick_rate_milliseconds: u64,
+  pub animation_tick_rate_milliseconds: u64,
   pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
   pub enforce_wide_search_bar: bool,
@@ -818,7 +820,8 @@ impl UserConfig {
         seek_milliseconds: 5 * 1000,
         volume_increment: 10,
         volume_percent: 100,
-        tick_rate_milliseconds: 16,
+        tick_rate_milliseconds: 250,
+        animation_tick_rate_milliseconds: 16,
         enable_text_emphasis: true,
         show_loading_indicator: true,
         enforce_wide_search_bar: false,
@@ -1015,11 +1018,34 @@ impl UserConfig {
       self.behavior.volume_percent = volume.min(100);
     }
 
-    if let Some(tick_rate) = behavior_config.tick_rate_milliseconds {
+    let loaded_tick_rate = behavior_config.tick_rate_milliseconds;
+    let loaded_animation_tick_rate = behavior_config.animation_tick_rate_milliseconds;
+
+    if let Some(tick_rate) = loaded_tick_rate {
       if tick_rate >= 1000 {
         return Err(anyhow!("Tick rate must be below 1000"));
       } else {
-        self.behavior.tick_rate_milliseconds = tick_rate;
+        // Before animation ticks existed, save_config wrote the old 16ms default
+        // into user configs. Treat the legacy 16ms normal tick as the old default
+        // when animation ticks are absent or still equal to the animation default,
+        // so upgraded users get the new normal UI cadence without manual edits.
+        self.behavior.tick_rate_milliseconds = if tick_rate == 16
+          && loaded_animation_tick_rate
+            .map(|animation_tick_rate| animation_tick_rate == 16)
+            .unwrap_or(true)
+        {
+          250
+        } else {
+          tick_rate
+        };
+      }
+    }
+
+    if let Some(tick_rate) = loaded_animation_tick_rate {
+      if tick_rate >= 1000 {
+        return Err(anyhow!("Animation tick rate must be below 1000"));
+      } else {
+        self.behavior.animation_tick_rate_milliseconds = tick_rate;
       }
     }
 
@@ -1218,6 +1244,7 @@ impl UserConfig {
       volume_increment: Some(self.behavior.volume_increment),
       volume_percent: Some(self.behavior.volume_percent),
       tick_rate_milliseconds: Some(self.behavior.tick_rate_milliseconds),
+      animation_tick_rate_milliseconds: Some(self.behavior.animation_tick_rate_milliseconds),
       enable_text_emphasis: Some(self.behavior.enable_text_emphasis),
       show_loading_indicator: Some(self.behavior.show_loading_indicator),
       enforce_wide_search_bar: Some(self.behavior.enforce_wide_search_bar),
@@ -1562,6 +1589,72 @@ mod tests {
     // Missing field defaults to None (not overriding the config default)
     let config: BehaviorConfigString = serde_yaml::from_str("{}").unwrap();
     assert_eq!(config.startup_behavior, None);
+  }
+
+  #[test]
+  fn missing_tick_rates_keep_defaults() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let behavior: BehaviorConfigString = serde_yaml::from_str("{}").unwrap();
+    let mut config = UserConfig::new();
+    config.load_behaviorconfig(behavior).unwrap();
+
+    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
+    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
+  }
+
+  #[test]
+  fn explicit_tick_rates_load_from_yaml() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let behavior: BehaviorConfigString =
+      serde_yaml::from_str("tick_rate_milliseconds: 500\nanimation_tick_rate_milliseconds: 20")
+        .unwrap();
+    let mut config = UserConfig::new();
+    config.load_behaviorconfig(behavior).unwrap();
+
+    assert_eq!(config.behavior.tick_rate_milliseconds, 500);
+    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 20);
+  }
+
+  #[test]
+  fn explicit_normal_tick_rate_is_preserved_without_animation_tick_rate() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let behavior: BehaviorConfigString =
+      serde_yaml::from_str("tick_rate_milliseconds: 100").unwrap();
+    let mut config = UserConfig::new();
+    config.load_behaviorconfig(behavior).unwrap();
+
+    assert_eq!(config.behavior.tick_rate_milliseconds, 100);
+    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
+  }
+
+  #[test]
+  fn legacy_saved_default_tick_rate_migrates_to_normal_default() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let behavior: BehaviorConfigString =
+      serde_yaml::from_str("tick_rate_milliseconds: 16").unwrap();
+    let mut config = UserConfig::new();
+    config.load_behaviorconfig(behavior).unwrap();
+
+    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
+    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
+  }
+
+  #[test]
+  fn legacy_saved_dual_default_tick_rates_migrate_normal_tick() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let behavior: BehaviorConfigString =
+      serde_yaml::from_str("tick_rate_milliseconds: 16\nanimation_tick_rate_milliseconds: 16")
+        .unwrap();
+    let mut config = UserConfig::new();
+    config.load_behaviorconfig(behavior).unwrap();
+
+    assert_eq!(config.behavior.tick_rate_milliseconds, 250);
+    assert_eq!(config.behavior.animation_tick_rate_milliseconds, 16);
   }
 
   #[cfg(feature = "cover-art")]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -29,7 +29,9 @@ use crate::cli;
 use crate::core::app::App;
 use crate::core::auth;
 use crate::core::config::ClientConfig;
-use crate::core::user_config::{StartupBehavior, UserConfig, UserConfigPaths};
+use crate::core::user_config::{
+  validate_tick_rate_milliseconds, StartupBehavior, UserConfig, UserConfigPaths,
+};
 #[cfg(feature = "discord-rpc")]
 use crate::infra::discord_rpc;
 #[cfg(all(feature = "macos-media", target_os = "macos"))]
@@ -419,11 +421,10 @@ pub async fn run() -> Result<()> {
       Arg::new("tick-rate")
         .short('t')
         .long("tick-rate")
-        .help("Set the tick rate (milliseconds): the lower the number the higher the FPS.")
+        .help("Set the normal UI tick rate in milliseconds.")
         .long_help(
-          "Specify the tick rate in milliseconds: the lower the number the \
-higher the FPS. It can be nicer to have a lower value when you want to use the audio analysis view \
-of the app. Beware that this comes at a CPU cost!",
+          "Specify the normal UI tick rate in milliseconds. Lower values refresh non-animated \
+screens more often and cost more CPU. Animation-heavy views keep their separate animation tick rate.",
         ),
     )
     .arg(
@@ -566,11 +567,8 @@ of the app. Beware that this comes at a CPU cost!",
     .get_one::<String>("tick-rate")
     .and_then(|tick_rate| tick_rate.parse().ok())
   {
-    if tick_rate >= 1000 {
-      panic!("Tick rate must be below 1000");
-    } else {
-      user_config.behavior.tick_rate_milliseconds = tick_rate;
-    }
+    user_config.behavior.tick_rate_milliseconds =
+      validate_tick_rate_milliseconds(tick_rate, "Tick rate")?;
   }
 
   let mut client_config = ClientConfig::new();

--- a/src/tui/event/events.rs
+++ b/src/tui/event/events.rs
@@ -1,4 +1,5 @@
 use super::key::Key;
+use crate::core::user_config::{normalize_tick_rate_milliseconds, DEFAULT_TICK_RATE_MILLISECONDS};
 use crossterm::event::{self, Event as CrosstermEvent, KeyEventKind, MouseEvent, MouseEventKind};
 use std::{
   sync::{
@@ -23,7 +24,7 @@ impl Default for EventConfig {
   fn default() -> EventConfig {
     EventConfig {
       exit_key: Key::Ctrl('c'),
-      tick_rate: Duration::from_millis(250),
+      tick_rate: Duration::from_millis(DEFAULT_TICK_RATE_MILLISECONDS),
     }
   }
 }
@@ -59,9 +60,9 @@ impl Events {
   /// Constructs an new instance of `Events` from given config.
   pub fn with_config(config: EventConfig) -> Events {
     let (tx, rx) = mpsc::channel();
-    let tick_rate_milliseconds = Arc::new(AtomicU64::new(
-      config.tick_rate.as_millis().try_into().unwrap_or(u64::MAX),
-    ));
+    let tick_rate_milliseconds = Arc::new(AtomicU64::new(normalize_tick_rate_milliseconds(
+      config.tick_rate.as_millis().try_into().unwrap_or(i64::MAX),
+    )));
 
     let event_tx = tx.clone();
     let event_tick_rate_milliseconds = tick_rate_milliseconds.clone();
@@ -112,9 +113,12 @@ impl Events {
   }
 
   pub fn set_tick_rate(&self, tick_rate: u64) {
-    self
-      .tick_rate_milliseconds
-      .store(tick_rate.max(1), Ordering::Relaxed);
+    let tick_rate = normalize_tick_rate_milliseconds(tick_rate as i64);
+    if self.tick_rate_milliseconds.load(Ordering::Relaxed) != tick_rate {
+      self
+        .tick_rate_milliseconds
+        .store(tick_rate, Ordering::Relaxed);
+    }
   }
 
   /// Attempts to read an event.

--- a/src/tui/event/events.rs
+++ b/src/tui/event/events.rs
@@ -1,6 +1,13 @@
 use super::key::Key;
 use crossterm::event::{self, Event as CrosstermEvent, KeyEventKind, MouseEvent, MouseEventKind};
-use std::{sync::mpsc, thread, time::Duration};
+use std::{
+  sync::{
+    atomic::{AtomicU64, Ordering},
+    mpsc, Arc,
+  },
+  thread,
+  time::{Duration, Instant},
+};
 
 #[derive(Debug, Clone, Copy)]
 /// Configuration for event handling.
@@ -27,14 +34,15 @@ pub enum Event {
   Input(Key),
   /// A mouse event occurred.
   Mouse(MouseEvent),
-  /// An tick event occurred.
-  Tick,
+  /// A tick event occurred.
+  Tick(Duration),
 }
 
 /// A small event handler that wrap crossterm input and tick event. Each event
 /// type is handled in its own thread and returned to a common `Receiver`
 pub struct Events {
   rx: mpsc::Receiver<Event>,
+  tick_rate_milliseconds: Arc<AtomicU64>,
   // Need to be kept around to prevent disposing the sender side.
   _tx: mpsc::Sender<Event>,
 }
@@ -51,12 +59,19 @@ impl Events {
   /// Constructs an new instance of `Events` from given config.
   pub fn with_config(config: EventConfig) -> Events {
     let (tx, rx) = mpsc::channel();
+    let tick_rate_milliseconds = Arc::new(AtomicU64::new(
+      config.tick_rate.as_millis().try_into().unwrap_or(u64::MAX),
+    ));
 
     let event_tx = tx.clone();
+    let event_tick_rate_milliseconds = tick_rate_milliseconds.clone();
     thread::spawn(move || {
+      let mut last_tick = Instant::now();
       loop {
+        let tick_rate = Duration::from_millis(event_tick_rate_milliseconds.load(Ordering::Relaxed));
+
         // poll for tick rate duration, if no event, sent tick event.
-        if event::poll(config.tick_rate).unwrap() {
+        if event::poll(tick_rate).unwrap() {
           match event::read().unwrap() {
             // Only process key press events, not release or repeat.
             // This fixes duplicate key events on Windows where both
@@ -81,13 +96,25 @@ impl Events {
         }
 
         // If send fails, the receiver has been dropped (app is closing)
-        if event_tx.send(Event::Tick).is_err() {
+        let elapsed = last_tick.elapsed();
+        last_tick = Instant::now();
+        if event_tx.send(Event::Tick(elapsed)).is_err() {
           break;
         }
       }
     });
 
-    Events { rx, _tx: tx }
+    Events {
+      rx,
+      tick_rate_milliseconds,
+      _tx: tx,
+    }
+  }
+
+  pub fn set_tick_rate(&self, tick_rate: u64) {
+    self
+      .tick_rate_milliseconds
+      .store(tick_rate.max(1), Ordering::Relaxed);
   }
 
   /// Attempts to read an event.

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -346,6 +346,13 @@ pub async fn start_ui(
       };
 
       let current_route = app.get_current_route();
+      let current_tick_rate = if current_route.active_block == ActiveBlock::Analysis {
+        app.user_config.behavior.animation_tick_rate_milliseconds
+      } else {
+        app.user_config.behavior.tick_rate_milliseconds
+      };
+      events.set_tick_rate(current_tick_rate);
+
       terminal.draw(|f| {
         use ratatui::{prelude::Style, widgets::Block};
         f.render_widget(
@@ -465,7 +472,7 @@ pub async fn start_ui(
           handlers::mouse_handler(mouse, &mut app);
         }
       }
-      event::Event::Tick => {
+      event::Event::Tick(elapsed) => {
         #[cfg(all(feature = "macos-media", target_os = "macos"))]
         {
           use objc2_foundation::{NSDate, NSRunLoop};
@@ -473,7 +480,7 @@ pub async fn start_ui(
         }
 
         let mut app = app.lock().await;
-        app.update_on_tick();
+        app.update_on_tick(elapsed);
 
         #[cfg(feature = "streaming")]
         app.flush_pending_native_seek();

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -346,7 +346,11 @@ pub async fn start_ui(
       };
 
       let current_route = app.get_current_route();
-      let current_tick_rate = if current_route.active_block == ActiveBlock::Analysis {
+      let animation_active = matches!(
+        current_route.active_block,
+        ActiveBlock::Analysis | ActiveBlock::Home
+      ) || app.liked_song_animation_frame.is_some();
+      let current_tick_rate = if animation_active {
         app.user_config.behavior.animation_tick_rate_milliseconds
       } else {
         app.user_config.behavior.tick_rate_milliseconds

--- a/src/tui/ui/audio_analysis.rs
+++ b/src/tui/ui/audio_analysis.rs
@@ -1,6 +1,6 @@
 use super::util;
 use crate::core::app::App;
-use crate::core::user_config::VisualizerStyle;
+use crate::core::user_config::{normalize_tick_rate_milliseconds, VisualizerStyle};
 use ratatui::{
   buffer::Buffer,
   layout::{Constraint, Layout, Rect},
@@ -22,11 +22,8 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
 
   let white = Style::default().fg(app.user_config.theme.text);
   let gray = Style::default().fg(app.user_config.theme.inactive);
-  let tick_rate = app
-    .user_config
-    .behavior
-    .animation_tick_rate_milliseconds
-    .max(1);
+  let tick_rate = app.user_config.behavior.animation_tick_rate_milliseconds;
+  let tick_rate = normalize_tick_rate_milliseconds(tick_rate as i64);
   let visualizer_style = app.user_config.behavior.visualizer_style;
 
   let info_block = Block::default()

--- a/src/tui/ui/audio_analysis.rs
+++ b/src/tui/ui/audio_analysis.rs
@@ -22,7 +22,11 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
 
   let white = Style::default().fg(app.user_config.theme.text);
   let gray = Style::default().fg(app.user_config.theme.inactive);
-  let tick_rate = app.user_config.behavior.tick_rate_milliseconds;
+  let tick_rate = app
+    .user_config
+    .behavior
+    .animation_tick_rate_milliseconds
+    .max(1);
   let visualizer_style = app.user_config.behavior.visualizer_style;
 
   let info_block = Block::default()


### PR DESCRIPTION
 # Summary

Adds adaptive tick-rate handling so regular screens can use a slower UI cadence while animation-heavy views keep the fast refresh rate. Centralizes tick-rate defaults/bounds, rejects zero tick rates from config, preserves existing animated behavior, and updates `--tick-rate` help text to match the split normal/animation behavior.

  # Testing

  - `cargo fmt --all`
  - `cargo test --no-default-features --features telemetry tick_rates`
    - passed: 2 tests
  - `cargo test --no-default-features --features telemetry zero_tick_rates_are_rejected`
    - passed: 1 test
  - `cargo test --no-default-features --features telemetry`
    - passed: 193 tests
  - `cargo clippy --no-default-features --features telemetry -- -D warnings`
    - passed
  - `cargo check`
    - passed
  - `git diff --check`
    - passed

  # Additional notes

  No screenshots. This keeps the existing fast animation cadence for audio analysis, the home banner, and the liked-song flash while allowing non-animated screens to tick more slowly.