### PR TITLE
fix #254: keep native recovery from reclaiming transferred playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Native streaming device handoff**: Kept native streaming recovery from stealing playback back after the user transfers listening from spotatui to another Spotify Connect device ([#254](https://github.com/LargeModGames/spotatui/issues/254)).
+
 ## [v0.38.3] - 2026-05-23
 
 ### Added

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -449,6 +449,7 @@ async fn handle_player_events(
           &shared_position,
           &shared_is_playing,
           "Native streaming disconnected; attempting recovery.",
+          false,
         )
         .await
         {
@@ -466,6 +467,7 @@ async fn handle_player_events(
     &shared_position,
     &shared_is_playing,
     "Native streaming stopped; attempting recovery.",
+    true,
   )
   .await
   {
@@ -501,6 +503,7 @@ async fn disconnect_streaming_player(
   shared_position: &Arc<AtomicU64>,
   shared_is_playing: &Arc<AtomicBool>,
   status_message: &str,
+  allow_reselect_device: bool,
 ) -> Option<StreamingRecoveryRequest> {
   let mut app_lock = app.lock().await;
   let current_player = app_lock.streaming_player.as_ref()?;
@@ -508,7 +511,10 @@ async fn disconnect_streaming_player(
     return None;
   }
 
-  let reselect_device = current_playback_matches_native(&app_lock, player);
+  // Spotify Connect sends SessionDisconnected when the user intentionally moves
+  // playback to another device. At that point the API context can still be the
+  // old native device, so only reselect native for non-Connect-disconnect paths.
+  let reselect_device = allow_reselect_device && current_playback_matches_native(&app_lock, player);
 
   app_lock.streaming_player = None;
   app_lock.is_streaming_active = false;


### PR DESCRIPTION


**Bug fix for native streaming handoff:**

* Updated the logic in `disconnect_streaming_player` (in `src/infra/player/events.rs`) to only allow device reselection if the disconnect was not due to a user-initiated Spotify Connect device transfer, preventing unwanted playback takeover. This is controlled by a new `allow_reselect_device` parameter.
* Modified calls to `disconnect_streaming_player` to pass the appropriate value for `allow_reselect_device` depending on the context: `false` for native streaming disconnects and `true` for other recovery paths. 




