### PR TITLE
Refactor auth token refresh and retry handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Spotify auth retry path**: Centralized authenticated Spotify API requests behind a shared refresh-and-retry flow so expired access tokens are handled consistently across playback, library, search, recommendation, metadata, and user calls.
+
 ## [v0.38.4] 2026-05-26
 
 ### Added

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -8,9 +8,9 @@ use rand::{thread_rng, Rng};
 use rspotify::model::{
   context::CurrentPlaybackContext,
   idtypes::{Id, PlayContextId, PlayableId},
+  playlist::FullPlaylist,
   PlayableItem,
 };
-use rspotify::prelude::*;
 
 pub struct CliApp {
   pub net: Network,
@@ -490,7 +490,11 @@ impl CliApp {
       if uri.contains("spotify:playlist:") {
         let id_str = uri.split(':').next_back().unwrap();
         if let Ok(playlist_id) = rspotify::model::idtypes::PlaylistId::from_id(id_str) {
-          match self.net.spotify.playlist(playlist_id, None, None).await {
+          match self
+            .net
+            .spotify_get_typed::<FullPlaylist>(&format!("playlists/{}", playlist_id.id()), &[])
+            .await
+          {
             Ok(p) => {
               let num = p.items.total;
               Some(thread_rng().gen_range(0..num) as usize)

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -145,6 +145,7 @@ fn build_pkce_spotify_client(
   }));
   let config = Config {
     cache_path,
+    token_refreshing: false,
     token_callback_fn: Arc::new(Some(token_callback)),
     ..Default::default()
   };
@@ -634,7 +635,7 @@ mod tests {
   }
 
   #[test]
-  fn test_pkce_client_keeps_rspotify_auto_refresh_with_cache_callback() {
+  fn test_pkce_client_disables_rspotify_auto_refresh_with_cache_callback() {
     let spotify = build_pkce_spotify_client(
       "test_client_id",
       "http://localhost:8888/callback".to_string(),
@@ -642,8 +643,8 @@ mod tests {
     );
 
     assert!(
-      spotify.config.token_refreshing,
-      "rspotify auto-refresh should remain available for direct client calls"
+      !spotify.config.token_refreshing,
+      "authenticated requests should use spotatui's shared refresh-and-retry path"
     );
     assert!(
       spotify.config.token_callback_fn.as_ref().is_some(),

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -275,8 +275,8 @@ impl Network {
       "me/library",
       &query,
       Some(json!({ "uris": uris })),
-      Some(&self.token_cache_path),
-      Some(&self.app),
+      &self.token_cache_path,
+      &self.app,
     )
     .await?;
     Ok(())
@@ -294,8 +294,8 @@ impl Network {
       "me/library",
       &query,
       Some(json!({ "uris": uris })),
-      Some(&self.token_cache_path),
-      Some(&self.app),
+      &self.token_cache_path,
+      &self.app,
     )
     .await?;
     Ok(())
@@ -775,8 +775,8 @@ impl LibraryNetwork for Network {
       &format!("playlists/{}/tracks", playlist_id.id()),
       &[],
       Some(body),
-      Some(&self.token_cache_path),
-      Some(&self.app),
+      &self.token_cache_path,
+      &self.app,
     )
     .await
     {
@@ -927,8 +927,8 @@ impl LibraryNetwork for Network {
       &create_path,
       &[],
       Some(create_body),
-      Some(&self.token_cache_path),
-      Some(&self.app),
+      &self.token_cache_path,
+      &self.app,
     )
     .await
     {

--- a/src/infra/network/metadata.rs
+++ b/src/infra/network/metadata.rs
@@ -1,22 +1,41 @@
-use super::requests::spotify_get_typed_compat_for;
 use super::Network;
 use crate::core::app::{
   ActiveBlock, Artist, ArtistBlock, EpisodeTableContext, RouteId, ScrollableResultPages,
   SelectedFullShow, SelectedShow,
 };
 use anyhow::anyhow;
-use futures::stream::StreamExt;
+use reqwest::Method;
 use rspotify::model::{
-  album::SimplifiedAlbum,
+  album::{FullAlbum, SimplifiedAlbum},
   artist::FullArtist,
   enums::Country,
-  idtypes::{AlbumId, ArtistId, LibraryId, ShowId, TrackId},
-  page::Page,
+  idtypes::{AlbumId, ArtistId, ShowId, TrackId},
+  page::{CursorBasedPage, Page},
   show::SimplifiedShow,
-  Market,
+  track::FullTrack,
 };
 use rspotify::prelude::*;
-use tokio::try_join;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct ArtistTopTracksResponse {
+  tracks: Vec<FullTrack>,
+}
+
+#[derive(Deserialize)]
+struct RelatedArtistsResponse {
+  artists: Vec<FullArtist>,
+}
+
+#[derive(Deserialize)]
+struct FollowedArtistsResponse {
+  artists: CursorBasedPage<FullArtist>,
+}
+
+fn country_code(country: Country) -> String {
+  let code: &'static str = country.into();
+  code.to_string()
+}
 
 pub trait MetadataNetwork {
   async fn get_artist(
@@ -47,57 +66,84 @@ impl MetadataNetwork for Network {
     country: Option<Country>,
   ) {
     let artist_id_str = artist_id.id().to_string();
-    let market = country.map(Market::Country);
-    #[allow(deprecated)]
-    let top_tracks_req = self.spotify.artist_top_tracks(artist_id.clone(), market);
-    #[allow(deprecated)]
-    let related_artists_req = self.spotify.artist_related_artists(artist_id.clone());
-    let albums_req = self.spotify.artist_albums(artist_id.clone(), None, market);
+    let artist_path = format!("artists/{}", artist_id.id());
+    let top_tracks_path = format!("{}/top-tracks", artist_path);
+    let related_artists_path = format!("{}/related-artists", artist_path);
+    let mut top_tracks_query = Vec::new();
+    if let Some(country) = country {
+      top_tracks_query.push(("market", country_code(country)));
+    }
 
-    // Note: artist_albums returns a Paginator (Stream), we need to collect it.
-    // However try_join! expects futures. We wrap stream collection in async block.
-    let albums_fut = async {
-      let stream = albums_req;
-      let items: Vec<_> = stream.collect().await;
+    let (top_tracks_res, related_artists_res) = tokio::join!(
+      self.spotify_get_typed::<ArtistTopTracksResponse>(&top_tracks_path, &top_tracks_query),
+      self.spotify_get_typed::<RelatedArtistsResponse>(&related_artists_path, &[])
+    );
 
-      // Flatten results and collect SimplifiedAlbum
-      let albums: Vec<SimplifiedAlbum> = items.into_iter().filter_map(|r| r.ok()).collect();
-
-      // Wrap in Page
-      Ok(Page {
-        items: albums,
-        href: String::new(),
-        limit: 50,
-        next: None,
-        offset: 0,
-        previous: None,
-        total: 0,
-      })
-    };
-
-    let res = try_join!(top_tracks_req, related_artists_req, albums_fut);
-
-    match res {
-      Ok((top_tracks, related_artists, albums)) => {
-        let mut app = self.app.lock().await;
-        app.artist = Some(Artist {
-          artist_id: artist_id_str,
-          artist_name: input_artist_name,
-          albums,
-          related_artists,
-          top_tracks,
-          selected_album_index: 0,
-          selected_related_artist_index: 0,
-          selected_top_track_index: 0,
-          artist_selected_block: ArtistBlock::TopTracks,
-          artist_hovered_block: ArtistBlock::TopTracks,
-        });
-        app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
-      }
+    let top_tracks = match top_tracks_res {
+      Ok(res) => res.tracks,
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
+        return;
       }
+    };
+    let related_artists = match related_artists_res {
+      Ok(res) => res.artists,
+      Err(e) => {
+        self.handle_error(anyhow!(e)).await;
+        return;
+      }
+    };
+
+    let mut album_items = Vec::new();
+    let mut offset = 0u32;
+    let limit = 50u32;
+    loop {
+      let mut query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+      if let Some(country) = country {
+        query.push(("market", country_code(country)));
+      }
+      let page = match self
+        .spotify_get_typed::<Page<SimplifiedAlbum>>(&format!("{}/albums", artist_path), &query)
+        .await
+      {
+        Ok(page) => page,
+        Err(e) => {
+          self.handle_error(anyhow!(e)).await;
+          return;
+        }
+      };
+      let next = page.next.is_some();
+      album_items.extend(page.items);
+      if !next {
+        break;
+      }
+      offset += limit;
     }
+
+    let albums = Page {
+      items: album_items,
+      href: String::new(),
+      limit,
+      next: None,
+      offset: 0,
+      previous: None,
+      total: 0,
+    };
+
+    let mut app = self.app.lock().await;
+    app.artist = Some(Artist {
+      artist_id: artist_id_str,
+      artist_name: input_artist_name,
+      albums,
+      related_artists,
+      top_tracks,
+      selected_album_index: 0,
+      selected_related_artist_index: 0,
+      selected_top_track_index: 0,
+      artist_selected_block: ArtistBlock::TopTracks,
+      artist_hovered_block: ArtistBlock::TopTracks,
+    });
+    app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
   }
 
   async fn get_album_tracks(&mut self, album: Box<SimplifiedAlbum>) {
@@ -105,12 +151,12 @@ impl MetadataNetwork for Network {
     if let Some(id) = album_id {
       let path = format!("albums/{}/tracks", id.id());
       // TODO: Handle pagination for albums with > 50 tracks
-      match spotify_get_typed_compat_for::<Page<rspotify::model::track::SimplifiedTrack>>(
-        &self.spotify,
-        &path,
-        &[("limit", "50".to_string()), ("offset", "0".to_string())],
-      )
-      .await
+      match self
+        .spotify_get_typed::<Page<rspotify::model::track::SimplifiedTrack>>(
+          &path,
+          &[("limit", "50".to_string()), ("offset", "0".to_string())],
+        )
+        .await
       {
         Ok(tracks) => {
           let mut app = self.app.lock().await;
@@ -128,7 +174,10 @@ impl MetadataNetwork for Network {
   }
 
   async fn get_album(&mut self, album_id: AlbumId<'static>) {
-    match self.spotify.album(album_id, None).await {
+    match self
+      .spotify_get_typed::<FullAlbum>(&format!("albums/{}", album_id.id()), &[])
+      .await
+    {
       Ok(album) => {
         let mut app = self.app.lock().await;
         app.selected_album_full = Some(crate::core::app::SelectedFullAlbum {
@@ -149,12 +198,9 @@ impl MetadataNetwork for Network {
       ("limit", self.large_search_limit.to_string()),
       ("offset", "0".to_string()),
     ];
-    match spotify_get_typed_compat_for::<Page<rspotify::model::show::SimplifiedEpisode>>(
-      &self.spotify,
-      &path,
-      &query,
-    )
-    .await
+    match self
+      .spotify_get_typed::<Page<rspotify::model::show::SimplifiedEpisode>>(&path, &query)
+      .await
     {
       Ok(episodes) => {
         if !episodes.items.is_empty() {
@@ -177,7 +223,8 @@ impl MetadataNetwork for Network {
 
   async fn get_show(&mut self, show_id: ShowId<'static>) {
     let path = format!("shows/{}", show_id.id());
-    match spotify_get_typed_compat_for::<rspotify::model::show::FullShow>(&self.spotify, &path, &[])
+    match self
+      .spotify_get_typed::<rspotify::model::show::FullShow>(&path, &[])
       .await
     {
       Ok(show) => {
@@ -203,12 +250,9 @@ impl MetadataNetwork for Network {
       query.push(("offset", offset.to_string()));
     }
 
-    match spotify_get_typed_compat_for::<Page<rspotify::model::show::SimplifiedEpisode>>(
-      &self.spotify,
-      &path,
-      &query,
-    )
-    .await
+    match self
+      .spotify_get_typed::<Page<rspotify::model::show::SimplifiedEpisode>>(&path, &query)
+      .await
     {
       Ok(episodes) => {
         if !episodes.items.is_empty() {
@@ -224,29 +268,36 @@ impl MetadataNetwork for Network {
 
   async fn get_followed_artists(&mut self, after: Option<ArtistId<'static>>) {
     let limit = self.large_search_limit;
-    let after_id = after.as_ref().map(|id| id.id());
+    let mut query = vec![("type", "artist".to_string()), ("limit", limit.to_string())];
+    if let Some(after) = after.as_ref() {
+      query.push(("after", after.id().to_string()));
+    }
+
     match self
-      .spotify
-      .current_user_followed_artists(after_id, Some(limit))
+      .spotify_get_typed::<FollowedArtistsResponse>("me/following", &query)
       .await
     {
-      Ok(artists_page) => {
+      Ok(res) => {
         let mut app = self.app.lock().await;
-        // Error: add_pages expects CursorBasedPage<FullArtist>, but items is Vec<FullArtist>
-        // Check add_pages definition. It takes T.
-        // artists_page is CursorBasedPage<FullArtist>.
-        // So we should pass the whole page if add_pages handles it.
-        // App definition: saved_artists: ScrollableResultPages<CursorBasedPage<FullArtist>>
-        app.library.saved_artists.add_pages(artists_page);
+        app.library.saved_artists.add_pages(res.artists);
       }
       Err(e) => self.handle_error(anyhow!(e)).await,
     }
   }
 
   async fn user_unfollow_artists(&mut self, artist_ids: Vec<ArtistId<'static>>) {
+    let ids = artist_ids
+      .iter()
+      .map(|id| id.id().to_string())
+      .collect::<Vec<_>>()
+      .join(",");
     match self
-      .spotify
-      .library_remove(artist_ids.into_iter().map(LibraryId::Artist))
+      .spotify_api_request_json(
+        Method::DELETE,
+        "me/following",
+        &[("type", "artist".to_string()), ("ids", ids)],
+        None,
+      )
       .await
     {
       Ok(_) => {
@@ -257,9 +308,18 @@ impl MetadataNetwork for Network {
   }
 
   async fn user_follow_artists(&mut self, artist_ids: Vec<ArtistId<'static>>) {
+    let ids = artist_ids
+      .iter()
+      .map(|id| id.id().to_string())
+      .collect::<Vec<_>>()
+      .join(",");
     match self
-      .spotify
-      .library_add(artist_ids.into_iter().map(LibraryId::Artist))
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/following",
+        &[("type", "artist".to_string()), ("ids", ids)],
+        None,
+      )
       .await
     {
       Ok(_) => {
@@ -271,8 +331,20 @@ impl MetadataNetwork for Network {
 
   async fn user_artist_check_follow(&mut self, artist_ids: Vec<ArtistId<'static>>) {
     match self
-      .spotify
-      .library_contains(artist_ids.iter().map(|id| LibraryId::Artist(id.as_ref())))
+      .spotify_get_typed::<Vec<bool>>(
+        "me/following/contains",
+        &[
+          ("type", "artist".to_string()),
+          (
+            "ids",
+            artist_ids
+              .iter()
+              .map(|id| id.id().to_string())
+              .collect::<Vec<_>>()
+              .join(","),
+          ),
+        ],
+      )
       .await
     {
       Ok(is_following) => {
@@ -295,7 +367,10 @@ impl MetadataNetwork for Network {
   }
 
   async fn get_album_for_track(&mut self, track_id: TrackId<'static>) {
-    match self.spotify.track(track_id, None).await {
+    match self
+      .spotify_get_typed::<FullTrack>(&format!("tracks/{}", track_id.id()), &[])
+      .await
+    {
       Ok(track) => {
         // FullTrack.album is SimplifiedAlbum (not Option) in rspotify 0.14
         let album = track.album;

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -662,16 +662,27 @@ impl PlaybackNetwork for Network {
             "starting native playback via Spotify context route on device {}",
             device_id
           );
-          let offset_struct = api_playback_offset(uris.as_deref(), offset);
+          let body = api_playback_body(Some(&context), uris.as_deref(), offset);
           match self
-            .spotify
-            .start_context_playback(context, Some(device_id.as_str()), offset_struct, None)
+            .spotify_api_request_json(
+              Method::PUT,
+              "me/player/play",
+              &[("device_id", device_id.clone())],
+              body,
+            )
             .await
           {
             Ok(_) => {
               if let Err(e) = self
-                .spotify
-                .shuffle(desired_shuffle_state, Some(device_id.as_str()))
+                .spotify_api_request_json(
+                  Method::PUT,
+                  "me/player/shuffle",
+                  &[
+                    ("state", desired_shuffle_state.to_string()),
+                    ("device_id", device_id.clone()),
+                  ],
+                  None,
+                )
                 .await
               {
                 let mut app = self.app.lock().await;

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1,15 +1,18 @@
-use super::requests::spotify_get_typed_compat_for;
 use super::{IoEvent, Network};
 use crate::tui::ui::util::create_artist_string;
 use anyhow::anyhow;
-use chrono::Duration as ChronoDuration;
 use chrono::TimeDelta;
+use reqwest::Method;
+#[cfg(feature = "streaming")]
+use rspotify::model::device::DevicePayload;
 use rspotify::model::{
+  context::CurrentUserQueue,
   enums::RepeatState,
   idtypes::{PlayContextId, PlayableId},
-  Offset, PlayableItem,
+  PlayableItem,
 };
 use rspotify::prelude::*;
+use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "streaming")]
@@ -71,15 +74,41 @@ fn trim_api_playback_uris(
   (trimmed_uris, Some(selected_index - start))
 }
 
-fn api_playback_offset(
+fn api_playback_offset_json(
   context_uris: Option<&[PlayableId<'static>]>,
   offset: Option<usize>,
-) -> Option<Offset> {
+) -> Option<Value> {
   if let Some(first_uri) = context_uris.and_then(|uris| uris.first()) {
-    return Some(Offset::Uri(first_uri.uri()));
+    return Some(json!({ "uri": first_uri.uri() }));
   }
 
-  offset.map(|index| Offset::Position(ChronoDuration::milliseconds(index as i64)))
+  offset.map(|index| json!({ "position": index }))
+}
+
+fn api_playback_body(
+  context_id: Option<&PlayContextId<'static>>,
+  uris: Option<&[PlayableId<'static>]>,
+  offset: Option<usize>,
+) -> Option<Value> {
+  match (context_id, uris) {
+    (Some(context), track_uris) => {
+      let mut body = json!({ "context_uri": context.uri() });
+      if let Some(offset) = api_playback_offset_json(track_uris, offset) {
+        body["offset"] = offset;
+      }
+      Some(body)
+    }
+    (None, Some(track_uris)) => {
+      let mut body = json!({
+        "uris": track_uris.iter().map(|uri| uri.uri()).collect::<Vec<_>>()
+      });
+      if let Some(offset) = api_playback_offset_json(None, offset) {
+        body["offset"] = offset;
+      }
+      Some(body)
+    }
+    (None, None) => None,
+  }
 }
 
 fn playable_item_id(item: &PlayableItem) -> Option<String> {
@@ -217,12 +246,12 @@ impl PlaybackNetwork for Network {
         None
       };
 
-    let context = spotify_get_typed_compat_for::<Option<rspotify::model::CurrentPlaybackContext>>(
-      &self.spotify,
-      "me/player",
-      &[("additional_types", "episode,track".to_string())],
-    )
-    .await;
+    let context = self
+      .spotify_get_typed::<Option<rspotify::model::CurrentPlaybackContext>>(
+        "me/player",
+        &[("additional_types", "episode,track".to_string())],
+      )
+      .await;
 
     let mut app = self.app.lock().await;
 
@@ -621,37 +650,22 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    let result = match (context_id, uris) {
-      (Some(context), track_uris) => {
-        let offset_struct = api_playback_offset(track_uris.as_deref(), offset);
-        self
-          .spotify
-          .start_context_playback(
-            context,
-            None, // device_id
-            offset_struct,
-            None, // position
-          )
-          .await
-      }
-      (None, Some(track_uris)) => {
-        let offset_struct = api_playback_offset(None, offset);
-        self
-          .spotify
-          .start_uris_playback(
-            track_uris,
-            None, // device_id
-            offset_struct,
-            None, // position
-          )
-          .await
-      }
-      (None, None) => self.spotify.resume_playback(None, None).await,
-    };
+    let body = api_playback_body(context_id.as_ref(), uris.as_deref(), offset);
+    let result = self
+      .spotify_api_request_json(Method::PUT, "me/player/play", &[], body)
+      .await;
 
     match result {
       Ok(_) => {
-        if let Err(e) = self.spotify.shuffle(desired_shuffle_state, None).await {
+        if let Err(e) = self
+          .spotify_api_request_json(
+            Method::PUT,
+            "me/player/shuffle",
+            &[("state", desired_shuffle_state.to_string())],
+            None,
+          )
+          .await
+        {
           let mut app = self.app.lock().await;
           app.handle_error(anyhow!(e));
         }
@@ -685,7 +699,10 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    match self.spotify.pause_playback(None).await {
+    match self
+      .spotify_api_request_json(Method::PUT, "me/player/pause", &[], None)
+      .await
+    {
       Ok(_) => {
         let mut app = self.app.lock().await;
         if let Some(ctx) = &mut app.current_playback_context {
@@ -708,7 +725,10 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    if let Err(e) = self.spotify.next_track(None).await {
+    if let Err(e) = self
+      .spotify_api_request_json(Method::POST, "me/player/next", &[], None)
+      .await
+    {
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -723,7 +743,10 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    if let Err(e) = self.spotify.previous_track(None).await {
+    if let Err(e) = self
+      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
+      .await
+    {
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -743,7 +766,10 @@ impl PlaybackNetwork for Network {
     // First previous_track restarts the current track (if past Spotify's ~3s
     // threshold). After a short delay the second call actually skips to the
     // previous track, since the position is now back at 0.
-    if let Err(e) = self.spotify.previous_track(None).await {
+    if let Err(e) = self
+      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
+      .await
+    {
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
       return;
@@ -751,7 +777,10 @@ impl PlaybackNetwork for Network {
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    if let Err(e) = self.spotify.previous_track(None).await {
+    if let Err(e) = self
+      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
+      .await
+    {
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -767,8 +796,12 @@ impl PlaybackNetwork for Network {
     }
 
     if let Err(e) = self
-      .spotify
-      .seek_track(ChronoDuration::milliseconds(position_ms as i64), None)
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/player/seek",
+        &[("position_ms", position_ms.to_string())],
+        None,
+      )
       .await
     {
       let mut app = self.app.lock().await;
@@ -789,7 +822,15 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    match self.spotify.shuffle(shuffle_state, None).await {
+    match self
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/player/shuffle",
+        &[("state", shuffle_state.to_string())],
+        None,
+      )
+      .await
+    {
       Ok(_) => {
         let mut app = self.app.lock().await;
         if let Some(ctx) = &mut app.current_playback_context {
@@ -816,7 +857,16 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    match self.spotify.repeat(repeat_state, None).await {
+    let repeat_state_param: &'static str = repeat_state.into();
+    match self
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/player/repeat",
+        &[("state", repeat_state_param.to_string())],
+        None,
+      )
+      .await
+    {
       Ok(_) => {
         let mut app = self.app.lock().await;
         if let Some(ctx) = &mut app.current_playback_context {
@@ -855,7 +905,15 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    match self.spotify.volume(volume, None).await {
+    match self
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/player/volume",
+        &[("volume_percent", volume.to_string())],
+        None,
+      )
+      .await
+    {
       Ok(_) => {
         let mut app = self.app.lock().await;
         if let Some(ctx) = &mut app.current_playback_context {
@@ -907,7 +965,18 @@ impl PlaybackNetwork for Network {
       }
     }
 
-    if let Err(e) = self.spotify.transfer_playback(&device_id, Some(true)).await {
+    if let Err(e) = self
+      .spotify_api_request_json(
+        Method::PUT,
+        "me/player",
+        &[],
+        Some(json!({
+          "device_ids": [device_id.clone()],
+          "play": true
+        })),
+      )
+      .await
+    {
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     } else {
@@ -968,9 +1037,13 @@ impl PlaybackNetwork for Network {
           tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        match self.spotify.device().await {
-          Ok(devices) => {
-            if let Some(device) = devices
+        match self
+          .spotify_get_typed::<DevicePayload>("me/player/devices", &[])
+          .await
+        {
+          Ok(payload) => {
+            if let Some(device) = payload
+              .devices
               .iter()
               .find(|d| d.name.to_lowercase() == device_name.to_lowercase())
             {
@@ -998,12 +1071,9 @@ impl PlaybackNetwork for Network {
     }
 
     // Check if we are paused/stopped
-    let context = spotify_get_typed_compat_for::<Option<rspotify::model::CurrentPlaybackContext>>(
-      &self.spotify,
-      "me/player",
-      &[],
-    )
-    .await;
+    let context = self
+      .spotify_get_typed::<Option<rspotify::model::CurrentPlaybackContext>>("me/player", &[])
+      .await;
 
     if let Ok(Some(ctx)) = context {
       if !ctx.is_playing {
@@ -1032,7 +1102,15 @@ impl PlaybackNetwork for Network {
   }
 
   async fn add_item_to_queue(&mut self, item: PlayableId<'static>) {
-    match self.spotify.add_item_to_queue(item, None).await {
+    match self
+      .spotify_api_request_json(
+        Method::POST,
+        "me/player/queue",
+        &[("uri", item.uri())],
+        None,
+      )
+      .await
+    {
       Ok(_) => {
         let mut app = self.app.lock().await;
         app.status_message = Some("Added to queue".to_string());
@@ -1046,7 +1124,10 @@ impl PlaybackNetwork for Network {
   }
 
   async fn get_queue(&mut self) {
-    match self.spotify.current_user_queue().await {
+    match self
+      .spotify_get_typed::<CurrentUserQueue>("me/player/queue", &[])
+      .await
+    {
       Ok(q) => {
         let mut app = self.app.lock().await;
         app.queue = Some(q);
@@ -1152,34 +1233,26 @@ mod tests {
       playable_track("0000000000000000000002"),
     ];
 
-    let offset = api_playback_offset(Some(&uris), Some(1));
+    let offset = api_playback_offset_json(Some(&uris), Some(1));
 
     assert_eq!(
       offset,
-      Some(Offset::Uri(
-        "spotify:track:0000000000000000000001".to_string()
-      ))
+      Some(json!({ "uri": "spotify:track:0000000000000000000001" }))
     );
   }
 
   #[test]
   fn api_playback_offset_uses_position_for_uri_list_playback() {
-    let offset = api_playback_offset(None, Some(1));
+    let offset = api_playback_offset_json(None, Some(1));
 
-    assert_eq!(
-      offset,
-      Some(Offset::Position(ChronoDuration::milliseconds(1)))
-    );
+    assert_eq!(offset, Some(json!({ "position": 1 })));
   }
 
   #[test]
   fn api_playback_offset_falls_back_to_position_when_context_has_no_uri() {
-    let offset = api_playback_offset(None, Some(3));
+    let offset = api_playback_offset_json(None, Some(3));
 
-    assert_eq!(
-      offset,
-      Some(Offset::Position(ChronoDuration::milliseconds(3)))
-    );
+    assert_eq!(offset, Some(json!({ "position": 3 })));
   }
 
   #[test]

--- a/src/infra/network/recommend.rs
+++ b/src/infra/network/recommend.rs
@@ -1,14 +1,28 @@
 use super::Network;
 use crate::core::app::{ActiveBlock, RouteId, TrackTableContext};
 use anyhow::anyhow;
-use futures::future;
 use rspotify::model::{
   enums::Country,
   idtypes::{ArtistId, TrackId},
-  track::FullTrack,
-  Market,
+  track::{FullTrack, SimplifiedTrack},
 };
 use rspotify::prelude::*;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct RecommendationsResponse {
+  tracks: Vec<SimplifiedTrack>,
+}
+
+#[derive(Deserialize)]
+struct TracksResponse {
+  tracks: Vec<FullTrack>,
+}
+
+fn country_code(country: Country) -> String {
+  let code: &'static str = country.into();
+  code.to_string()
+}
 
 pub trait RecommendationNetwork {
   async fn get_recommendations_for_seed(
@@ -33,19 +47,34 @@ impl RecommendationNetwork for Network {
     first_track: Box<Option<FullTrack>>,
     country: Option<Country>,
   ) {
-    let _market = country.map(Market::Country);
     let limit = self.large_search_limit;
+    let mut query = vec![("limit", limit.to_string())];
+    if let Some(country) = country {
+      query.push(("market", country_code(country)));
+    }
+    if let Some(seed_artists) = seed_artists.as_ref() {
+      query.push((
+        "seed_artists",
+        seed_artists
+          .iter()
+          .map(|id| id.id().to_string())
+          .collect::<Vec<_>>()
+          .join(","),
+      ));
+    }
+    if let Some(seed_tracks) = seed_tracks.as_ref() {
+      query.push((
+        "seed_tracks",
+        seed_tracks
+          .iter()
+          .map(|id| id.id().to_string())
+          .collect::<Vec<_>>()
+          .join(","),
+      ));
+    }
 
     match self
-      .spotify
-      .recommendations(
-        std::iter::empty(),
-        seed_artists,
-        None::<Vec<&str>>, // seed_genres
-        seed_tracks,
-        _market,
-        Some(limit),
-      )
+      .spotify_get_typed::<RecommendationsResponse>("recommendations", &query)
       .await
     {
       Ok(recommendations) => {
@@ -54,8 +83,6 @@ impl RecommendationNetwork for Network {
         // This is tricky. Recommendations usually return SimplifiedTracks.
         // We probably need to fetch FullTracks or fake it.
         // For now, let's map what we can and use a dummy album or fail.
-        // Better: use spotify.tracks() to fetch full details if possible.
-
         // Actually, we can fetch the full tracks using the IDs.
         let track_ids: Vec<TrackId> = recommendations
           .tracks
@@ -63,10 +90,25 @@ impl RecommendationNetwork for Network {
           .filter_map(|t| t.id.clone())
           .collect();
 
-        let fetch_futures = track_ids.into_iter().map(|id| self.spotify.track(id, None));
-
-        let results = future::join_all(fetch_futures).await;
-        let full_tracks: Vec<_> = results.into_iter().filter_map(|res| res.ok()).collect();
+        let ids = track_ids
+          .iter()
+          .map(|id| id.id().to_string())
+          .collect::<Vec<_>>()
+          .join(",");
+        let full_tracks = if ids.is_empty() {
+          Vec::new()
+        } else {
+          match self
+            .spotify_get_typed::<TracksResponse>("tracks", &[("ids", ids)])
+            .await
+          {
+            Ok(res) => res.tracks,
+            Err(e) => {
+              self.handle_error(anyhow!(e)).await;
+              return;
+            }
+          }
+        };
 
         let mut app = self.app.lock().await;
         app.track_table.tracks = full_tracks;

--- a/src/infra/network/requests.rs
+++ b/src/infra/network/requests.rs
@@ -1,3 +1,4 @@
+use super::Network;
 use crate::core::{app::App, auth};
 use anyhow::anyhow;
 use reqwest::Method;
@@ -5,6 +6,7 @@ use rspotify::AuthCodePkceSpotify;
 use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use std::{
+  future::Future,
   path::Path,
   sync::Arc,
   sync::OnceLock,
@@ -14,6 +16,7 @@ use tokio::sync::Mutex;
 
 static SPOTIFY_API_PACING: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
 const SPOTIFY_API_MIN_INTERVAL: Duration = Duration::from_millis(250);
+const SPOTIFY_API_BASE_URL: &str = "https://api.spotify.com/v1/";
 
 pub async fn pace_spotify_api_call() {
   let pacing_lock = SPOTIFY_API_PACING.get_or_init(|| Mutex::new(None));
@@ -29,26 +32,58 @@ pub async fn pace_spotify_api_call() {
   *last_request_started_at = Some(Instant::now());
 }
 
-pub async fn spotify_api_request_json_for(
-  spotify: &AuthCodePkceSpotify,
-  method: Method,
-  path: &str,
-  query: &[(&str, String)],
-  body: Option<Value>,
-) -> anyhow::Result<Value> {
-  spotify_api_request_json_for_with_refresh(spotify, method, path, query, body, None, None).await
-}
-
 pub async fn spotify_api_request_json_for_with_refresh(
   spotify: &AuthCodePkceSpotify,
   method: Method,
   path: &str,
   query: &[(&str, String)],
   body: Option<Value>,
-  token_cache_path: Option<&Path>,
-  app: Option<&Arc<Mutex<App>>>,
+  token_cache_path: &Path,
+  app: &Arc<Mutex<App>>,
 ) -> anyhow::Result<Value> {
-  let mut url = reqwest::Url::parse("https://api.spotify.com/v1/")?.join(path)?;
+  spotify_api_request_json_for_base_with_refresh(
+    spotify,
+    SPOTIFY_API_BASE_URL,
+    method,
+    path,
+    query,
+    body,
+    |force| async move {
+      match auth::refresh_token_and_cache(spotify, token_cache_path, force).await {
+        Ok(expiry) => {
+          let mut app = app.lock().await;
+          app.spotify_token_expiry = expiry;
+          app.auth_refresh_in_progress = false;
+          Ok(Some(expiry))
+        }
+        Err(e) => {
+          let mut app = app.lock().await;
+          app.auth_refresh_in_progress = false;
+          app.is_loading = false;
+          Err(e)
+        }
+      }
+    },
+  )
+  .await
+}
+
+async fn spotify_api_request_json_for_base_with_refresh<F, Fut>(
+  spotify: &AuthCodePkceSpotify,
+  base_url: &str,
+  method: Method,
+  path: &str,
+  query: &[(&str, String)],
+  body: Option<Value>,
+  mut refresh_token: F,
+) -> anyhow::Result<Value>
+where
+  F: FnMut(bool) -> Fut,
+  Fut: Future<Output = anyhow::Result<Option<std::time::SystemTime>>>,
+{
+  refresh_token(false).await?;
+
+  let mut url = reqwest::Url::parse(base_url)?.join(path)?;
   if !query.is_empty() {
     let mut qp = url.query_pairs_mut();
     for (k, v) in query {
@@ -104,37 +139,28 @@ pub async fn spotify_api_request_json_for_with_refresh(
     let status = response.status();
 
     if status == reqwest::StatusCode::UNAUTHORIZED && !refreshed_after_unauthorized {
-      if let Some(token_cache_path) = token_cache_path {
-        match auth::refresh_token_and_cache(spotify, token_cache_path, true).await {
-          Ok(expiry) => {
-            if let Some(app) = app {
-              let mut app = app.lock().await;
-              app.spotify_token_expiry = expiry;
-              app.auth_refresh_in_progress = false;
-            }
-            refreshed_after_unauthorized = true;
-            continue;
-          }
-          Err(refresh_err) => {
-            if let Some(app) = app {
-              app.lock().await.auth_refresh_in_progress = false;
-            }
-            let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!(
-              "Spotify API {} failed: {} (token refresh failed: {})",
-              status,
-              body,
-              refresh_err
-            ));
-          }
+      match refresh_token(true).await {
+        Ok(Some(_)) => {
+          refreshed_after_unauthorized = true;
+          continue;
         }
-      } else {
-        let body = response.text().await.unwrap_or_default();
-        return Err(anyhow!(
-          "Spotify API {} failed: {} (token refresh unavailable for this request)",
-          status,
-          body
-        ));
+        Ok(None) => {
+          let body = response.text().await.unwrap_or_default();
+          return Err(anyhow!(
+            "Spotify API {} failed: {} (token refresh unavailable for this request)",
+            status,
+            body
+          ));
+        }
+        Err(refresh_err) => {
+          let body = response.text().await.unwrap_or_default();
+          return Err(anyhow!(
+            "Spotify API {} failed: {} (token refresh failed: {})",
+            status,
+            body,
+            refresh_err
+          ));
+        }
       }
     }
 
@@ -154,6 +180,39 @@ pub async fn spotify_api_request_json_for_with_refresh(
 
     let body = response.text().await.unwrap_or_default();
     return Err(anyhow!("Spotify API {} failed: {}", status, body));
+  }
+}
+
+impl Network {
+  pub async fn spotify_api_request_json(
+    &self,
+    method: Method,
+    path: &str,
+    query: &[(&str, String)],
+    body: Option<Value>,
+  ) -> anyhow::Result<Value> {
+    spotify_api_request_json_for_with_refresh(
+      &self.spotify,
+      method,
+      path,
+      query,
+      body,
+      &self.token_cache_path,
+      &self.app,
+    )
+    .await
+  }
+
+  pub async fn spotify_get_typed<T: DeserializeOwned>(
+    &self,
+    path: &str,
+    query: &[(&str, String)],
+  ) -> anyhow::Result<T> {
+    let mut value = self
+      .spotify_api_request_json(Method::GET, path, query, None)
+      .await?;
+    normalize_spotify_payload(&mut value);
+    Ok(serde_json::from_value(value)?)
   }
 }
 
@@ -286,16 +345,6 @@ pub fn is_transient_network_error(e: &anyhow::Error) -> bool {
     || text.contains("dns")
 }
 
-pub async fn spotify_get_typed_compat_for<T: DeserializeOwned>(
-  spotify: &AuthCodePkceSpotify,
-  path: &str,
-  query: &[(&str, String)],
-) -> anyhow::Result<T> {
-  let mut value = spotify_api_request_json_for(spotify, Method::GET, path, query, None).await?;
-  normalize_spotify_payload(&mut value);
-  Ok(serde_json::from_value(value)?)
-}
-
 pub async fn spotify_get_typed_compat_for_with_refresh<T: DeserializeOwned>(
   spotify: &AuthCodePkceSpotify,
   path: &str,
@@ -309,10 +358,133 @@ pub async fn spotify_get_typed_compat_for_with_refresh<T: DeserializeOwned>(
     path,
     query,
     None,
-    Some(token_cache_path),
-    Some(app),
+    token_cache_path,
+    app,
   )
   .await?;
   normalize_spotify_payload(&mut value);
   Ok(serde_json::from_value(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{TimeDelta, Utc};
+  use rspotify::{Config, Credentials, OAuth, Token};
+  use std::{
+    sync::{
+      atomic::{AtomicUsize, Ordering},
+      Arc,
+    },
+    time::SystemTime,
+  };
+  use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+  };
+
+  async fn spotify_with_access_token(access_token: &str) -> AuthCodePkceSpotify {
+    let spotify = AuthCodePkceSpotify::with_config(
+      Credentials::new_pkce("test_client_id"),
+      OAuth {
+        redirect_uri: "http://localhost:8888/callback".to_string(),
+        ..Default::default()
+      },
+      Config::default(),
+    );
+
+    let mut token_lock = spotify.token.lock().await.expect("Failed to lock token");
+    *token_lock = Some(Token {
+      access_token: access_token.to_string(),
+      refresh_token: Some("refresh_token".to_string()),
+      expires_in: TimeDelta::seconds(3600),
+      expires_at: Some(Utc::now() + TimeDelta::seconds(3600)),
+      scopes: Default::default(),
+    });
+    drop(token_lock);
+
+    spotify
+  }
+
+  async fn read_http_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut buf = vec![0; 4096];
+    let n = stream.read(&mut buf).await.unwrap();
+    String::from_utf8_lossy(&buf[..n]).to_string()
+  }
+
+  #[tokio::test]
+  async fn retries_once_with_refreshed_token_after_401() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1/", listener.local_addr().unwrap());
+    let seen_authorization = Arc::new(Mutex::new(Vec::<String>::new()));
+    let seen_authorization_for_server = Arc::clone(&seen_authorization);
+
+    let server = tokio::spawn(async move {
+      for status in ["401 Unauthorized", "200 OK"] {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_http_request(&mut stream).await;
+        if let Some(header) = request
+          .lines()
+          .find(|line| line.to_ascii_lowercase().starts_with("authorization:"))
+        {
+          seen_authorization_for_server
+            .lock()
+            .await
+            .push(header.to_ascii_lowercase());
+        }
+
+        let body = if status.starts_with("200") {
+          r#"{"ok":true}"#
+        } else {
+          r#"{"error":"expired"}"#
+        };
+        let response = format!(
+          "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+          body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+      }
+    });
+
+    let spotify = spotify_with_access_token("old_access").await;
+    let refresh_calls = Arc::new(AtomicUsize::new(0));
+    let refresh_calls_for_closure = Arc::clone(&refresh_calls);
+    let spotify_for_closure = spotify.clone();
+
+    let result = spotify_api_request_json_for_base_with_refresh(
+      &spotify,
+      &base_url,
+      Method::GET,
+      "me",
+      &[],
+      None,
+      move |force| {
+        let spotify = spotify_for_closure.clone();
+        let refresh_calls = Arc::clone(&refresh_calls_for_closure);
+        async move {
+          refresh_calls.fetch_add(1, Ordering::SeqCst);
+          if force {
+            let mut token_lock = spotify.token.lock().await.expect("Failed to lock token");
+            let token = token_lock.as_mut().unwrap();
+            token.access_token = "new_access".to_string();
+          }
+          Ok(Some(SystemTime::now() + Duration::from_secs(3600)))
+        }
+      },
+    )
+    .await
+    .unwrap();
+
+    server.await.unwrap();
+
+    assert_eq!(result, json!({ "ok": true }));
+    assert_eq!(refresh_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+      *seen_authorization.lock().await,
+      vec![
+        "authorization: bearer old_access".to_string(),
+        "authorization: bearer new_access".to_string()
+      ]
+    );
+  }
 }

--- a/src/infra/network/search.rs
+++ b/src/infra/network/search.rs
@@ -1,20 +1,35 @@
-use super::requests::spotify_get_typed_compat_for;
 use super::{IoEvent, Network};
 use anyhow::anyhow;
 use rspotify::model::{
-  artist::FullArtist,
-  enums::{Country, Market, SearchType},
-  idtypes::AlbumId,
-  page::Page,
-  search::SearchResult,
+  artist::FullArtist, enums::Country, idtypes::AlbumId, page::Page, playlist::SimplifiedPlaylist,
+  show::SimplifiedShow, track::FullTrack, SimplifiedAlbum,
 };
 use rspotify::prelude::*;
 use serde::Deserialize;
-use tokio::try_join;
 
 #[derive(Deserialize, Debug)]
 pub struct ArtistSearchResponse {
   artists: Page<FullArtist>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TrackSearchResponse {
+  tracks: Page<FullTrack>,
+}
+
+#[derive(Deserialize, Debug)]
+struct AlbumSearchResponse {
+  albums: Page<SimplifiedAlbum>,
+}
+
+#[derive(Deserialize, Debug)]
+struct PlaylistSearchResponse {
+  playlists: Page<SimplifiedPlaylist>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ShowSearchResponse {
+  shows: Page<SimplifiedShow>,
 }
 
 pub trait SearchNetwork {
@@ -27,44 +42,21 @@ impl SearchNetwork for Network {
     // Don't pass market to search - when market is specified, Spotify doesn't return
     // available_markets field, but rspotify 0.14 models require it for tracks/albums.
     // We'll handle null playlist fields by searching playlists separately without requiring all fields.
-    let _market = country.map(Market::Country);
+    let _country = country;
 
-    let search_track = self.spotify.search(
-      &search_term,
-      SearchType::Track,
-      None,
-      None, // include_external
-      Some(self.small_search_limit),
-      Some(0),
-    );
+    let base_query = |search_type: &str| {
+      vec![
+        ("q", search_term.clone()),
+        ("type", search_type.to_string()),
+        ("limit", self.small_search_limit.to_string()),
+        ("offset", "0".to_string()),
+      ]
+    };
 
-    let search_album = self.spotify.search(
-      &search_term,
-      SearchType::Album,
-      None,
-      None, // include_external
-      Some(self.small_search_limit),
-      Some(0),
-    );
-
-    let search_playlist = self.spotify.search(
-      &search_term,
-      SearchType::Playlist,
-      None,
-      None, // include_external
-      Some(self.small_search_limit),
-      Some(0),
-    );
-
-    let search_show = self.spotify.search(
-      &search_term,
-      SearchType::Show,
-      None,
-      None, // include_external
-      Some(self.small_search_limit),
-      Some(0),
-    );
-
+    let track_query = base_query("track");
+    let album_query = base_query("album");
+    let playlist_query = base_query("playlist");
+    let show_query = base_query("show");
     let artist_query = vec![
       ("q", search_term.clone()),
       ("type", "artist".to_string()),
@@ -72,36 +64,41 @@ impl SearchNetwork for Network {
       ("offset", "0".to_string()),
     ];
 
-    // Run all futures concurrently
-    let (main_search, playlist_search, artist_search) = tokio::join!(
-      async { try_join!(search_track, search_album, search_show) },
-      search_playlist,
-      spotify_get_typed_compat_for::<ArtistSearchResponse>(&self.spotify, "search", &artist_query)
+    let (track_search, album_search, show_search, playlist_search, artist_search) = tokio::join!(
+      self.spotify_get_typed::<TrackSearchResponse>("search", &track_query),
+      self.spotify_get_typed::<AlbumSearchResponse>("search", &album_query),
+      self.spotify_get_typed::<ShowSearchResponse>("search", &show_query),
+      self.spotify_get_typed::<PlaylistSearchResponse>("search", &playlist_query),
+      self.spotify_get_typed::<ArtistSearchResponse>("search", &artist_query)
     );
 
-    // Handle main search results
-    let (track_result, album_result, show_result) = match main_search {
-      Ok((
-        SearchResult::Tracks(tracks),
-        SearchResult::Albums(albums),
-        SearchResult::Shows(shows),
-      )) => (Some(tracks), Some(albums), Some(shows)),
+    let track_result = match track_search {
+      Ok(res) => Some(res.tracks),
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
         return;
       }
-      _ => return,
+    };
+    let album_result = match album_search {
+      Ok(res) => Some(res.albums),
+      Err(e) => {
+        self.handle_error(anyhow!(e)).await;
+        return;
+      }
+    };
+    let show_result = match show_search {
+      Ok(res) => Some(res.shows),
+      Err(e) => {
+        self.handle_error(anyhow!(e)).await;
+        return;
+      }
     };
 
     let artist_result = artist_search.ok().map(|res| res.artists);
 
     // Handle playlist search separately since it can fail with null fields from Spotify API
     // Silently ignore playlist errors - this is a known Spotify API issue
-    let playlist_result = match playlist_search {
-      Ok(SearchResult::Playlists(playlists)) => Some(playlists),
-      Err(_) => None,
-      _ => None,
-    };
+    let playlist_result = playlist_search.ok().map(|res| res.playlists);
 
     let mut app = self.app.lock().await;
 
@@ -154,25 +151,23 @@ impl SearchNetwork for Network {
   }
 
   async fn search_tracks_for_playlist(&mut self, search_term: String) {
-    let result = self
-      .spotify
-      .search(
-        &search_term,
-        SearchType::Track,
-        None,
-        None,
-        Some(self.large_search_limit),
-        Some(0),
-      )
-      .await;
+    let query = vec![
+      ("q", search_term),
+      ("type", "track".to_string()),
+      ("limit", self.large_search_limit.to_string()),
+      ("offset", "0".to_string()),
+    ];
 
-    let tracks = match result {
-      Ok(SearchResult::Tracks(page)) => page
+    let tracks = match self
+      .spotify_get_typed::<TrackSearchResponse>("search", &query)
+      .await
+    {
+      Ok(res) => res
+        .tracks
         .items
         .into_iter()
         .filter_map(|t| if t.id.is_some() { Some(t) } else { None })
         .collect::<Vec<_>>(),
-      Ok(_) => return,
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
         return;

--- a/src/infra/network/user.rs
+++ b/src/infra/network/user.rs
@@ -1,12 +1,25 @@
-use super::requests::{is_rate_limited_error, spotify_get_typed_compat_for};
+use super::requests::is_rate_limited_error;
 use super::Network;
 use crate::core::app::{ActiveBlock, DiscoverTimeRange, RouteId};
 use anyhow::anyhow;
 
 use rand::seq::SliceRandom;
-use rspotify::model::{artist::FullArtist, page::Page, track::FullTrack};
+use rspotify::model::{
+  artist::FullArtist,
+  device::DevicePayload,
+  page::{CursorBasedPage, Page},
+  playing::PlayHistory,
+  track::FullTrack,
+  user::PrivateUser,
+};
 use rspotify::prelude::*;
+use serde::Deserialize;
 use std::time::{Duration, Instant};
+
+#[derive(Deserialize)]
+struct ArtistTopTracksResponse {
+  tracks: Vec<FullTrack>,
+}
 
 pub trait UserNetwork {
   async fn get_user(&mut self);
@@ -19,7 +32,7 @@ pub trait UserNetwork {
 
 impl UserNetwork for Network {
   async fn get_user(&mut self) {
-    match self.spotify.me().await {
+    match self.spotify_get_typed::<PrivateUser>("me", &[]).await {
       Ok(user) => {
         let mut app = self.app.lock().await;
         app.user = Some(user);
@@ -40,14 +53,13 @@ impl UserNetwork for Network {
   }
 
   async fn get_devices(&mut self) {
-    if let Ok(devices_vec) = self.spotify.device().await {
+    if let Ok(result) = self
+      .spotify_get_typed::<DevicePayload>("me/player/devices", &[])
+      .await
+    {
       let mut app = self.app.lock().await;
       app.push_navigation_stack(RouteId::SelectedDevice, ActiveBlock::SelectDevice);
-      if !devices_vec.is_empty() {
-        // Wrap Vec<Device> in DevicePayload
-        let result = rspotify::model::device::DevicePayload {
-          devices: devices_vec,
-        };
+      if !result.devices.is_empty() {
         app.devices = Some(result);
         // Select the first device in the list
         app.selected_device_index = Some(0);
@@ -68,15 +80,15 @@ impl UserNetwork for Network {
       app.discover_loading = true;
     }
 
-    match spotify_get_typed_compat_for::<Page<FullTrack>>(
-      &self.spotify,
-      "me/top/tracks",
-      &[
-        ("time_range", range_str.to_string()),
-        ("limit", "50".to_string()),
-      ],
-    )
-    .await
+    match self
+      .spotify_get_typed::<Page<FullTrack>>(
+        "me/top/tracks",
+        &[
+          ("time_range", range_str.to_string()),
+          ("limit", "50".to_string()),
+        ],
+      )
+      .await
     {
       Ok(page) => {
         let mut app = self.app.lock().await;
@@ -99,12 +111,12 @@ impl UserNetwork for Network {
     }
 
     // 1. Get top artists
-    let artists_res = spotify_get_typed_compat_for::<Page<FullArtist>>(
-      &self.spotify,
-      "me/top/artists",
-      &[("limit", "5".to_string())], // Get top 5 artists
-    )
-    .await;
+    let artists_res = self
+      .spotify_get_typed::<Page<FullArtist>>(
+        "me/top/artists",
+        &[("limit", "5".to_string())], // Get top 5 artists
+      )
+      .await;
 
     let artists = match artists_res {
       Ok(page) => page.items,
@@ -120,9 +132,12 @@ impl UserNetwork for Network {
 
     // 2. Get top tracks for each artist
     for artist in artists {
-      #[allow(deprecated)]
-      if let Ok(tracks) = self.spotify.artist_top_tracks(artist.id, None).await {
-        all_tracks.extend(tracks);
+      let path = format!("artists/{}/top-tracks", artist.id.id());
+      if let Ok(res) = self
+        .spotify_get_typed::<ArtistTopTracksResponse>(&path, &[])
+        .await
+      {
+        all_tracks.extend(res.tracks);
       }
     }
 
@@ -141,8 +156,10 @@ impl UserNetwork for Network {
   async fn get_recently_played(&mut self) {
     let limit = self.large_search_limit;
     match self
-      .spotify
-      .current_user_recently_played(Some(limit), None)
+      .spotify_get_typed::<CursorBasedPage<PlayHistory>>(
+        "me/player/recently-played",
+        &[("limit", limit.to_string())],
+      )
       .await
     {
       Ok(recently_played) => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,7 +60,7 @@ use std::{
   fs,
   io::{self, Write},
   panic,
-  path::PathBuf,
+  path::{Path, PathBuf},
   sync::{atomic::AtomicU64, Arc},
 };
 use tokio::sync::Mutex;
@@ -133,7 +133,7 @@ fn subscription_level_label(level: rspotify::model::SubscriptionLevel) -> &'stat
 #[cfg(feature = "streaming")]
 async fn account_supports_native_streaming(
   spotify: &AuthCodePkceSpotify,
-  token_cache_path: &PathBuf,
+  token_cache_path: &Path,
   app: &Arc<Mutex<App>>,
 ) -> (bool, Option<&'static str>) {
   match spotify_get_typed_compat_for_with_refresh::<PrivateUser>(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -55,12 +55,14 @@ use log::warn;
 #[cfg(feature = "streaming")]
 use rspotify::{model::user::PrivateUser, AuthCodePkceSpotify};
 #[cfg(feature = "streaming")]
+use std::path::Path;
+#[cfg(feature = "streaming")]
 use std::time::Duration;
 use std::{
   fs,
   io::{self, Write},
   panic,
-  path::{Path, PathBuf},
+  path::PathBuf,
   sync::{atomic::AtomicU64, Arc},
 };
 use tokio::sync::Mutex;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -38,6 +38,8 @@ use crate::infra::discord_rpc;
 use crate::infra::macos_media;
 #[cfg(all(feature = "mpris", target_os = "linux"))]
 use crate::infra::mpris;
+#[cfg(feature = "streaming")]
+use crate::infra::network::requests::spotify_get_typed_compat_for_with_refresh;
 use crate::infra::network::{IoEvent, Network};
 #[cfg(feature = "streaming")]
 use crate::infra::player;
@@ -51,9 +53,7 @@ use log::info;
 #[cfg(feature = "streaming")]
 use log::warn;
 #[cfg(feature = "streaming")]
-use rspotify::prelude::*;
-#[cfg(feature = "streaming")]
-use rspotify::AuthCodePkceSpotify;
+use rspotify::{model::user::PrivateUser, AuthCodePkceSpotify};
 #[cfg(feature = "streaming")]
 use std::time::Duration;
 use std::{
@@ -133,8 +133,18 @@ fn subscription_level_label(level: rspotify::model::SubscriptionLevel) -> &'stat
 #[cfg(feature = "streaming")]
 async fn account_supports_native_streaming(
   spotify: &AuthCodePkceSpotify,
+  token_cache_path: &PathBuf,
+  app: &Arc<Mutex<App>>,
 ) -> (bool, Option<&'static str>) {
-  match spotify.me().await {
+  match spotify_get_typed_compat_for_with_refresh::<PrivateUser>(
+    spotify,
+    "me",
+    &[],
+    token_cache_path,
+    app,
+  )
+  .await
+  {
     #[allow(deprecated)]
     Ok(user) => match user.product {
       Some(rspotify::model::SubscriptionLevel::Premium) => (true, None),
@@ -688,10 +698,8 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   #[cfg(feature = "streaming")]
   let selected_redirect_uri = authenticated.redirect_uri;
 
-  // Persist whatever token is now in memory. rspotify's auto_reauth (token_refreshing=true)
-  // silently refreshes the token during the spotify.me() probe in ensure_auth_token, rotating
-  // the refresh_token but never writing the result to disk (token_cached=false by default).
-  // Saving here ensures the on-disk token is always the current one, not the original stale one.
+  // Persist whatever token is now in memory. All later Spotify requests go through
+  // spotatui's refresh-and-cache path so the on-disk token stays current.
   if let Err(e) = auth::save_token_to_file(&spotify, &final_token_cache_path).await {
     log::warn!("Failed to cache token on startup: {}", e);
   }
@@ -727,7 +735,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     #[cfg(feature = "streaming")]
     let (streaming_supported_for_account, streaming_startup_status_message) =
       if client_config.enable_streaming {
-        account_supports_native_streaming(&spotify).await
+        account_supports_native_streaming(&spotify, &final_token_cache_path, &app).await
       } else {
         (false, None)
       };
@@ -1028,7 +1036,11 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
         let saved_device_id = network.client_config.device_id.clone();
         let mut devices_snapshot = None;
 
-        if let Ok(devices_vec) = network.spotify.device().await {
+        if let Ok(devices) = network
+          .spotify_get_typed::<rspotify::model::device::DevicePayload>("me/player/devices", &[])
+          .await
+        {
+          let devices_vec = devices.devices;
           let mut app = network.app.lock().await;
           app.devices = Some(rspotify::model::device::DevicePayload {
             devices: devices_vec.clone(),


### PR DESCRIPTION
# Summary

Refactors Spotify auth handling so authenticated API calls go through a shared refresh/cache/retry path instead of relying on rspotify auto-refresh. This prevents expired or refreshed tokens from breaking the cache and forcing re-login.

# Testing
  - `cargo fmt --all`
  - `cargo clippy --no-default-features --features telemetry -- -D warnings`
  - `cargo test --no-default-features --features telemetry`
  - `cargo check`

# Additional notes
No UI changes.

This also preserves refreshed tokens without dropping the cached `refresh_token`, disables rspotify auto-refresh after moving authenticated calls to shared helpers, and adds shared 401 refresh/retry coverage.

P.S.
I'd suggest someone does another iteration of manual testing, I did and haven't faced any issues, but to make sure I didn't miss anything