### PR TITLE
Feat/listening history recap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
 ### Added
 
 - **Optional self-update feature**: Added a default-on `self-update` Cargo feature so package builds can omit update checks and installer code with `--no-default-features --features telemetry` ([#270](https://github.com/LargeModGames/spotatui/issues/270)).
+- **Listening history export & recap**: Added local listening history collection to `~/.config/spotatui/history/listens.jsonl` and a new CLI command `spotatui history recap --period 30d --output ./file.html` to generate a shareable HTML recap. Recaps exclude short/skipped plays and power future sync and analytics features.
+- **Generate Recap keybinding**: Added a configurable `R` keybinding to generate and open a 30-day listening recap HTML card directly from the app.
+- **Listening history sync token**: Added optional `behavior.sync_token` setting for syncing listening history with spotatui.com
+- **Native playback origin tracking**: Added `NativePlaybackOrigin` enum to distinguish between context-backed playback (safe for Spotify API handoff) and raw URI-list playback (stays on native route for stability).
+- **Track kind detection**: Extended native track info to capture whether a track is a regular `Track` or an `Episode`, enabling proper URI construction and future episode-specific UI handling.
 
 ### Fixed
 
 - **Native streaming device handoff**: Kept native streaming recovery from stealing playback back after the user transfers listening from spotatui to another Spotify Connect device ([#254](https://github.com/LargeModGames/spotatui/issues/254)).
+- **Context-backed native playback**: Native playback started from a Spotify context (e.g., album, playlist, queue) now prefers Spotify-visible playback starts when safe, while raw URI-list playback remains on the stable direct native path to avoid regression.
 
 ## [v0.38.3] - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ spotatui list --liked --limit 50 # See your liked songs (50 is the max limit)
 
 # Looks for 'An even cooler song' and gives you the '{name} from {album}' of up to 30 matches
 spotatui search "An even cooler song" --tracks --format "%t from %b" --limit 30
+
+# Generate a shareable HTML recap from spotatui's local listening history
+spotatui history recap --period 30d --output ./spotatui-recap.html
 ```
 
 ## Native Streaming
@@ -192,12 +195,15 @@ spotatui can play audio directly without needing spotifyd or the official Spotif
 
 - Works with media keys, MPRIS (Linux), and macOS Now Playing
 - Premium account required
+- Context-backed native playback prefers Spotify-visible playback starts when it is safe to do so, while raw URI-list playback stays on the stable direct native path
 
 See the [Native Streaming Wiki](https://github.com/LargeModGames/spotatui/wiki/Native-Streaming) for setup details.
 
 ## Configuration
 
 A configuration file is located at `${HOME}/.config/spotatui/config.yml`.
+
+spotatui also stores local listening history at `${HOME}/.config/spotatui/history/listens.jsonl`. This powers the `spotatui history recap` CLI and starts collecting from rollout onward; short or skipped plays are stored but excluded from recap totals.
 
 See the [Configuration Wiki](https://github.com/LargeModGames/spotatui/wiki/Configuration) for the full config file reference.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/spotatui.svg)](https://crates.io/crates/spotatui)
 [![Upstream](https://img.shields.io/badge/upstream-Rigellute%2Fspotify--tui-blue)](https://github.com/Rigellute/spotify-tui)
+[![X](https://img.shields.io/badge/@LargeModGames-000000?logo=x&logoColor=white)](https://twitter.com/LargeModGames)
 [![Songs played using Spotatui](https://img.shields.io/badge/dynamic/json?url=https://spotatui-counter.spotatui.workers.dev&query=count&label=Songs%20played%20using%20spotatui&labelColor=0b0f14&color=1ed760&logo=spotify&logoColor=1ed760&style=flat-square&cacheSeconds=600)](https://github.com/LargeModGames/spotatui)
 [![spotatui Contributors](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/LargeModGames/spotatui/main/.all-contributorsrc&query=%24.contributors.length&label=spotatui%20contributors&color=1ed760&style=flat-square)](#spotatui-contributors)
 [![Upstream Contributors](https://img.shields.io/badge/upstream_contributors-94-orange.svg?style=flat-square)](#upstream-contributors-spotify-tui)
@@ -314,7 +315,7 @@ sudo apt-get install -y -qq pkg-config libssl-dev libxcb1-dev libxcb-render0-dev
 
 ## Maintainer
 
-Maintained by **[LargeModGames](https://github.com/LargeModGames)**.
+Maintained by **[LargeModGames](https://github.com/LargeModGames)** ([@LargeModGames](https://twitter.com/LargeModGames) on Twitter).
 
 Originally forked from [spotify-tui](https://github.com/Rigellute/spotify-tui) by [Alexander Keliris](https://github.com/Rigellute).
 

--- a/src/cli/history.rs
+++ b/src/cli/history.rs
@@ -1,0 +1,51 @@
+use crate::infra::history::{export_history_recap, parse_recap_period};
+use anyhow::Result;
+use clap::{Arg, ArgMatches, Command};
+use std::path::PathBuf;
+
+pub fn history_subcommand() -> Command {
+  Command::new("history")
+    .about("Work with spotatui local listening history")
+    .subcommand_required(true)
+    .subcommand(
+      Command::new("recap")
+        .about("Generate a shareable HTML recap from local listening history")
+        .arg(
+          Arg::new("period")
+            .long("period")
+            .default_value("30d")
+            .value_parser(["7d", "30d", "month", "year", "all"])
+            .help("Time range to include in the recap"),
+        )
+        .arg(
+          Arg::new("output")
+            .long("output")
+            .short('o')
+            .default_value("spotatui-recap.html")
+            .value_name("PATH")
+            .help("Path to write the HTML recap file"),
+        ),
+    )
+}
+
+pub fn handle_history_matches(matches: &ArgMatches) -> Result<String> {
+  let recap_matches = matches
+    .subcommand_matches("recap")
+    .expect("clap guarantees a history subcommand");
+  let period = parse_recap_period(
+    recap_matches
+      .get_one::<String>("period")
+      .expect("period has default"),
+  )?;
+  let output_path = PathBuf::from(
+    recap_matches
+      .get_one::<String>("output")
+      .expect("output is required"),
+  );
+  let listen_count = export_history_recap(period, &output_path)?;
+  Ok(format!(
+    "Generated recap from {} qualified listens at {}",
+    listen_count,
+    output_path.display()
+  ))
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,13 @@
 mod clap;
 mod cli_app;
 mod handle;
+mod history;
 #[cfg(feature = "self-update")]
 mod update;
 mod util;
 
 pub use self::clap::{list_subcommand, play_subcommand, playback_subcommand, search_subcommand};
+pub use self::history::{handle_history_matches, history_subcommand};
 use cli_app::CliApp;
 pub use handle::handle_matches;
 #[cfg(feature = "self-update")]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -459,6 +459,21 @@ pub enum LyricsStatus {
   NotFound,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NativePlaybackOrigin {
+  Context,
+  #[default]
+  RawList,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NativeTrackKind {
+  #[default]
+  Track,
+  Episode,
+}
+
 /// Immediate track info from native player for instant UI updates
 /// Used to display track info immediately when skipping, before API responds
 #[derive(Clone, Debug, Default)]
@@ -468,6 +483,7 @@ pub struct NativeTrackInfo {
   #[allow(dead_code)]
   pub album: String, // Reserved for future use (e.g., displaying album in playbar)
   pub duration_ms: u32,
+  pub kind: NativeTrackKind,
 }
 
 /// A node in the playlist folder hierarchy from Spotify's rootlist
@@ -735,6 +751,9 @@ pub struct App {
   /// Native playback state - updated by player events, used when streaming is active
   /// This is more reliable than current_playback_context.is_playing during native streaming
   pub native_is_playing: Option<bool>,
+  /// Tracks whether the current native playback was started from a Spotify context
+  /// or from a raw URI-list/native-only route.
+  pub native_playback_origin: Option<NativePlaybackOrigin>,
   /// Prevent idle/sleep during playback
   pub keepawake: Option<keepawake::KeepAwake>,
   /// Timestamp of the last native device activation
@@ -963,6 +982,7 @@ impl Default for App {
       is_streaming_active: false,
       native_device_id: None,
       native_is_playing: None,
+      native_playback_origin: None,
       keepawake: None,
       last_device_activation: None,
       native_activation_pending: false,
@@ -3043,6 +3063,19 @@ impl App {
           ),
         },
         SettingItem {
+          id: "behavior.sync_token".to_string(),
+          name: "Sync Token".to_string(),
+          description: "API token from spotatui.com to sync listening history".to_string(),
+          value: SettingValue::String(
+            self
+              .user_config
+              .behavior
+              .sync_token
+              .clone()
+              .unwrap_or_default(),
+          ),
+        },
+        SettingItem {
           id: "behavior.liked_icon".to_string(),
           name: "Liked Icon".to_string(),
           description: "Icon for liked songs".to_string(),
@@ -3235,6 +3268,12 @@ impl App {
           description: "Toggle saved state for the currently playing track or episode"
             .to_string(),
           value: SettingValue::Key(key_to_string(&self.user_config.keys.like_track)),
+        },
+        SettingItem {
+          id: "keys.generate_recap".to_string(),
+          name: "Generate Listening Recap".to_string(),
+          description: "Generate and open the 30-day listening recap HTML card".to_string(),
+          value: SettingValue::Key(key_to_string(&self.user_config.keys.generate_recap)),
         },
         SettingItem {
           id: "keys.copy_song_url".to_string(),
@@ -3482,6 +3521,16 @@ impl App {
             };
           }
         }
+        "behavior.sync_token" => {
+          if let SettingValue::String(v) = &setting.value {
+            let trimmed = v.trim();
+            self.user_config.behavior.sync_token = if trimmed.is_empty() {
+              None
+            } else {
+              Some(trimmed.to_string())
+            };
+          }
+        }
         "behavior.liked_icon" => {
           if let SettingValue::String(v) = &setting.value {
             self.user_config.behavior.liked_icon = v.clone();
@@ -3687,6 +3736,13 @@ impl App {
           if let SettingValue::Key(v) = &setting.value {
             if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
               self.user_config.keys.like_track = key;
+            }
+          }
+        }
+        "keys.generate_recap" => {
+          if let SettingValue::Key(v) = &setting.value {
+            if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
+              self.user_config.keys.generate_recap = key;
             }
           }
         }

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -670,6 +670,7 @@ pub struct KeyBindingsString {
   save_settings: Option<String>,
   listening_party: Option<String>,
   like_track: Option<String>,
+  generate_recap: Option<String>,
 }
 
 #[derive(Clone)]
@@ -707,6 +708,7 @@ pub struct KeyBindings {
   pub save_settings: Key,
   pub listening_party: Key,
   pub like_track: Key,
+  pub generate_recap: Key,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -751,6 +753,7 @@ pub struct BehaviorConfigString {
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: Option<u16>,
   pub keepawake_enabled: Option<bool>,
+  pub sync_token: Option<String>,
 }
 
 #[derive(Clone)]
@@ -795,6 +798,7 @@ pub struct BehaviorConfig {
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: u16,
   pub keepawake_enabled: bool,
+  pub sync_token: Option<String>,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -873,6 +877,7 @@ impl UserConfig {
         save_settings: Key::Alt('s'),
         listening_party: Key::Ctrl('p'),
         like_track: Key::Char('F'),
+        generate_recap: Key::Char('R'),
       },
       behavior: BehaviorConfig {
         seek_milliseconds: 5 * 1000,
@@ -915,6 +920,7 @@ impl UserConfig {
         #[cfg(feature = "cover-art")]
         playbar_cover_art_size_percent: 100,
         keepawake_enabled: true,
+        sync_token: None,
       },
       path_to_config: None,
     }
@@ -989,6 +995,7 @@ impl UserConfig {
     to_keys!(save_settings);
     to_keys!(listening_party);
     to_keys!(like_track);
+    to_keys!(generate_recap);
 
     Ok(())
   }
@@ -1204,6 +1211,15 @@ impl UserConfig {
       }
     }
 
+    if let Some(sync_token) = behavior_config.sync_token {
+      let trimmed = sync_token.trim();
+      if trimmed.is_empty() {
+        self.behavior.sync_token = None;
+      } else {
+        self.behavior.sync_token = Some(trimmed.to_string());
+      }
+    }
+
     if let Some(stop_after_current_track) = behavior_config.stop_after_current_track {
       self.behavior.stop_after_current_track = stop_after_current_track;
     }
@@ -1323,6 +1339,7 @@ impl UserConfig {
       visualizer_style: Some(self.behavior.visualizer_style),
       dismissed_announcements: Some(self.behavior.dismissed_announcements.clone()),
       relay_server_url: Some(self.behavior.relay_server_url.clone()),
+      sync_token: self.behavior.sync_token.clone(),
       stop_after_current_track: Some(self.behavior.stop_after_current_track),
       sidebar_width_percent: Some(self.behavior.sidebar_width_percent),
       playbar_height_rows: Some(self.behavior.playbar_height_rows),
@@ -1412,6 +1429,7 @@ impl UserConfig {
       save_settings: Some(key_to_config_string(self.keys.save_settings)),
       listening_party: Some(key_to_config_string(self.keys.listening_party)),
       like_track: Some(key_to_config_string(self.keys.like_track)),
+      generate_recap: Some(key_to_config_string(self.keys.generate_recap)),
     };
 
     // Helper to build theme config from current values

--- a/src/infra/history.rs
+++ b/src/infra/history.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 
 const HISTORY_SUBDIR: &str = "history";
 const LISTENS_FILE_NAME: &str = "listens.jsonl";
-const CLOUD_SYNC_URL: &str = "https://spotatui-web.spotatui.workers.dev/api/sync";
+const CLOUD_SYNC_URL: &str = "https://spotatui.com/api/sync";
 const MAX_INTERVAL_MS: u64 = 5_000;
 const REPLAY_RESET_THRESHOLD_MS: u128 = 15_000;
 const REPLAY_PREVIOUS_PROGRESS_FLOOR_MS: u128 = 30_000;
@@ -1567,5 +1567,10 @@ mod tests {
     let filtered = filter_listens_for_period(&records, RecapPeriod::All);
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].title, "Track 21");
+  }
+
+  #[test]
+  fn cloud_sync_uses_public_spotatui_domain() {
+    assert_eq!(CLOUD_SYNC_URL, "https://spotatui.com/api/sync");
   }
 }

--- a/src/infra/history.rs
+++ b/src/infra/history.rs
@@ -1,0 +1,1571 @@
+use crate::core::app::App;
+use crate::infra::media_metadata::{
+  current_playback_snapshot, PlaybackItemKind, PlaybackSnapshot, PlaybackSource,
+};
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Datelike, Duration, Timelike, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Mutex;
+
+const HISTORY_SUBDIR: &str = "history";
+const LISTENS_FILE_NAME: &str = "listens.jsonl";
+const CLOUD_SYNC_URL: &str = "https://spotatui-web.spotatui.workers.dev/api/sync";
+const MAX_INTERVAL_MS: u64 = 5_000;
+const REPLAY_RESET_THRESHOLD_MS: u128 = 15_000;
+const REPLAY_PREVIOUS_PROGRESS_FLOOR_MS: u128 = 30_000;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryPlaybackSource {
+  NativeContext,
+  NativeRawList,
+  ExternalDevice,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryItemKind {
+  Track,
+  Episode,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ListenRecord {
+  pub started_at: DateTime<Utc>,
+  pub ended_at: DateTime<Utc>,
+  pub listened_ms: u64,
+  pub duration_ms: u32,
+  pub qualified: bool,
+  pub title: String,
+  pub artists: Vec<String>,
+  pub album: String,
+  pub item_kind: HistoryItemKind,
+  pub item_id: Option<String>,
+  pub item_uri: Option<String>,
+  pub context_uri: Option<String>,
+  pub source: HistoryPlaybackSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SessionIdentity {
+  title: String,
+  artists: Vec<String>,
+  album: String,
+  item_id: Option<String>,
+  item_uri: Option<String>,
+  context_uri: Option<String>,
+  source: HistoryPlaybackSource,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveListenSession {
+  started_at: DateTime<Utc>,
+  identity: SessionIdentity,
+  title: String,
+  artists: Vec<String>,
+  album: String,
+  item_kind: HistoryItemKind,
+  item_id: Option<String>,
+  item_uri: Option<String>,
+  context_uri: Option<String>,
+  source: HistoryPlaybackSource,
+  duration_ms: u32,
+  listened_ms: u64,
+  last_progress_ms: u128,
+  last_is_playing: bool,
+}
+
+#[derive(Default)]
+struct HistoryCollector {
+  current: Option<ActiveListenSession>,
+  last_observed_at: Option<Instant>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecapPeriod {
+  SevenDays,
+  ThirtyDays,
+  Month,
+  Year,
+  All,
+}
+
+pub fn spawn_history_collector(app: Arc<Mutex<App>>) {
+  tokio::spawn(async move {
+    let mut collector = HistoryCollector::default();
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    let mut last_auto_check = Instant::now();
+
+    // Check on startup
+    perform_auto_recap_check(&app);
+
+    // Sync history to cloud on startup
+    let sync_token_opt = if let Ok(app_guard) = app.try_lock() {
+      app_guard.user_config.behavior.sync_token.clone()
+    } else {
+      None
+    };
+
+    if let Some(token) = sync_token_opt {
+      tokio::spawn(async move {
+        if let Err(e) = sync_history_to_cloud(&token).await {
+          log::warn!("failed to run startup history cloud sync: {}", e);
+        }
+      });
+    }
+
+    loop {
+      interval.tick().await;
+
+      if last_auto_check.elapsed().as_secs() >= 3600 {
+        last_auto_check = Instant::now();
+        perform_auto_recap_check(&app);
+      }
+
+      let snapshot = if let Ok(app) = app.try_lock() {
+        current_playback_snapshot(&app)
+      } else {
+        continue;
+      };
+
+      if let Err(error) = collector.observe(snapshot) {
+        log::warn!("listening history collector failed: {}", error);
+      }
+    }
+  });
+}
+
+fn last_recap_file_path() -> Result<PathBuf> {
+  let home = dirs::home_dir().ok_or_else(|| anyhow!("No $HOME directory found for history"))?;
+  Ok(
+    home
+      .join(".config")
+      .join("spotatui")
+      .join(HISTORY_SUBDIR)
+      .join("last_recap_at.txt"),
+  )
+}
+
+fn perform_auto_recap_check(app: &Arc<Mutex<App>>) {
+  let path = match last_recap_file_path() {
+    Ok(p) => p,
+    Err(e) => {
+      log::warn!("failed to get last recap file path: {}", e);
+      return;
+    }
+  };
+
+  let now = Utc::now();
+  let should_generate = match fs::read_to_string(&path) {
+    Ok(content) => {
+      if let Ok(ts) = content.trim().parse::<i64>() {
+        let diff_secs = now.timestamp() - ts;
+        diff_secs >= 30 * 24 * 3600
+      } else {
+        true
+      }
+    }
+    Err(_) => true,
+  };
+
+  if should_generate {
+    let home = match dirs::home_dir() {
+      Some(h) => h,
+      None => return,
+    };
+    let output_path = home
+      .join(".config")
+      .join("spotatui")
+      .join("spotatui-recap.html");
+
+    match export_history_recap(RecapPeriod::ThirtyDays, &output_path) {
+      Ok(count) => {
+        if count > 0 {
+          if let Err(e) = fs::write(&path, now.timestamp().to_string()) {
+            log::warn!("failed to write last recap timestamp: {}", e);
+          }
+
+          if let Ok(mut app_guard) = app.try_lock() {
+            app_guard.set_status_message(
+              format!(
+                "30-day listening recap generated at ~/.config/spotatui/spotatui-recap.html ({} listens)",
+                count
+              ),
+              10,
+            );
+          }
+        }
+      }
+      Err(e) => {
+        log::warn!("failed to automatically generate recap: {}", e);
+      }
+    }
+  }
+}
+
+pub fn export_history_recap(period: RecapPeriod, output_path: &Path) -> Result<usize> {
+  let listens = load_listens()?;
+  let filtered = filter_listens_for_period(&listens, period);
+  let html = render_history_recap_html(period, &filtered);
+
+  if let Some(parent) = output_path.parent() {
+    fs::create_dir_all(parent)?;
+  }
+  fs::write(output_path, html)?;
+
+  Ok(filtered.len())
+}
+
+pub fn parse_recap_period(value: &str) -> Result<RecapPeriod> {
+  match value {
+    "7d" => Ok(RecapPeriod::SevenDays),
+    "30d" => Ok(RecapPeriod::ThirtyDays),
+    "month" => Ok(RecapPeriod::Month),
+    "year" => Ok(RecapPeriod::Year),
+    "all" => Ok(RecapPeriod::All),
+    _ => Err(anyhow!("unsupported recap period '{}'", value)),
+  }
+}
+
+pub fn load_listens() -> Result<Vec<ListenRecord>> {
+  let path = listens_file_path()?;
+  if !path.exists() {
+    return Ok(Vec::new());
+  }
+
+  let file = fs::File::open(path)?;
+  let reader = BufReader::new(file);
+  let mut listens = Vec::new();
+  for line in reader.lines() {
+    let line = line?;
+    if line.trim().is_empty() {
+      continue;
+    }
+
+    match serde_json::from_str::<ListenRecord>(&line) {
+      Ok(record) => listens.push(record),
+      Err(error) => {
+        log::warn!("skipping malformed history line: {}", error);
+      }
+    }
+  }
+
+  Ok(listens)
+}
+
+impl HistoryCollector {
+  fn observe(&mut self, snapshot: Option<PlaybackSnapshot>) -> Result<()> {
+    let now_utc = Utc::now();
+    let now_instant = Instant::now();
+
+    if let Some(current) = &mut self.current {
+      if let Some(last_observed_at) = self.last_observed_at {
+        let elapsed_ms = now_instant
+          .saturating_duration_since(last_observed_at)
+          .as_millis()
+          .min(MAX_INTERVAL_MS as u128) as u64;
+        if current.last_is_playing {
+          current.listened_ms = current.listened_ms.saturating_add(elapsed_ms);
+        }
+      }
+    }
+    self.last_observed_at = Some(now_instant);
+
+    let snapshot = snapshot.filter(|snapshot| snapshot.item_kind == PlaybackItemKind::Track);
+    match snapshot {
+      Some(snapshot) => {
+        let identity = SessionIdentity::from_snapshot(&snapshot);
+        let should_roll = self.current.as_ref().is_some_and(|current| {
+          current.identity != identity
+            || (current.last_progress_ms > REPLAY_PREVIOUS_PROGRESS_FLOOR_MS
+              && snapshot.progress_ms + REPLAY_RESET_THRESHOLD_MS < current.last_progress_ms)
+        });
+
+        if should_roll {
+          self.finalize_current(now_utc)?;
+        }
+
+        if self.current.is_none() {
+          self.current = Some(ActiveListenSession::from_snapshot(snapshot, now_utc));
+          return Ok(());
+        }
+
+        if let Some(current) = &mut self.current {
+          current.duration_ms = snapshot.metadata.duration_ms;
+          current.last_progress_ms = snapshot.progress_ms;
+          current.last_is_playing = snapshot.is_playing;
+        }
+      }
+      None => {
+        self.finalize_current(now_utc)?;
+      }
+    }
+
+    Ok(())
+  }
+
+  fn finalize_current(&mut self, ended_at: DateTime<Utc>) -> Result<()> {
+    let Some(current) = self.current.take() else {
+      return Ok(());
+    };
+
+    if current.listened_ms == 0 {
+      return Ok(());
+    }
+
+    append_listen_record(ListenRecord::from_active_session(current, ended_at))
+  }
+}
+
+impl SessionIdentity {
+  fn from_snapshot(snapshot: &PlaybackSnapshot) -> Self {
+    Self {
+      title: snapshot.metadata.title.clone(),
+      artists: snapshot.metadata.artists.clone(),
+      album: snapshot.metadata.album.clone(),
+      item_id: snapshot.item_id.clone(),
+      item_uri: snapshot.item_uri.clone(),
+      context_uri: snapshot.context_uri.clone(),
+      source: history_source_from_snapshot(snapshot),
+    }
+  }
+}
+
+impl ActiveListenSession {
+  fn from_snapshot(snapshot: PlaybackSnapshot, started_at: DateTime<Utc>) -> Self {
+    let source = history_source_from_snapshot(&snapshot);
+    let identity = SessionIdentity::from_snapshot(&snapshot);
+    let PlaybackSnapshot {
+      metadata,
+      item_id,
+      item_uri,
+      context_uri,
+      source: _,
+      progress_ms,
+      is_playing,
+      ..
+    } = snapshot;
+    let title = metadata.title;
+    let artists = metadata.artists;
+    let album = metadata.album;
+    let duration_ms = metadata.duration_ms;
+    Self {
+      started_at,
+      identity,
+      title,
+      artists,
+      album,
+      item_kind: HistoryItemKind::Track,
+      item_id,
+      item_uri,
+      context_uri,
+      source,
+      duration_ms,
+      listened_ms: 0,
+      last_progress_ms: progress_ms,
+      last_is_playing: is_playing,
+    }
+  }
+}
+
+impl ListenRecord {
+  fn from_active_session(session: ActiveListenSession, ended_at: DateTime<Utc>) -> Self {
+    let qualified = qualifies_listen(session.duration_ms, session.listened_ms);
+    Self {
+      started_at: session.started_at,
+      ended_at,
+      listened_ms: session.listened_ms,
+      duration_ms: session.duration_ms,
+      qualified,
+      title: session.title,
+      artists: session.artists,
+      album: session.album,
+      item_kind: session.item_kind,
+      item_id: session.item_id,
+      item_uri: session.item_uri,
+      context_uri: session.context_uri,
+      source: session.source,
+    }
+  }
+}
+
+fn listens_file_path() -> Result<PathBuf> {
+  let home = dirs::home_dir().ok_or_else(|| anyhow!("No $HOME directory found for history"))?;
+  Ok(
+    home
+      .join(".config")
+      .join("spotatui")
+      .join(HISTORY_SUBDIR)
+      .join(LISTENS_FILE_NAME),
+  )
+}
+
+fn append_listen_record(record: ListenRecord) -> Result<()> {
+  let path = listens_file_path()?;
+  if let Some(parent) = path.parent() {
+    fs::create_dir_all(parent)?;
+  }
+
+  let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+  serde_json::to_writer(&mut file, &record)?;
+  writeln!(file)?;
+  Ok(())
+}
+
+fn qualifies_listen(duration_ms: u32, listened_ms: u64) -> bool {
+  if duration_ms <= 30_000 {
+    return false;
+  }
+
+  let threshold_ms = u64::from(duration_ms / 2).min(240_000);
+  listened_ms >= threshold_ms
+}
+
+fn history_source_from_snapshot(snapshot: &PlaybackSnapshot) -> HistoryPlaybackSource {
+  match snapshot.source {
+    PlaybackSource::NativeContext => HistoryPlaybackSource::NativeContext,
+    PlaybackSource::NativeRawList => HistoryPlaybackSource::NativeRawList,
+    PlaybackSource::ExternalDevice => HistoryPlaybackSource::ExternalDevice,
+  }
+}
+
+fn filter_listens_for_period(listens: &[ListenRecord], period: RecapPeriod) -> Vec<ListenRecord> {
+  let now = Utc::now();
+  listens
+    .iter()
+    .filter(|record| record.qualified)
+    .filter(|record| match period {
+      RecapPeriod::SevenDays => record.ended_at >= now - Duration::days(7),
+      RecapPeriod::ThirtyDays => record.ended_at >= now - Duration::days(30),
+      RecapPeriod::Month => {
+        record.ended_at.year() == now.year() && record.ended_at.month() == now.month()
+      }
+      RecapPeriod::Year => record.ended_at.year() == now.year(),
+      RecapPeriod::All => true,
+    })
+    .cloned()
+    .collect()
+}
+
+fn render_history_recap_html(period: RecapPeriod, listens: &[ListenRecord]) -> String {
+  let total_listening_ms = listens.iter().map(|record| record.listened_ms).sum::<u64>();
+  let top_tracks = aggregate_top_tracks(listens);
+  let top_artists = aggregate_top_artists(listens);
+  let top_albums = aggregate_top_albums(listens);
+  let listening_days = aggregate_days(listens);
+  let listening_hours = aggregate_hours(listens);
+
+  let top_album_title = escape_html(
+    top_albums
+      .first()
+      .map(|entry| entry.display.as_str())
+      .unwrap_or("No data"),
+  );
+
+  let top_track_raw = top_tracks
+    .first()
+    .map(|entry| entry.display.as_str())
+    .unwrap_or("No data");
+  let top_track_title_clean = if top_track_raw == "No data" {
+    "No data".to_string()
+  } else {
+    top_track_raw
+      .split(" - ")
+      .next()
+      .unwrap_or(top_track_raw)
+      .to_string()
+  };
+  let top_track_title_clean = escape_html(&top_track_title_clean);
+
+  let top_track_artist = if top_track_raw == "No data" {
+    "No data".to_string()
+  } else {
+    top_track_raw
+      .split(" - ")
+      .nth(1)
+      .unwrap_or("")
+      .to_string()
+  };
+  let top_track_artist = escape_html(&top_track_artist);
+
+  format!(
+    r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>spotatui recap</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {{
+      --bg: #05080c;
+      --accent: #1db954;
+      --accent-glow: rgba(29, 185, 84, 0.15);
+      --card-gradient: linear-gradient(135deg, #0b1a11 0%, #050a0f 100%);
+      --text: #f1f5f9;
+      --text-muted: #94a3b8;
+      --border: rgba(255, 255, 255, 0.05);
+      --font-sans: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: "JetBrains Mono", monospace;
+    }}
+    * {{
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }}
+    body {{
+      min-height: 100vh;
+      background: radial-gradient(circle at 50% 0%, #0e2417 0%, #05080c 70%);
+      color: var(--text);
+      font-family: var(--font-sans);
+      padding: 40px 20px 60px;
+    }}
+    .app-container {{
+      max-width: 1200px;
+      margin: 0 auto;
+      width: 100%;
+    }}
+    .app-header {{
+      text-align: center;
+      margin-bottom: 40px;
+    }}
+    .app-header h1 {{
+      font-size: 2.2rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      font-family: var(--font-sans);
+      margin-bottom: 6px;
+    }}
+    .brand-logo {{
+      color: var(--text);
+    }}
+    .brand-accent {{
+      color: var(--accent);
+      text-shadow: 0 0 10px rgba(29, 185, 84, 0.4);
+    }}
+    .app-header p {{
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-weight: 600;
+    }}
+    .app-desc {{
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      max-width: 580px;
+      margin: 12px auto 0;
+      line-height: 1.5;
+      text-transform: none !important;
+      letter-spacing: normal !important;
+      font-weight: 400 !important;
+    }}
+    .dashboard-grid {{
+      display: grid;
+      grid-template-columns: 440px 1fr;
+      gap: 40px;
+      align-items: start;
+    }}
+    @media (max-width: 1024px) {{
+      .dashboard-grid {{
+        grid-template-columns: 1fr;
+        gap: 32px;
+      }}
+      .share-column {{
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }}
+    }}
+    .share-column {{
+      position: sticky;
+      top: 40px;
+    }}
+    .card-wrapper {{
+      width: 440px;
+      height: 660px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-radius: 28px;
+    }}
+    @media (max-width: 480px) {{
+      .card-wrapper {{
+        transform: scale(0.8);
+        height: 528px;
+        margin-bottom: -40px;
+      }}
+    }}
+    @media (max-width: 380px) {{
+      .card-wrapper {{
+        transform: scale(0.68);
+        height: 448px;
+        margin-bottom: -80px;
+      }}
+    }}
+    .share-card {{
+      width: 440px;
+      height: 660px;
+      background: var(--card-gradient);
+      border: 1px solid rgba(29, 185, 84, 0.22);
+      border-radius: 28px;
+      padding: 32px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      position: relative;
+      overflow: hidden;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.8), 0 0 40px rgba(29, 185, 84, 0.12);
+      box-sizing: border-box;
+    }}
+    .card-glow {{
+      position: absolute;
+      top: -150px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 300px;
+      height: 300px;
+      background: radial-gradient(circle, rgba(29, 185, 84, 0.18) 0%, transparent 70%);
+      pointer-events: none;
+      z-index: 0;
+    }}
+    .card-header {{
+      position: relative;
+      height: 32px;
+      z-index: 1;
+      width: 100%;
+      margin-bottom: 10px;
+    }}
+    .card-brand {{
+      position: absolute;
+      left: 0;
+      top: 0;
+      font-family: var(--font-sans);
+      font-weight: 800;
+      font-size: 1.25rem;
+      letter-spacing: -0.02em;
+    }}
+    .period-badge {{
+      position: absolute;
+      right: 0;
+      top: 0;
+      font-size: 0.72rem;
+      font-weight: 700;
+      color: var(--accent);
+      background: rgba(29, 185, 84, 0.12);
+      border: 1px solid rgba(29, 185, 84, 0.3);
+      padding: 5px 12px;
+      border-radius: 99px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }}
+    .cover-container {{
+      position: relative;
+      width: 174px;
+      height: 174px;
+      margin: 0 auto;
+      border-radius: 20px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 15px 35px rgba(0, 0, 0, 0.5), 0 0 30px rgba(29, 185, 84, 0.15);
+      z-index: 1;
+    }}
+    .cover-placeholder {{
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: linear-gradient(135deg, #1b2820 0%, #05080c 100%);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1;
+    }}
+    .cover-img {{
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      z-index: 2;
+      display: none;
+    }}
+    .top-track-card {{
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      border-radius: 18px;
+      padding: 16px 20px;
+      text-align: center;
+      backdrop-filter: blur(10px);
+      z-index: 1;
+      width: 100%;
+    }}
+    .rank-badge {{
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      color: var(--accent);
+      background: rgba(29, 185, 84, 0.1);
+      padding: 3px 8px;
+      border-radius: 6px;
+      letter-spacing: 0.08em;
+      font-weight: 700;
+      display: inline-block;
+      margin-bottom: 8px;
+      border: 1px solid rgba(29, 185, 84, 0.18);
+    }}
+    .track-title {{
+      font-size: 1.15rem;
+      font-weight: 800;
+      color: #ffffff;
+      margin-bottom: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }}
+    .track-artist {{
+      font-size: 0.88rem;
+      color: var(--text-muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }}
+    .card-stats-grid {{
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      z-index: 1;
+      width: 100%;
+    }}
+    .stats-row {{
+      display: flex;
+      gap: 12px;
+      width: 100%;
+    }}
+    .stat-pill {{
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(255, 255, 255, 0.03);
+      border-radius: 14px;
+      padding: 10px 14px;
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+      box-sizing: border-box;
+    }}
+    .stat-pill.full-width {{
+      flex: none;
+      width: 100%;
+    }}
+    .stat-label {{
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 3px;
+      font-weight: 500;
+    }}
+    .stat-value {{
+      font-size: 0.92rem;
+      font-weight: 700;
+      color: #ffffff;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }}
+    .card-footer {{
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
+      padding-top: 14px;
+      position: relative;
+      height: 30px;
+      z-index: 1;
+      width: 100%;
+    }}
+    .card-footer-left {{
+      position: absolute;
+      left: 0;
+      top: 14px;
+      font-size: 0.72rem;
+      color: var(--text-muted);
+    }}
+    .card-footer-right {{
+      position: absolute;
+      right: 0;
+      top: 14px;
+      font-size: 0.72rem;
+      font-family: var(--font-mono);
+      color: var(--accent);
+    }}
+    .download-container {{
+      margin-top: 20px;
+      width: 100%;
+      max-width: 440px;
+      display: flex;
+      justify-content: center;
+    }}
+    .download-btn {{
+      background: linear-gradient(90deg, var(--accent) 0%, #10b981 100%);
+      border: none;
+      border-radius: 14px;
+      color: #ffffff;
+      font-size: 0.95rem;
+      font-weight: 700;
+      padding: 14px 28px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      box-shadow: 0 10px 20px rgba(29, 185, 84, 0.25);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      width: 100%;
+      justify-content: center;
+      font-family: var(--font-sans);
+    }}
+    .download-btn:hover {{
+      transform: translateY(-2px);
+      box-shadow: 0 15px 30px rgba(29, 185, 84, 0.35);
+    }}
+    .download-btn:active {{
+      transform: translateY(0);
+    }}
+    .animate-spin {{
+      animation: spin 1s linear infinite;
+    }}
+    .details-column {{
+      min-width: 0;
+    }}
+    .details-section-title {{
+      font-size: 1.25rem;
+      font-weight: 800;
+      margin-bottom: 20px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #38bdf8;
+      border-left: 3px solid var(--accent);
+      padding-left: 12px;
+      line-height: 1;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 20px;
+      margin-bottom: 24px;
+    }}
+    .panel {{
+      background: rgba(10, 18, 30, 0.5);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 24px;
+      backdrop-filter: blur(20px);
+    }}
+    .panel h2 {{
+      margin: 0 0 16px 0;
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #f8fafc;
+    }}
+    .ranked-list {{
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }}
+    .ranked-list li {{
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 10px 14px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.01);
+      border: 1px solid rgba(255, 255, 255, 0.02);
+      margin-bottom: 8px;
+      transition: all 0.2s ease;
+    }}
+    .ranked-list li:hover {{
+      background: rgba(29, 185, 84, 0.04);
+      border-color: rgba(29, 185, 84, 0.15);
+      transform: translateX(4px);
+    }}
+    .rank {{
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      font-weight: 800;
+      color: var(--accent);
+      width: 20px;
+    }}
+    .recent-icon {{
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+    }}
+    .entry-details {{
+      flex: 1;
+      min-width: 0;
+    }}
+    .entry-details strong {{
+      display: block;
+      font-size: 0.92rem;
+      font-weight: 600;
+      color: #f1f5f9;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }}
+    .entry-artist {{
+      font-size: 0.82rem;
+      color: var(--accent);
+      margin-top: 2px;
+      font-weight: 500;
+    }}
+    .subtle {{
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      margin-top: 2px;
+    }}
+    .bars {{
+      display: grid;
+      gap: 12px;
+    }}
+    .bar-row {{
+      display: grid;
+      gap: 6px;
+    }}
+    .bar-label {{
+      display: flex;
+      justify-content: space-between;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--text-muted);
+    }}
+    .bar {{
+      height: 8px;
+      border-radius: 99px;
+      background: rgba(255, 255, 255, 0.03);
+      overflow: hidden;
+      position: relative;
+    }}
+    .bar > span {{
+      display: block;
+      height: 100%;
+      border-radius: 99px;
+      background: linear-gradient(90deg, var(--accent) 0%, #10b981 100%);
+      box-shadow: 0 0 10px rgba(29, 185, 84, 0.3);
+    }}
+    footer {{
+      margin-top: 48px;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #64748b;
+      line-height: 1.6;
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
+      border-top: 1px solid var(--border);
+      padding-top: 24px;
+    }}
+  </style>
+</head>
+<body>
+  <div class="app-container">
+    <header class="app-header">
+      <h1><span class="brand-logo">spota</span><span class="brand-accent">tui</span></h1>
+      <p>Listening History Recap</p>
+      <p class="app-desc">{summary}</p>
+    </header>
+
+    <div class="dashboard-grid">
+      <!-- Left Column: The Share Card Area -->
+      <div class="share-column">
+        <div class="card-wrapper">
+          <div id="share-card" class="share-card">
+            <!-- Ambient glowing node inside the card -->
+            <div class="card-glow"></div>
+            
+            <div class="card-header">
+              <span class="card-brand">spota<span style="color:var(--accent)">tui</span></span>
+              <span class="period-badge">{title}</span>
+            </div>
+            
+            <div class="cover-container">
+              <div id="cover-art-placeholder" class="cover-placeholder">
+                <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
+              </div>
+              <img id="cover-art-img" class="cover-img" alt="Cover Art" crossorigin="anonymous">
+            </div>
+            
+            <div class="top-track-card">
+              <span class="rank-badge">NO. 1 TRACK</span>
+              <div class="track-title">{top_track_title}</div>
+              <div class="track-artist">{top_track_artist}</div>
+            </div>
+            
+            <div class="card-stats-grid">
+              <div class="stats-row">
+                <div class="stat-pill">
+                  <span class="stat-label">Qualified Plays</span>
+                  <span class="stat-value">{total_plays}</span>
+                </div>
+                <div class="stat-pill">
+                  <span class="stat-label">Listening Time</span>
+                  <span class="stat-value">{total_time}</span>
+                </div>
+              </div>
+              <div class="stat-pill full-width">
+                <span class="stat-label">Top Artist</span>
+                <span class="stat-value">{top_artist_name}</span>
+              </div>
+              <div class="stat-pill full-width">
+                <span class="stat-label">Top Album</span>
+                <span class="stat-value">{top_album_title}</span>
+              </div>
+            </div>
+            
+            <div class="card-footer">
+              <span class="card-footer-left">generated by <strong>spotatui</strong></span>
+              <span class="card-footer-right">github.com/LargeModGames/spotatui</span>
+            </div>
+          </div>
+        </div>
+        
+        <div class="download-container">
+          <button class="download-btn" onclick="downloadCard()">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+            Download Share Card
+          </button>
+        </div>
+      </div>
+      
+      <!-- Right Column: Detailed Insights Dashboard -->
+      <div class="details-column">
+        <div class="details-section-title">Detailed Analytics</div>
+        
+        <div class="grid">
+          <article class="panel">
+            <h2>Top Tracks</h2>
+            {top_tracks_html}
+          </article>
+          <article class="panel">
+            <h2>Top Artists</h2>
+            {top_artists_html}
+          </article>
+          <article class="panel">
+            <h2>Top Albums</h2>
+            {top_albums_html}
+          </article>
+          <article class="panel">
+            <h2>Recent Plays</h2>
+            {recent_html}
+          </article>
+        </div>
+        
+        <div class="grid">
+          <article class="panel">
+            <h2>Listening by Day</h2>
+            {days_html}
+          </article>
+          <article class="panel">
+            <h2>Listening by Hour</h2>
+            {hours_html}
+          </article>
+        </div>
+      </div>
+    </div>
+
+    <footer>
+      History is generated from spotatui local listening records and starts when the feature is enabled. Short or skipped plays are stored but excluded from headline recap totals.
+    </footer>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {{
+      const trackTitle = "{top_track_title}";
+      const trackArtist = "{top_artist_name}";
+      
+      if (trackTitle && trackTitle !== "No data") {{
+        // Clean parentheses or bracket noise for high search precision
+        const cleanTitle = trackTitle.replace(/\([^)]*\)/g, '').replace(/\[[^\]]*\]/g, '').trim();
+        const query = encodeURIComponent(`${{cleanTitle}} ${{trackArtist}}`);
+        const url = `https://itunes.apple.com/search?term=${{query}}&limit=1&entity=song`;
+        
+        fetch(url)
+          .then(res => res.json())
+          .then(data => {{
+            if (data.results && data.results.length > 0) {{
+              const artworkUrl = data.results[0].artworkUrl100.replace('100x100bb', '600x600bb');
+              const img = document.getElementById('cover-art-img');
+              img.src = artworkUrl;
+              img.onload = () => {{
+                img.style.display = 'block';
+                document.getElementById('cover-art-placeholder').style.display = 'none';
+              }};
+            }}
+          }})
+          .catch(err => console.error('Error fetching cover art:', err));
+      }}
+    }});
+
+    function downloadCard() {{
+      const card = document.getElementById('share-card');
+      const btn = document.querySelector('.download-btn');
+      const wrapper = document.querySelector('.card-wrapper');
+      const originalText = btn.innerHTML;
+      
+      btn.disabled = true;
+      btn.innerHTML = `
+        <svg class="animate-spin" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 1 1 21.2 8H18" /></svg>
+        Generating...
+      `;
+      btn.style.opacity = '0.7';
+
+      const originalTransform = wrapper.style.transform;
+      const originalMargin = wrapper.style.marginBottom;
+      const originalHeight = wrapper.style.height;
+      const originalBoxShadow = card.style.boxShadow;
+
+      wrapper.style.transform = 'none';
+      wrapper.style.marginBottom = '0';
+      wrapper.style.height = 'auto';
+      card.style.boxShadow = 'none';
+
+      document.fonts.ready.then(() => {{
+        setTimeout(() => {{
+          html2canvas(card, {{
+            scale: 3,
+            useCORS: true,
+            backgroundColor: '#05080c',
+            logging: false,
+            width: 440,
+            height: 660,
+            windowWidth: 440,
+            windowHeight: 660
+          }}).then(canvas => {{
+            wrapper.style.transform = originalTransform;
+            wrapper.style.marginBottom = originalMargin;
+            wrapper.style.height = originalHeight;
+            card.style.boxShadow = originalBoxShadow;
+
+            const link = document.createElement('a');
+            const dateStr = new Date().toISOString().slice(0, 10);
+            link.download = `spotatui-recap-${{dateStr}}.png`;
+            link.href = canvas.toDataURL('image/png');
+            link.click();
+            
+            btn.disabled = false;
+            btn.innerHTML = originalText;
+            btn.style.opacity = '1';
+          }}).catch(err => {{
+            console.error(err);
+            wrapper.style.transform = originalTransform;
+            wrapper.style.marginBottom = originalMargin;
+            wrapper.style.height = originalHeight;
+            card.style.boxShadow = originalBoxShadow;
+
+            alert('Could not render image. Please try again!');
+            btn.disabled = false;
+            btn.innerHTML = originalText;
+            btn.style.opacity = '1';
+          }});
+        }}, 300);
+      }});
+    }}
+  </script>
+</body>
+</html>
+"#,
+    title = escape_html(period_label(period)),
+    summary = escape_html(if listens.is_empty() {
+      "No qualified local listening history was recorded for this window yet."
+    } else {
+      "A shareable HTML snapshot of your qualified local listening history, generated directly from spotatui."
+    }),
+    total_plays = listens.len(),
+    total_time = format_duration(total_listening_ms),
+    top_track_title = top_track_title_clean,
+    top_track_artist = top_track_artist,
+    top_artist_name = escape_html(
+      top_artists
+        .first()
+        .map(|entry| entry.display.as_str())
+        .unwrap_or("No data"),
+    ),
+    top_album_title = top_album_title,
+    top_tracks_html = render_ranked_entries(&top_tracks, "No tracks yet."),
+    top_artists_html = render_ranked_entries(&top_artists, "No artists yet."),
+    top_albums_html = render_ranked_entries(&top_albums, "No albums yet."),
+    recent_html = render_recent_entries(listens),
+    days_html = render_bar_entries(&listening_days),
+    hours_html = render_bar_entries(&listening_hours),
+  )
+}
+
+#[derive(Clone)]
+struct RankedEntry {
+  display: String,
+  detail: String,
+  value: u64,
+}
+
+fn aggregate_top_tracks(listens: &[ListenRecord]) -> Vec<RankedEntry> {
+  let mut totals: BTreeMap<String, (String, u64, u64)> = BTreeMap::new();
+  for record in listens {
+    let key = record
+      .item_id
+      .clone()
+      .or_else(|| record.item_uri.clone())
+      .unwrap_or_else(|| format!("{}::{}", record.title, record.artists.join(", ")));
+    let entry = totals.entry(key).or_insert_with(|| {
+      (
+        format!("{} - {}", record.title, record.artists.join(", ")),
+        0,
+        0,
+      )
+    });
+    entry.1 += record.listened_ms;
+    entry.2 += 1;
+  }
+
+  sort_ranked_entries(
+    totals
+      .into_values()
+      .map(|(display, listened_ms, plays)| RankedEntry {
+        display,
+        detail: format!("{} plays · {}", plays, format_duration(listened_ms)),
+        value: listened_ms,
+      })
+      .collect(),
+  )
+}
+
+fn split_artists(combo: &str) -> Vec<String> {
+  let normalized = combo
+    .replace(" and ", ", ")
+    .replace(" & ", ", ");
+  normalized
+    .split(',')
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect()
+}
+
+fn aggregate_top_artists(listens: &[ListenRecord]) -> Vec<RankedEntry> {
+  let mut totals: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+  for record in listens {
+    for artist_combo in &record.artists {
+      let individual_artists = split_artists(artist_combo);
+      for artist in individual_artists {
+        let entry = totals.entry(artist).or_insert((0, 0));
+        entry.0 += record.listened_ms;
+        entry.1 += 1;
+      }
+    }
+  }
+
+  sort_ranked_entries(
+    totals
+      .into_iter()
+      .map(|(artist, (listened_ms, plays))| RankedEntry {
+        display: artist,
+        detail: format!("{} track hits · {}", plays, format_duration(listened_ms)),
+        value: listened_ms,
+      })
+      .collect(),
+  )
+}
+
+fn aggregate_top_albums(listens: &[ListenRecord]) -> Vec<RankedEntry> {
+  let mut totals: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+  for record in listens {
+    if record.album.trim().is_empty() {
+      continue;
+    }
+    let entry = totals.entry(record.album.clone()).or_insert((0, 0));
+    entry.0 += record.listened_ms;
+    entry.1 += 1;
+  }
+
+  sort_ranked_entries(
+    totals
+      .into_iter()
+      .map(|(album, (listened_ms, plays))| RankedEntry {
+        display: album,
+        detail: format!("{} plays · {}", plays, format_duration(listened_ms)),
+        value: listened_ms,
+      })
+      .collect(),
+  )
+}
+
+
+fn aggregate_days(listens: &[ListenRecord]) -> Vec<RankedEntry> {
+  let mut totals: BTreeMap<String, u64> = BTreeMap::new();
+  for record in listens {
+    let label = record.ended_at.format("%Y-%m-%d").to_string();
+    *totals.entry(label).or_default() += record.listened_ms;
+  }
+
+  totals
+    .into_iter()
+    .rev()
+    .take(10)
+    .map(|(label, listened_ms)| RankedEntry {
+      display: label,
+      detail: format_duration(listened_ms),
+      value: listened_ms,
+    })
+    .collect::<Vec<_>>()
+    .into_iter()
+    .rev()
+    .collect()
+}
+
+fn aggregate_hours(listens: &[ListenRecord]) -> Vec<RankedEntry> {
+  let mut totals: BTreeMap<u32, u64> = BTreeMap::new();
+  for record in listens {
+    let local_hour = record.ended_at.with_timezone(&chrono::Local).hour();
+    *totals.entry(local_hour).or_default() += record.listened_ms;
+  }
+
+  (0..24)
+    .map(|hour| RankedEntry {
+      display: format!("{hour:02}:00"),
+      detail: format_duration(*totals.get(&hour).unwrap_or(&0)),
+      value: *totals.get(&hour).unwrap_or(&0),
+    })
+    .collect()
+}
+
+fn sort_ranked_entries(mut entries: Vec<RankedEntry>) -> Vec<RankedEntry> {
+  entries.sort_by(|left, right| {
+    right
+      .value
+      .cmp(&left.value)
+      .then_with(|| left.display.cmp(&right.display))
+  });
+  entries.truncate(5);
+  entries
+}
+
+fn render_ranked_entries(entries: &[RankedEntry], empty_label: &str) -> String {
+  if entries.is_empty() {
+    return format!(r#"<p class="subtle">{}</p>"#, escape_html(empty_label));
+  }
+
+  let items = entries
+    .iter()
+    .enumerate()
+    .map(|(i, entry)| {
+      let parts: Vec<&str> = entry.display.split(" - ").collect();
+      let (title, subtitle) = if parts.len() == 2 {
+        (parts[0], format!("<div class=\"entry-artist\">{}</div>", escape_html(parts[1])))
+      } else {
+        (entry.display.as_str(), "".to_string())
+      };
+
+      let detail_html = format!(r#"<div class="subtle">{}</div>"#, escape_html(&entry.detail));
+      format!(
+        "<li><span class=\"rank\">#{}</span><div class=\"entry-details\"><strong>{}</strong>{}{}</div></li>",
+        i + 1,
+        escape_html(title),
+        subtitle,
+        detail_html
+      )
+    })
+    .collect::<Vec<_>>()
+    .join("");
+  format!("<ul class=\"ranked-list\">{items}</ul>")
+}
+
+fn render_recent_entries(listens: &[ListenRecord]) -> String {
+  let recent_records = listens
+    .iter()
+    .rev()
+    .take(5)
+    .collect::<Vec<_>>();
+
+  if recent_records.is_empty() {
+    return r#"<p class="subtle">No recent plays.</p>"#.to_string();
+  }
+
+  let items = recent_records
+    .iter()
+    .map(|record| {
+      let local_time = record.ended_at.with_timezone(&chrono::Local);
+      let time_str = local_time.format("%b %d, %H:%M").to_string();
+      format!(
+        "<li><span class=\"recent-icon\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"></circle><polyline points=\"12 6 12 12 16 14\"></polyline></svg></span><div class=\"entry-details\"><strong>{}</strong><div class=\"entry-artist\">{}</div><div class=\"subtle\">listened at {}</div></div></li>",
+        escape_html(&record.title),
+        escape_html(&record.artists.join(", ")),
+        escape_html(&time_str)
+      )
+    })
+    .collect::<Vec<_>>()
+    .join("");
+  format!("<ul class=\"ranked-list\">{items}</ul>")
+}
+
+fn render_bar_entries(entries: &[RankedEntry]) -> String {
+  if entries.is_empty() {
+    return r#"<p class="subtle">No data yet.</p>"#.to_string();
+  }
+
+  let max_value = entries
+    .iter()
+    .map(|entry| entry.value)
+    .max()
+    .unwrap_or(1)
+    .max(1);
+  let rows = entries
+    .iter()
+    .map(|entry| {
+      let width = (entry.value as f64 / max_value as f64) * 100.0;
+      format!(
+        r#"<div class="bar-row">
+  <div class="bar-label"><span>{}</span><span>{}</span></div>
+  <div class="bar"><span style="width:{:.2}%"></span></div>
+</div>"#,
+        escape_html(&entry.display),
+        escape_html(&entry.detail),
+        width
+      )
+    })
+    .collect::<Vec<_>>()
+    .join("");
+  format!(r#"<div class="bars">{rows}</div>"#)
+}
+
+fn period_label(period: RecapPeriod) -> &'static str {
+  match period {
+    RecapPeriod::SevenDays => "Last 7 Days",
+    RecapPeriod::ThirtyDays => "Last 30 Days",
+    RecapPeriod::Month => "This Month",
+    RecapPeriod::Year => "This Year",
+    RecapPeriod::All => "All Time",
+  }
+}
+
+fn format_duration(total_ms: u64) -> String {
+  let total_minutes = total_ms / 1000 / 60;
+  let hours = total_minutes / 60;
+  let minutes = total_minutes % 60;
+  if hours == 0 {
+    format!("{minutes}m")
+  } else {
+    format!("{hours}h {minutes}m")
+  }
+}
+
+fn escape_html(input: &str) -> String {
+  input
+    .replace('&', "&amp;")
+    .replace('<', "&lt;")
+    .replace('>', "&gt;")
+    .replace('"', "&quot;")
+    .replace('\'', "&#39;")
+}
+
+fn last_synced_file_path() -> Result<PathBuf> {
+  let home = dirs::home_dir().ok_or_else(|| anyhow!("No $HOME directory found for history"))?;
+  Ok(
+    home
+      .join(".config")
+      .join("spotatui")
+      .join(HISTORY_SUBDIR)
+      .join("last_synced_at.txt"),
+  )
+}
+
+pub async fn sync_history_to_cloud(sync_token: &str) -> Result<()> {
+  let path = last_synced_file_path()?;
+
+  use chrono::TimeZone;
+  let last_synced_at = match fs::read_to_string(&path) {
+    Ok(content) => {
+      DateTime::parse_from_rfc3339(content.trim())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc.timestamp_opt(0, 0).unwrap())
+    }
+    Err(_) => Utc.timestamp_opt(0, 0).unwrap(),
+  };
+
+  let listens = load_listens()?;
+  let new_listens: Vec<&ListenRecord> = listens
+    .iter()
+    .filter(|record| record.ended_at > last_synced_at)
+    .collect();
+
+  if new_listens.is_empty() {
+    log::info!("no new listening history records to sync");
+    return Ok(());
+  }
+
+  let client = reqwest::Client::new();
+
+  let response = client
+    .post(CLOUD_SYNC_URL)
+    .header("Authorization", format!("Bearer {}", sync_token))
+    .json(&new_listens)
+    .send()
+    .await?;
+
+  if response.status().is_success() {
+    if let Some(last_record) = new_listens.last() {
+      fs::write(&path, last_record.ended_at.to_rfc3339())?;
+    }
+    log::info!("successfully synchronized listening history to cloud ({} tracks)", new_listens.len());
+  } else {
+    let status = response.status();
+    let err_body = response.text().await.unwrap_or_default();
+    log::warn!("failed to synchronize history: {} (status {})", err_body, status);
+    return Err(anyhow!("Sync failed: {}", err_body));
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::TimeZone;
+
+  fn record_at(day: u32, listened_ms: u64, qualified: bool) -> ListenRecord {
+    let timestamp = Utc.with_ymd_and_hms(2026, 5, day, 12, 0, 0).unwrap();
+    ListenRecord {
+      started_at: timestamp,
+      ended_at: timestamp,
+      listened_ms,
+      duration_ms: 180_000,
+      qualified,
+      title: format!("Track {day}"),
+      artists: vec!["Artist".to_string()],
+      album: "Album".to_string(),
+      item_kind: HistoryItemKind::Track,
+      item_id: Some(format!("id-{day}")),
+      item_uri: Some(format!("spotify:track:id-{day}")),
+      context_uri: None,
+      source: HistoryPlaybackSource::NativeContext,
+    }
+  }
+
+  #[test]
+  fn qualification_requires_minimum_duration_and_progress() {
+    assert!(!qualifies_listen(30_000, 15_000));
+    assert!(!qualifies_listen(180_000, 80_000));
+    assert!(qualifies_listen(180_000, 90_000));
+    assert!(qualifies_listen(800_000, 240_000));
+  }
+
+  #[test]
+  fn all_time_filter_keeps_only_qualified_records() {
+    let records = vec![record_at(20, 100_000, false), record_at(21, 120_000, true)];
+    let filtered = filter_listens_for_period(&records, RecapPeriod::All);
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].title, "Track 21");
+  }
+}

--- a/src/infra/history.rs
+++ b/src/infra/history.rs
@@ -486,11 +486,7 @@ fn render_history_recap_html(period: RecapPeriod, listens: &[ListenRecord]) -> S
   let top_track_artist = if top_track_raw == "No data" {
     "No data".to_string()
   } else {
-    top_track_raw
-      .split(" - ")
-      .nth(1)
-      .unwrap_or("")
-      .to_string()
+    top_track_raw.split(" - ").nth(1).unwrap_or("").to_string()
   };
   let top_track_artist = escape_html(&top_track_artist);
 
@@ -1244,9 +1240,7 @@ fn aggregate_top_tracks(listens: &[ListenRecord]) -> Vec<RankedEntry> {
 }
 
 fn split_artists(combo: &str) -> Vec<String> {
-  let normalized = combo
-    .replace(" and ", ", ")
-    .replace(" & ", ", ");
+  let normalized = combo.replace(" and ", ", ").replace(" & ", ", ");
   normalized
     .split(',')
     .map(|s| s.trim().to_string())
@@ -1301,7 +1295,6 @@ fn aggregate_top_albums(listens: &[ListenRecord]) -> Vec<RankedEntry> {
       .collect(),
   )
 }
-
 
 fn aggregate_days(listens: &[ListenRecord]) -> Vec<RankedEntry> {
   let mut totals: BTreeMap<String, u64> = BTreeMap::new();
@@ -1383,11 +1376,7 @@ fn render_ranked_entries(entries: &[RankedEntry], empty_label: &str) -> String {
 }
 
 fn render_recent_entries(listens: &[ListenRecord]) -> String {
-  let recent_records = listens
-    .iter()
-    .rev()
-    .take(5)
-    .collect::<Vec<_>>();
+  let recent_records = listens.iter().rev().take(5).collect::<Vec<_>>();
 
   if recent_records.is_empty() {
     return r#"<p class="subtle">No recent plays.</p>"#.to_string();
@@ -1486,11 +1475,9 @@ pub async fn sync_history_to_cloud(sync_token: &str) -> Result<()> {
 
   use chrono::TimeZone;
   let last_synced_at = match fs::read_to_string(&path) {
-    Ok(content) => {
-      DateTime::parse_from_rfc3339(content.trim())
-        .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or_else(|_| Utc.timestamp_opt(0, 0).unwrap())
-    }
+    Ok(content) => DateTime::parse_from_rfc3339(content.trim())
+      .map(|dt| dt.with_timezone(&Utc))
+      .unwrap_or_else(|_| Utc.timestamp_opt(0, 0).unwrap()),
     Err(_) => Utc.timestamp_opt(0, 0).unwrap(),
   };
 
@@ -1518,11 +1505,18 @@ pub async fn sync_history_to_cloud(sync_token: &str) -> Result<()> {
     if let Some(last_record) = new_listens.last() {
       fs::write(&path, last_record.ended_at.to_rfc3339())?;
     }
-    log::info!("successfully synchronized listening history to cloud ({} tracks)", new_listens.len());
+    log::info!(
+      "successfully synchronized listening history to cloud ({} tracks)",
+      new_listens.len()
+    );
   } else {
     let status = response.status();
     let err_body = response.text().await.unwrap_or_default();
-    log::warn!("failed to synchronize history: {} (status {})", err_body, status);
+    log::warn!(
+      "failed to synchronize history: {} (status {})",
+      err_body,
+      status
+    );
     return Err(anyhow!("Sync failed: {}", err_body));
   }
 

--- a/src/infra/media_metadata.rs
+++ b/src/infra/media_metadata.rs
@@ -7,9 +7,23 @@
   allow(dead_code)
 )]
 
-use crate::core::app::App;
+use crate::core::app::{App, NativePlaybackOrigin, NativeTrackKind};
 use crate::tui::ui::util::create_artist_string;
 use rspotify::model::{PlayableItem, RepeatState};
+use rspotify::prelude::Id;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlaybackItemKind {
+  Track,
+  Episode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlaybackSource {
+  NativeContext,
+  NativeRawList,
+  ExternalDevice,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaybackMetadata {
@@ -23,6 +37,11 @@ pub struct PlaybackMetadata {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlaybackSnapshot {
   pub metadata: PlaybackMetadata,
+  pub item_kind: PlaybackItemKind,
+  pub item_id: Option<String>,
+  pub item_uri: Option<String>,
+  pub context_uri: Option<String>,
+  pub source: PlaybackSource,
   pub progress_ms: u128,
   pub is_playing: bool,
   pub shuffle: bool,
@@ -39,17 +58,30 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
   let context = app.current_playback_context.as_ref();
   let use_native_metadata = app.is_streaming_active && app.native_track_info.is_some();
 
-  let metadata = if use_native_metadata {
+  let (metadata, item_kind, item_id, item_uri) = if use_native_metadata {
     let native_info = app.native_track_info.as_ref()?;
-    PlaybackMetadata {
-      title: native_info.name.clone(),
-      artists: vec![native_info.artists_display.clone()],
-      album: native_info.album.clone(),
-      image_url: image_url_from_context_item(context.and_then(|ctx| ctx.item.as_ref())),
-      duration_ms: native_info.duration_ms,
-    }
+    let item_kind = match native_info.kind {
+      NativeTrackKind::Track => PlaybackItemKind::Track,
+      NativeTrackKind::Episode => PlaybackItemKind::Episode,
+    };
+    let item_id = app.last_track_id.clone();
+    let item_uri = item_id
+      .as_deref()
+      .map(|id| playback_uri_for_item_kind(item_kind, id));
+    (
+      PlaybackMetadata {
+        title: native_info.name.clone(),
+        artists: vec![native_info.artists_display.clone()],
+        album: native_info.album.clone(),
+        image_url: image_url_from_context_item(context.and_then(|ctx| ctx.item.as_ref())),
+        duration_ms: native_info.duration_ms,
+      },
+      item_kind,
+      item_id,
+      item_uri,
+    )
   } else {
-    metadata_from_context_item(context.and_then(|ctx| ctx.item.as_ref()))?
+    metadata_and_identity_from_context_item(context.and_then(|ctx| ctx.item.as_ref()))?
   };
 
   let is_playing = if use_native_metadata {
@@ -63,9 +95,31 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
     .map(|context| context.shuffle_state)
     .unwrap_or(app.user_config.behavior.shuffle_enabled);
   let repeat = context.map(|context| context.repeat_state);
+  let context_uri = context
+    .and_then(|ctx| ctx.context.as_ref())
+    .map(|context| context.uri.clone());
+  let source = if app.is_streaming_active {
+    match app.native_playback_origin.unwrap_or_else(|| {
+      if context_uri.is_some() {
+        NativePlaybackOrigin::Context
+      } else {
+        NativePlaybackOrigin::RawList
+      }
+    }) {
+      NativePlaybackOrigin::Context => PlaybackSource::NativeContext,
+      NativePlaybackOrigin::RawList => PlaybackSource::NativeRawList,
+    }
+  } else {
+    PlaybackSource::ExternalDevice
+  };
 
   Some(PlaybackSnapshot {
     metadata,
+    item_kind,
+    item_id,
+    item_uri,
+    context_uri,
+    source,
     progress_ms: app.song_progress_ms,
     is_playing,
     shuffle,
@@ -73,23 +127,57 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
   })
 }
 
-fn metadata_from_context_item(item: Option<&PlayableItem>) -> Option<PlaybackMetadata> {
+fn metadata_and_identity_from_context_item(
+  item: Option<&PlayableItem>,
+) -> Option<(
+  PlaybackMetadata,
+  PlaybackItemKind,
+  Option<String>,
+  Option<String>,
+)> {
   match item? {
-    PlayableItem::Track(track) => Some(PlaybackMetadata {
-      title: track.name.clone(),
-      artists: vec![create_artist_string(&track.artists)],
-      album: track.album.name.clone(),
-      image_url: track.album.images.first().map(|image| image.url.clone()),
-      duration_ms: track.duration.num_milliseconds() as u32,
-    }),
-    PlayableItem::Episode(episode) => Some(PlaybackMetadata {
-      title: episode.name.clone(),
-      artists: vec![episode.show.name.clone()],
-      album: String::new(),
-      image_url: episode.images.first().map(|image| image.url.clone()),
-      duration_ms: episode.duration.num_milliseconds() as u32,
-    }),
+    PlayableItem::Track(track) => {
+      let item_id = track.id.as_ref().map(|id| id.id().to_string());
+      Some((
+        PlaybackMetadata {
+          title: track.name.clone(),
+          artists: vec![create_artist_string(&track.artists)],
+          album: track.album.name.clone(),
+          image_url: track.album.images.first().map(|image| image.url.clone()),
+          duration_ms: track.duration.num_milliseconds() as u32,
+        },
+        PlaybackItemKind::Track,
+        item_id.clone(),
+        item_id
+          .as_deref()
+          .map(|id| playback_uri_for_item_kind(PlaybackItemKind::Track, id)),
+      ))
+    }
+    PlayableItem::Episode(episode) => {
+      let item_id = Some(episode.id.id().to_string());
+      Some((
+        PlaybackMetadata {
+          title: episode.name.clone(),
+          artists: vec![episode.show.name.clone()],
+          album: String::new(),
+          image_url: episode.images.first().map(|image| image.url.clone()),
+          duration_ms: episode.duration.num_milliseconds() as u32,
+        },
+        PlaybackItemKind::Episode,
+        item_id.clone(),
+        item_id
+          .as_deref()
+          .map(|id| playback_uri_for_item_kind(PlaybackItemKind::Episode, id)),
+      ))
+    }
     PlayableItem::Unknown(_) => None,
+  }
+}
+
+fn playback_uri_for_item_kind(item_kind: PlaybackItemKind, id: &str) -> String {
+  match item_kind {
+    PlaybackItemKind::Track => format!("spotify:track:{id}"),
+    PlaybackItemKind::Episode => format!("spotify:episode:{id}"),
   }
 }
 
@@ -104,7 +192,7 @@ fn image_url_from_context_item(item: Option<&PlayableItem>) -> Option<String> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::core::app::NativeTrackInfo;
+  use crate::core::app::{NativePlaybackOrigin, NativeTrackInfo, NativeTrackKind};
   use chrono::{Duration, Utc};
   use rspotify::model::{
     context::{Actions, CurrentPlaybackContext},
@@ -242,7 +330,9 @@ mod tests {
       artists_display: "Native Artist".to_string(),
       album: "Native Album".to_string(),
       duration_ms: 123_000,
+      kind: NativeTrackKind::Track,
     });
+    app.native_playback_origin = Some(NativePlaybackOrigin::RawList);
 
     let snapshot = current_playback_snapshot(&app).unwrap();
 
@@ -250,6 +340,8 @@ mod tests {
     assert_eq!(snapshot.metadata.artists, vec!["Native Artist"]);
     assert_eq!(snapshot.metadata.album, "Native Album");
     assert_eq!(snapshot.metadata.duration_ms, 123_000);
+    assert_eq!(snapshot.item_kind, PlaybackItemKind::Track);
+    assert_eq!(snapshot.source, PlaybackSource::NativeRawList);
     assert_eq!(snapshot.progress_ms, 12_000);
     assert!(snapshot.is_playing);
   }
@@ -275,6 +367,7 @@ mod tests {
       artists_display: "Native Artist".to_string(),
       album: "Native Album".to_string(),
       duration_ms: 123_000,
+      kind: NativeTrackKind::Track,
     });
     app.current_playback_context = Some(playback_context(PlayableItem::Track(track()), true));
 

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 #[cfg(feature = "discord-rpc")]
 pub mod discord_rpc;
+pub mod history;
 #[cfg(all(feature = "macos-media", target_os = "macos"))]
 pub mod macos_media;
 pub mod media_metadata;

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1,9 +1,13 @@
 use super::requests::spotify_get_typed_compat_for;
 use super::{IoEvent, Network};
+#[cfg(feature = "streaming")]
+use crate::core::app::NativePlaybackOrigin;
 use crate::tui::ui::util::create_artist_string;
 use anyhow::anyhow;
 use chrono::Duration as ChronoDuration;
 use chrono::TimeDelta;
+#[cfg(feature = "streaming")]
+use log::info;
 use rspotify::model::{
   enums::RepeatState,
   idtypes::{PlayContextId, PlayableId},
@@ -98,6 +102,13 @@ fn playable_item_name(item: &PlayableItem) -> Option<&str> {
   }
 }
 
+#[cfg(feature = "streaming")]
+#[derive(Debug, PartialEq, Eq)]
+enum NativePlaybackRoute {
+  ContextApi { device_id: String },
+  NativeLoad,
+}
+
 fn api_confirms_native_info_is_current(
   native_name: &str,
   item: &PlayableItem,
@@ -187,6 +198,53 @@ async fn is_native_streaming_active_for_playback(network: &Network) -> bool {
 
   // No match - not the active device
   false
+}
+
+#[cfg(feature = "streaming")]
+async fn requested_native_playback_origin(
+  network: &Network,
+  context_id: &Option<PlayContextId<'static>>,
+  uris: &Option<Vec<PlayableId<'static>>>,
+) -> NativePlaybackOrigin {
+  if context_id.is_some() {
+    return NativePlaybackOrigin::Context;
+  }
+
+  if uris.is_some() {
+    return NativePlaybackOrigin::RawList;
+  }
+
+  let app = network.app.lock().await;
+  if let Some(origin) = app.native_playback_origin {
+    return origin;
+  }
+
+  if app
+    .current_playback_context
+    .as_ref()
+    .and_then(|ctx| ctx.context.as_ref())
+    .is_some()
+  {
+    NativePlaybackOrigin::Context
+  } else {
+    NativePlaybackOrigin::RawList
+  }
+}
+
+#[cfg(feature = "streaming")]
+async fn resolve_native_playback_route(
+  network: &Network,
+  context_id: &Option<PlayContextId<'static>>,
+) -> NativePlaybackRoute {
+  if context_id.is_none() {
+    return NativePlaybackRoute::NativeLoad;
+  }
+
+  let app = network.app.lock().await;
+  match app.native_device_id.clone() {
+    Some(device_id) => NativePlaybackRoute::ContextApi { device_id },
+    None => NativePlaybackRoute::NativeLoad,
+  }
 }
 
 impl PlaybackNetwork for Network {
@@ -527,6 +585,8 @@ impl PlaybackNetwork for Network {
     #[cfg(feature = "streaming")]
     if is_native_streaming_active_for_playback(self).await {
       if let Some(player) = current_streaming_player(self).await {
+        let requested_origin = requested_native_playback_origin(self, &context_id, &uris).await;
+        let native_route = resolve_native_playback_route(self, &context_id).await;
         let activation_time = Instant::now();
         let should_transfer = {
           let app = self.app.lock().await;
@@ -551,10 +611,12 @@ impl PlaybackNetwork for Network {
           app.is_streaming_active = true;
           app.last_device_activation = Some(activation_time);
           app.native_activation_pending = false;
+          app.native_playback_origin = Some(requested_origin);
         }
 
         // For resume playback (no context, no uris)
         if context_id.is_none() && uris.is_none() {
+          info!("starting native resume playback via direct player route");
           player.play();
           // Update UI state immediately
           let mut app = self.app.lock().await;
@@ -562,6 +624,49 @@ impl PlaybackNetwork for Network {
             ctx.is_playing = true;
           }
           return;
+        }
+
+        if let (NativePlaybackRoute::ContextApi { device_id }, Some(context)) =
+          (&native_route, context_id.clone())
+        {
+          info!(
+            "starting native playback via Spotify context route on device {}",
+            device_id
+          );
+          let offset_struct = api_playback_offset(uris.as_deref(), offset);
+          match self
+            .spotify
+            .start_context_playback(context, Some(device_id.as_str()), offset_struct, None)
+            .await
+          {
+            Ok(_) => {
+              if let Err(e) = self
+                .spotify
+                .shuffle(desired_shuffle_state, Some(device_id.as_str()))
+                .await
+              {
+                let mut app = self.app.lock().await;
+                app.handle_error(anyhow!(e));
+              }
+
+              let mut app = self.app.lock().await;
+              app.instant_since_last_current_playback_poll =
+                Instant::now() - Duration::from_secs(6);
+              if let Some(ctx) = &mut app.current_playback_context {
+                ctx.is_playing = true;
+                ctx.shuffle_state = desired_shuffle_state;
+              }
+              app.user_config.behavior.shuffle_enabled = desired_shuffle_state;
+              app.dispatch(IoEvent::GetCurrentPlayback);
+              return;
+            }
+            Err(e) => {
+              info!(
+                "native context playback via Spotify API failed; falling back to direct native load: {}",
+                e
+              );
+            }
+          }
         }
 
         // For URI-based or context playback, use Spirc load directly.
@@ -604,6 +709,7 @@ impl PlaybackNetwork for Network {
           }
         };
 
+        info!("starting native playback via direct load route");
         if let Err(e) = player.load(request) {
           let mut app = self.app.lock().await;
           app.handle_error(anyhow!("Failed to start native playback: {}", e));
@@ -900,6 +1006,7 @@ impl PlaybackNetwork for Network {
           let mut app = self.app.lock().await;
           app.is_streaming_active = true;
           app.native_activation_pending = true;
+          app.native_playback_origin = None;
           app.last_device_activation = Some(Instant::now());
           app.instant_since_last_current_playback_poll = Instant::now() - Duration::from_secs(6);
           return;
@@ -924,6 +1031,7 @@ impl PlaybackNetwork for Network {
       {
         // If transferring away from native, update flag
         app.is_streaming_active = false;
+        app.native_playback_origin = None;
       }
     }
   }

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -1,4 +1,4 @@
-use crate::core::app::{self, App};
+use crate::core::app::{self, App, NativeTrackKind};
 use crate::core::config::ClientConfig;
 #[cfg(all(feature = "macos-media", target_os = "macos"))]
 use crate::infra::macos_media;
@@ -281,19 +281,23 @@ async fn handle_player_events(
       PlayerEvent::TrackChanged { audio_item } => {
         use librespot_metadata::audio::UniqueFields;
 
-        let (artists, album) = match &audio_item.unique_fields {
+        let (artists, album, kind) = match &audio_item.unique_fields {
           UniqueFields::Track { artists, album, .. } => {
             let artist_names: Vec<String> = artists.0.iter().map(|a| a.name.clone()).collect();
-            (artist_names, album.clone())
+            (artist_names, album.clone(), NativeTrackKind::Track)
           }
-          UniqueFields::Episode { show_name, .. } => (vec![show_name.clone()], String::new()),
+          UniqueFields::Episode { show_name, .. } => (
+            vec![show_name.clone()],
+            String::new(),
+            NativeTrackKind::Episode,
+          ),
           UniqueFields::Local { artists, album, .. } => {
             let artist_vec = artists
               .as_ref()
               .map(|a| vec![a.clone()])
               .unwrap_or_default();
             let album_str = album.clone().unwrap_or_default();
-            (artist_vec, album_str)
+            (artist_vec, album_str, NativeTrackKind::Track)
           }
         };
 
@@ -325,6 +329,7 @@ async fn handle_player_events(
           artists_display: artists.join(", "),
           album: album.clone(),
           duration_ms: audio_item.duration_ms,
+          kind,
         });
 
         app.song_progress_ms = 0;
@@ -522,6 +527,7 @@ async fn disconnect_streaming_player(
   app_lock.native_device_id = None;
   app_lock.native_is_playing = Some(false);
   app_lock.native_track_info = None;
+  app_lock.native_playback_origin = None;
   app_lock.song_progress_ms = 0;
   app_lock.last_track_id = None;
   app_lock.last_device_activation = None;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -554,6 +554,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     .subcommand(cli::playback_subcommand())
     .subcommand(cli::play_subcommand())
     .subcommand(cli::list_subcommand())
+    .subcommand(cli::history_subcommand())
     .subcommand(cli::search_subcommand()),
   );
 
@@ -575,6 +576,11 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
 
   // Handle self-update command (doesn't need Spotify auth)
   if handle_self_update_command(&matches)? {
+    return Ok(());
+  }
+
+  if let Some(history_matches) = matches.subcommand_matches("history") {
+    println!("{}", cli::handle_history_matches(history_matches)?);
     return Ok(());
   }
 
@@ -755,6 +761,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   // Launch the UI (async)
   } else {
     info!("launching interactive terminal ui");
+    crate::infra::history::spawn_history_collector(Arc::clone(&app));
     #[cfg(feature = "streaming")]
     let (streaming_supported_for_account, streaming_startup_status_message) =
       if client_config.enable_streaming {

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -191,6 +191,43 @@ pub fn handle_app(key: Key, app: &mut App) {
         playbar::toggle_like_currently_playing_item(app);
       }
     }
+    _ if key == app.user_config.keys.generate_recap => {
+      if is_input_mode(app) {
+        handle_block_events(key, app);
+      } else {
+        match dirs::home_dir() {
+          Some(home) => {
+            let output_path = home
+              .join(".config")
+              .join("spotatui")
+              .join("spotatui-recap.html");
+            match crate::infra::history::export_history_recap(
+              crate::infra::history::RecapPeriod::ThirtyDays,
+              &output_path,
+            ) {
+              Ok(count) => {
+                app.set_status_message(
+                  format!(
+                    "Listening recap generated at ~/.config/spotatui/spotatui-recap.html ({} listens)",
+                    count
+                  ),
+                  5,
+                );
+                if let Err(e) = open::that(&output_path) {
+                  log::warn!("failed to open recap in browser: {}", e);
+                }
+              }
+              Err(e) => {
+                app.set_status_message(format!("Failed to generate recap: {}", e), 5);
+              }
+            }
+          }
+          None => {
+            app.set_status_message("Error: Could not locate home directory", 5);
+          }
+        }
+      }
+    }
     // Resize sidebar: { decreases, } increases width
     Key::Char('{') => {
       if is_input_mode(app) {

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -700,12 +700,12 @@ pub async fn start_ui(
     app_guard.user_config.behavior.sync_token.clone()
   };
 
-    if let Some(token) = sync_token_opt {
-      info!("Synchronizing listening history to cloud before exit...");
-      if let Err(e) = crate::infra::history::sync_history_to_cloud(&token).await {
-        log::warn!("failed to run exit history cloud sync: {}", e);
-      }
+  if let Some(token) = sync_token_opt {
+    info!("Synchronizing listening history to cloud before exit...");
+    if let Err(e) = crate::infra::history::sync_history_to_cloud(&token).await {
+      log::warn!("failed to run exit history cloud sync: {}", e);
     }
+  }
 
   reset_window_title(&mut window_title_state)?;
   execute!(stdout(), DisableMouseCapture)?;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -235,6 +235,7 @@ mod tests {
       artists_display: "The Artist".to_string(),
       album: "The Album".to_string(),
       duration_ms: 180_000,
+      kind: crate::core::app::NativeTrackKind::Track,
     });
 
     assert_eq!(playback_window_title(&app), "The Track — The Artist");
@@ -249,6 +250,7 @@ mod tests {
       artists_display: "The\nArtist".to_string(),
       album: "The Album".to_string(),
       duration_ms: 180_000,
+      kind: crate::core::app::NativeTrackKind::Track,
     });
 
     assert_eq!(playback_window_title(&app), "The]2;Bad Track — TheArtist");
@@ -691,6 +693,19 @@ pub async fn start_ui(
 
   #[cfg(feature = "streaming")]
   pause_native_playback_before_exit(app).await;
+
+  // Sync history to cloud on exit
+  let sync_token_opt = {
+    let app_guard = app.lock().await;
+    app_guard.user_config.behavior.sync_token.clone()
+  };
+
+    if let Some(token) = sync_token_opt {
+      info!("Synchronizing listening history to cloud before exit...");
+      if let Err(e) = crate::infra::history::sync_history_to_cloud(&token).await {
+        log::warn!("failed to run exit history cloud sync: {}", e);
+      }
+    }
 
   reset_window_title(&mut window_title_state)?;
   execute!(stdout(), DisableMouseCapture)?;

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -345,6 +345,11 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("General"),
     ],
     vec![
+      String::from("Generate 30-day listening recap card"),
+      key_bindings.generate_recap.to_string(),
+      String::from("General"),
+    ],
+    vec![
       String::from("Open sort menu"),
       String::from(","),
       String::from("Track/Album/Artist list"),


### PR DESCRIPTION
This pull request introduces a major new feature: local listening history collection and recap generation, along with several supporting enhancements and fixes. Users can now generate a shareable HTML recap of their recent listening history via the CLI or a new keybinding, and the groundwork is laid for future sync and analytics features. Playback tracking and configuration options have also been improved.

**New listening history and recap features:**

- Local listening history is now collected at `~/.config/spotatui/history/listens.jsonl`. A new CLI command, `spotatui history recap --period 30d --output ./file.html`, generates a shareable HTML recap of your last 30 days (or other periods). Short/skipped plays are excluded from recaps. 
- Added a configurable `R` keybinding (`keys.generate_recap`) to generate and open a 30-day recap directly from the app. 
- Added an optional `behavior.sync_token` setting for future syncing of listening history with spotatui.com, configurable in the app and config file. 

**Playback tracking improvements:**

- Added `NativePlaybackOrigin` to track if native playback started from a Spotify context or a raw URI list, improving playback handoff logic and stability. 
- Extended native track info with a `NativeTrackKind` field to distinguish between tracks and episodes, enabling proper URI construction and future episode-specific UI. 

**Bug fixes and polish:**

- Improved native playback handoff: context-backed playback now prefers Spotify-visible starts when safe, while raw URI-list playback remains on the stable native path. 

These changes lay the foundation for powerful personal analytics, recap sharing, and future sync features, while also improving playback tracking and user configurability.