### PR TITLE
Feat/playlist track search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Playlist track search**: Added playlist-internal track search from playlist track tables with `<Ctrl+f>`, client-side matching across track title, artists, and album, loading feedback while large playlists are scanned, and `q`/the configured back key to clear the active playlist filter and restore the cached playlist view ([#198](https://github.com/LargeModGames/spotatui/issues/198)).
+
 ### Fixed
 
 - **Native streaming device handoff**: Kept native streaming recovery from stealing playback back after the user transfers listening from spotatui to another Spotify Connect device ([#254](https://github.com/LargeModGames/spotatui/issues/254)).

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,4 +1,4 @@
-use crate::core::sort::{SortContext, SortState};
+use crate::core::sort::{SortContext, SortField, SortOrder, SortState};
 use crate::core::user_config::{color_to_string, normalize_tick_rate_milliseconds, UserConfig};
 use crate::infra::network::sync::{PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
@@ -245,6 +245,13 @@ pub enum ActiveBlock {
   CreatePlaylistForm,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum InputContext {
+  #[default]
+  GlobalSearch,
+  PlaylistTrackSearch,
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum RouteId {
   Analysis,
@@ -387,6 +394,42 @@ pub struct TrackTable {
   pub tracks: Vec<FullTrack>,
   pub selected_index: usize,
   pub context: Option<TrackTableContext>,
+}
+
+fn sort_playlist_track_matches(matches: &mut [(FullTrack, usize)], sort_state: SortState) {
+  if sort_state.field == SortField::Default {
+    return;
+  }
+
+  matches.sort_by(|(track_a, position_a), (track_b, position_b)| {
+    let order = match sort_state.field {
+      SortField::Name => track_a.name.cmp(&track_b.name),
+      SortField::Duration => track_a.duration.cmp(&track_b.duration),
+      SortField::Artist => {
+        let empty_string = String::new();
+        let artist_a = track_a
+          .artists
+          .first()
+          .map(|artist| &artist.name)
+          .unwrap_or(&empty_string);
+        let artist_b = track_b
+          .artists
+          .first()
+          .map(|artist| &artist.name)
+          .unwrap_or(&empty_string);
+        artist_a.cmp(artist_b)
+      }
+      SortField::Album => track_a.album.name.cmp(&track_b.album.name),
+      SortField::DateAdded => position_a.cmp(position_b),
+      SortField::Default => std::cmp::Ordering::Equal,
+    };
+
+    if sort_state.order == SortOrder::Descending {
+      order.reverse()
+    } else {
+      order
+    }
+  });
 }
 
 #[derive(Clone)]
@@ -649,6 +692,7 @@ pub struct App {
   pub input: Vec<char>,
   pub input_idx: usize,
   pub input_cursor_position: u16,
+  pub input_context: InputContext,
   /// Horizontal scroll offset for the input box, computed during rendering.
   pub input_scroll_offset: Cell<u16>,
   pub liked_song_ids_set: HashSet<String>,
@@ -660,6 +704,8 @@ pub struct App {
   pub playlist_tracks: Option<Page<PlaylistItem>>,
   pub playlist_track_pages: ScrollableResultPages<Page<PlaylistItem>>,
   pub playlist_track_table_id: Option<PlaylistId<'static>>,
+  pub active_playlist_track_filter: Option<String>,
+  pub pending_playlist_track_search: Option<String>,
   pub playlists: Option<Page<SimplifiedPlaylist>>,
   pub recently_played: SpotifyResultAndSelectedIndex<Option<CursorBasedPage<PlayHistory>>>,
   pub recommendations_seed: String,
@@ -889,11 +935,14 @@ impl Default for App {
       input: vec![],
       input_idx: 0,
       input_cursor_position: 0,
+      input_context: InputContext::GlobalSearch,
       input_scroll_offset: Cell::new(0),
       playlist_offset: 0,
       playlist_tracks: None,
       playlist_track_pages: ScrollableResultPages::new(),
       playlist_track_table_id: None,
+      active_playlist_track_filter: None,
+      pending_playlist_track_search: None,
       playlists: None,
       recommendations_context: None,
       recommendations_seed: "".to_string(),
@@ -2224,6 +2273,8 @@ impl App {
       self.playlist_tracks_prefetch_generation.wrapping_add(1);
     self.playlist_tracks_prefetch_in_flight.clear();
     self.playlist_track_table_id = Some(playlist_id);
+    self.active_playlist_track_filter = None;
+    self.pending_playlist_track_search = None;
     self.playlist_track_pages.clear();
     self.playlist_tracks = None;
     self.playlist_offset = 0;
@@ -2254,6 +2305,50 @@ impl App {
     }
 
     self.track_table.tracks = tracks;
+  }
+
+  pub fn is_playlist_track_filter_active(&self) -> bool {
+    self.active_playlist_track_filter.is_some()
+  }
+
+  pub fn clear_playlist_track_filter(&mut self) {
+    self.active_playlist_track_filter = None;
+    self.pending_playlist_track_search = None;
+    self.input_context = InputContext::GlobalSearch;
+    if self.playlist_track_pages.pages.is_empty() {
+      self.track_table.tracks.clear();
+      self.track_table.selected_index = 0;
+      self.playlist_track_positions = None;
+      return;
+    }
+    self.set_playlist_tracks_to_table_continuous();
+  }
+
+  pub fn apply_playlist_track_search_results(
+    &mut self,
+    playlist_id: &PlaylistId<'_>,
+    query: String,
+    mut matches: Vec<(FullTrack, usize)>,
+  ) -> bool {
+    if !self.is_playlist_track_table_active_for(playlist_id) {
+      return false;
+    }
+
+    sort_playlist_track_matches(&mut matches, self.playlist_sort);
+
+    let track_ids = matches
+      .iter()
+      .filter_map(|(track, _)| track.id.clone().map(|id| id.into_static()))
+      .collect();
+    let (tracks, positions): (Vec<_>, Vec<_>) = matches.into_iter().unzip();
+
+    self.active_playlist_track_filter = Some(query);
+    self.pending_playlist_track_search = None;
+    self.track_table.selected_index = 0;
+    self.track_table.tracks = tracks;
+    self.playlist_track_positions = Some(positions);
+    self.dispatch(IoEvent::CurrentUserSavedTracksContains(track_ids));
+    true
   }
 
   pub fn is_playlist_track_table_context(&self) -> bool {
@@ -2340,6 +2435,10 @@ impl App {
   }
 
   pub fn current_playlist_has_more_tracks(&self) -> bool {
+    if self.is_playlist_track_filter_active() {
+      return false;
+    }
+
     self
       .playlist_tracks
       .as_ref()
@@ -2426,6 +2525,10 @@ impl App {
   }
 
   pub fn get_playlist_tracks_next(&mut self) {
+    if self.is_playlist_track_filter_active() {
+      return;
+    }
+
     let Some(playlist_id) = self.current_playlist_track_table_id() else {
       return;
     };
@@ -4283,6 +4386,67 @@ mod tests {
     assert_eq!(app.track_table.tracks.len(), 4);
     assert_eq!(app.track_table.selected_index, 2);
     assert_eq!(app.playlist_track_positions, Some(vec![0, 1, 2, 3]));
+  }
+
+  #[test]
+  fn playlist_search_results_preserve_source_positions_and_handle_no_matches() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = playlist_id("37i9dQZF1DX4WYpdgoIcn6");
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app.pending_playlist_track_search = Some("track".to_string());
+
+    assert!(app.apply_playlist_track_search_results(
+      &playlist_id,
+      "track".to_string(),
+      vec![
+        (full_track("0000000000000000000002", "Second"), 8),
+        (full_track("0000000000000000000004", "Fourth"), 11),
+      ],
+    ));
+
+    assert_eq!(app.active_playlist_track_filter, Some("track".to_string()));
+    assert!(app.pending_playlist_track_search.is_none());
+    assert_eq!(app.track_table.tracks.len(), 2);
+    assert_eq!(app.playlist_track_positions, Some(vec![8, 11]));
+    match rx.recv().unwrap() {
+      IoEvent::CurrentUserSavedTracksContains(track_ids) => {
+        assert_eq!(track_ids.len(), 2);
+      }
+      _ => panic!("unexpected event"),
+    }
+
+    assert!(app.apply_playlist_track_search_results(&playlist_id, "none".to_string(), vec![]));
+    assert!(app.track_table.tracks.is_empty());
+    assert_eq!(app.playlist_track_positions, Some(vec![]));
+  }
+
+  #[test]
+  fn clearing_playlist_search_restores_cached_continuous_view() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = playlist_id("37i9dQZF1DX4WYpdgoIcn6");
+    let page = playlist_page(
+      0,
+      2,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    );
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id);
+    app.playlist_track_pages.upsert_page_by_offset(page);
+    app.active_playlist_track_filter = Some("second".to_string());
+    app.track_table.tracks = vec![full_track("0000000000000000000002", "Second")];
+    app.playlist_track_positions = Some(vec![1]);
+
+    app.clear_playlist_track_filter();
+
+    assert!(app.active_playlist_track_filter.is_none());
+    assert_eq!(app.track_table.tracks.len(), 2);
+    assert_eq!(app.playlist_track_positions, Some(vec![0, 1]));
   }
 
   #[test]

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -46,6 +46,31 @@ fn populate_liked_song_ids_from_saved_tracks(
   }
 }
 
+fn playlist_track_search_terms(query: &str) -> Vec<String> {
+  query
+    .split_whitespace()
+    .map(|term| term.to_lowercase())
+    .filter(|term| !term.is_empty())
+    .collect()
+}
+
+fn playlist_track_search_haystack(track: &rspotify::model::track::FullTrack) -> String {
+  let mut haystack = format!("{} {}", track.name, track.album.name);
+  for artist in &track.artists {
+    haystack.push(' ');
+    haystack.push_str(&artist.name);
+  }
+  haystack.to_lowercase()
+}
+
+fn playlist_track_matches_terms(
+  track: &rspotify::model::track::FullTrack,
+  terms: &[String],
+) -> bool {
+  let haystack = playlist_track_search_haystack(track);
+  terms.iter().all(|term| haystack.contains(term))
+}
+
 pub async fn prefetch_saved_tracks_page_task(
   spotify: AuthCodePkceSpotify,
   app: Arc<Mutex<App>>,
@@ -203,6 +228,7 @@ pub async fn prefetch_playlist_tracks_page_task(
 pub trait LibraryNetwork {
   async fn get_current_user_playlists(&mut self);
   async fn get_playlist_tracks(&mut self, playlist_id: PlaylistId<'static>, playlist_offset: u32);
+  async fn search_playlist_tracks(&mut self, playlist_id: PlaylistId<'static>, query: String);
   async fn get_current_user_saved_tracks(&mut self, offset: Option<u32>);
   async fn get_current_user_saved_albums(&mut self, offset: Option<u32>);
   async fn current_user_saved_albums_contains(&mut self, album_ids: Vec<AlbumId<'static>>);
@@ -375,6 +401,9 @@ impl LibraryNetwork for Network {
       {
         Ok(page) => page,
         Err(e) => {
+          let mut app = self.app.lock().await;
+          app.pending_playlist_track_search = None;
+          drop(app);
           self.handle_error(anyhow!(e)).await;
           return;
         }
@@ -478,6 +507,66 @@ impl LibraryNetwork for Network {
         drop(app);
         self.handle_error(anyhow!(e)).await;
       }
+    }
+  }
+
+  async fn search_playlist_tracks(&mut self, playlist_id: PlaylistId<'static>, query: String) {
+    let terms = playlist_track_search_terms(&query);
+    if terms.is_empty() {
+      let mut app = self.app.lock().await;
+      app.clear_playlist_track_filter();
+      return;
+    }
+
+    let limit = self.large_search_limit;
+    let mut offset = 0u32;
+    let mut matches = Vec::new();
+
+    loop {
+      let path = format!("playlists/{}/items", playlist_id.id());
+      let page = match spotify_get_typed_compat_for_with_refresh::<Page<PlaylistItem>>(
+        &self.spotify,
+        &path,
+        &[("limit", limit.to_string()), ("offset", offset.to_string())],
+        &self.token_cache_path,
+        &self.app,
+      )
+      .await
+      {
+        Ok(page) => page,
+        Err(e) => {
+          self.handle_error(anyhow!(e)).await;
+          return;
+        }
+      };
+
+      if page.items.is_empty() {
+        break;
+      }
+
+      for (index, item) in page.items.iter().enumerate() {
+        if let Some(PlayableItem::Track(track)) = item.item.as_ref() {
+          if playlist_track_matches_terms(track, &terms) {
+            matches.push((track.clone(), page.offset as usize + index));
+          }
+        }
+      }
+
+      if page.next.is_none() {
+        break;
+      }
+      offset = page.offset.saturating_add(page.limit);
+    }
+
+    let match_count = matches.len();
+    let mut app = self.app.lock().await;
+    if app.apply_playlist_track_search_results(&playlist_id, query.clone(), matches) {
+      app.set_status_message(
+        format!("{match_count} playlist tracks match \"{query}\""),
+        3,
+      );
+    } else {
+      app.pending_playlist_track_search = None;
     }
   }
 
@@ -1081,6 +1170,48 @@ mod tests {
     assert!(liked_song_ids_set.contains("0000000000000000000001"));
     assert!(liked_song_ids_set.contains("0000000000000000000002"));
     assert!(!liked_song_ids_set.contains("spotify:track:0000000000000000000001"));
+  }
+
+  #[test]
+  fn playlist_track_filter_matches_title_artist_album_case_insensitively() {
+    let mut track = full_track("0000000000000000000001");
+    track.name = "Midnight City".to_string();
+    track.artists[0].name = "M83".to_string();
+    track.album.name = "Hurry Up".to_string();
+
+    assert!(playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("midnight")
+    ));
+    assert!(playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("m83")
+    ));
+    assert!(playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("hurry")
+    ));
+    assert!(playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("MIDNIGHT m83")
+    ));
+  }
+
+  #[test]
+  fn playlist_track_filter_requires_every_query_term() {
+    let mut track = full_track("0000000000000000000001");
+    track.name = "Midnight City".to_string();
+    track.artists[0].name = "M83".to_string();
+    track.album.name = "Hurry Up".to_string();
+
+    assert!(playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("city hurry")
+    ));
+    assert!(!playlist_track_matches_terms(
+      &track,
+      &playlist_track_search_terms("city missing")
+    ));
   }
 }
 

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -49,6 +49,7 @@ pub enum IoEvent {
   GetDevices,
   GetSearchResults(String, Option<Country>),
   GetPlaylistItems(PlaylistId<'static>, u32),
+  SearchPlaylistTracks(PlaylistId<'static>, String),
   GetCurrentSavedTracks(Option<u32>),
   StartPlayback(
     Option<PlayContextId<'static>>,
@@ -219,6 +220,9 @@ impl Network {
 
       IoEvent::GetPlaylistItems(playlist_id, playlist_offset) => {
         self.get_playlist_tracks(playlist_id, playlist_offset).await;
+      }
+      IoEvent::SearchPlaylistTracks(playlist_id, query) => {
+        self.search_playlist_tracks(playlist_id, query).await;
       }
       IoEvent::GetCurrentSavedTracks(offset) => {
         self.get_current_user_saved_tracks(offset).await;

--- a/src/tui/handlers/input.rs
+++ b/src/tui/handlers/input.rs
@@ -1,6 +1,6 @@
 extern crate unicode_width;
 
-use crate::core::app::{ActiveBlock, App, RouteId};
+use crate::core::app::{ActiveBlock, App, InputContext, RouteId};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
 use rspotify::model::idtypes::{AlbumId, PlaylistId, ShowId, TrackId};
@@ -62,9 +62,15 @@ pub fn handler(key: Key, app: &mut App) {
       app.input_idx += 1;
       app.input_cursor_position += compute_character_width(next_c);
     }
-    Key::Esc => {
-      app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
-    }
+    Key::Esc => match app.input_context {
+      InputContext::PlaylistTrackSearch => {
+        app.input_context = InputContext::GlobalSearch;
+        app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
+      }
+      InputContext::GlobalSearch => {
+        app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
+      }
+    },
     Key::Enter => {
       let input_str: String = app.input.iter().collect();
 
@@ -88,6 +94,11 @@ pub fn handler(key: Key, app: &mut App) {
 }
 
 fn process_input(app: &mut App, input: String) {
+  if app.input_context == InputContext::PlaylistTrackSearch {
+    process_playlist_track_search(app, input);
+    return;
+  }
+
   // Don't do anything if there is no input
   if input.is_empty() {
     return;
@@ -105,6 +116,23 @@ fn process_input(app: &mut App, input: String) {
   // Default fallback behavior: treat the input as a raw search phrase.
   app.dispatch(IoEvent::GetSearchResults(input, app.get_user_country()));
   app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
+}
+
+fn process_playlist_track_search(app: &mut App, input: String) {
+  let query = input.trim().to_string();
+  app.input_context = InputContext::GlobalSearch;
+  app.set_current_route_state(Some(ActiveBlock::TrackTable), Some(ActiveBlock::TrackTable));
+
+  if query.is_empty() {
+    app.clear_playlist_track_filter();
+    return;
+  }
+
+  if let Some(playlist_id) = app.current_playlist_track_table_id() {
+    app.pending_playlist_track_search = Some(query.clone());
+    app.set_status_message(format!("Searching playlist for \"{query}\"..."), 60);
+    app.dispatch(IoEvent::SearchPlaylistTracks(playlist_id, query));
+  }
 }
 
 fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) -> (String, bool) {
@@ -174,6 +202,7 @@ fn compute_character_width(character: char) -> u16 {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use rspotify::prelude::Id;
 
   fn str_to_vec_char(s: &str) -> Vec<char> {
     String::from(s).chars().collect()
@@ -279,6 +308,85 @@ mod tests {
 
     let current_route = app.get_current_route();
     assert_eq!(current_route.active_block, ActiveBlock::Empty);
+  }
+
+  #[test]
+  fn playlist_search_esc_returns_focus_to_track_table() {
+    let mut app = App::default();
+    app.input_context = InputContext::PlaylistTrackSearch;
+
+    handler(Key::Esc, &mut app);
+
+    let current_route = app.get_current_route();
+    assert_eq!(current_route.active_block, ActiveBlock::TrackTable);
+    assert_eq!(current_route.hovered_block, ActiveBlock::TrackTable);
+    assert_eq!(app.input_context, InputContext::GlobalSearch);
+  }
+
+  #[test]
+  fn playlist_search_enter_dispatches_playlist_search() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut app = App::new(
+      tx,
+      crate::core::user_config::UserConfig::new(),
+      std::time::SystemTime::now(),
+    );
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static();
+
+    app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id.clone());
+    app.input_context = InputContext::PlaylistTrackSearch;
+    app.input = str_to_vec_char("queen rock");
+    app.input_idx = app.input.len();
+    app.input_cursor_position = app.input.len() as u16;
+
+    handler(Key::Enter, &mut app);
+
+    match rx.recv().unwrap() {
+      IoEvent::SearchPlaylistTracks(id, query) => {
+        assert_eq!(id.id(), playlist_id.id());
+        assert_eq!(query, "queen rock");
+      }
+      _ => panic!("unexpected event"),
+    }
+    assert_eq!(app.input_context, InputContext::GlobalSearch);
+    assert_eq!(
+      app.get_current_route().active_block,
+      ActiveBlock::TrackTable
+    );
+    assert_eq!(
+      app.pending_playlist_track_search,
+      Some("queen rock".to_string())
+    );
+    assert_eq!(
+      app.status_message.as_deref(),
+      Some("Searching playlist for \"queen rock\"...")
+    );
+  }
+
+  #[test]
+  fn empty_playlist_search_clears_filter_without_dispatching() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut app = App::new(
+      tx,
+      crate::core::user_config::UserConfig::new(),
+      std::time::SystemTime::now(),
+    );
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static();
+
+    app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id);
+    app.input_context = InputContext::PlaylistTrackSearch;
+    app.active_playlist_track_filter = Some("old".to_string());
+
+    handler(Key::Enter, &mut app);
+
+    assert!(app.active_playlist_track_filter.is_none());
+    assert!(rx.try_recv().is_err());
   }
 
   #[test]

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -32,7 +32,7 @@ mod settings;
 mod sort_menu;
 mod track_table;
 
-use crate::core::app::{ActiveBlock, App, ArtistBlock, RouteId, SearchResultBlock};
+use crate::core::app::{ActiveBlock, App, ArtistBlock, InputContext, RouteId, SearchResultBlock};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
 use rspotify::model::idtypes::PlaylistId;
@@ -162,7 +162,18 @@ pub fn handle_app(key: Key, app: &mut App) {
     _ if key == app.user_config.keys.repeat => {
       app.repeat();
     }
+    Key::Ctrl('f')
+      if app.get_current_route().active_block == ActiveBlock::TrackTable
+        && app.is_playlist_track_table_context() =>
+    {
+      app.input.clear();
+      app.input_idx = 0;
+      app.input_cursor_position = 0;
+      app.input_context = InputContext::PlaylistTrackSearch;
+      app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
+    }
     _ if key == app.user_config.keys.search => {
+      app.input_context = InputContext::GlobalSearch;
       app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
     }
     _ if key == app.user_config.keys.copy_song_url => {
@@ -467,7 +478,6 @@ fn handle_jump_to_artist_album(app: &mut App) {
 #[cfg(test)]
 mod tests {
   use super::*;
-  #[cfg(target_os = "macos")]
   use crate::core::app::TrackTableContext;
   use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
@@ -475,6 +485,7 @@ mod tests {
   use rspotify::model::{
     context::{Actions, CurrentPlaybackContext},
     enums::{DeviceType, RepeatState},
+    idtypes::PlaylistId,
     CurrentlyPlayingType, Device, PlayableId, PlayableItem,
   };
   use std::{sync::mpsc::channel, time::SystemTime};
@@ -565,6 +576,50 @@ mod tests {
 
     // In input mode, 'F' should be added to the input buffer
     assert_eq!(app.input, vec!['F']);
+  }
+
+  #[test]
+  fn ctrl_f_in_playlist_track_table_opens_playlist_search_input() {
+    let mut app = App::default();
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static();
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id);
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+
+    handle_app(Key::Ctrl('f'), &mut app);
+
+    assert_eq!(app.input_context, InputContext::PlaylistTrackSearch);
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::Input);
+  }
+
+  #[test]
+  fn search_key_in_playlist_track_table_opens_global_search_input() {
+    let mut app = App::default();
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static();
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id);
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+
+    handle_app(app.user_config.keys.search, &mut app);
+
+    assert_eq!(app.input_context, InputContext::GlobalSearch);
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::Input);
+  }
+
+  #[test]
+  fn search_key_outside_playlist_track_table_opens_global_search_input() {
+    let mut app = App::default();
+    app.track_table.context = Some(TrackTableContext::SavedTracks);
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+
+    handle_app(app.user_config.keys.search, &mut app);
+
+    assert_eq!(app.input_context, InputContext::GlobalSearch);
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::Input);
   }
 
   #[cfg(target_os = "macos")]

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -388,6 +388,7 @@ fn focus_playbar(block: ActiveBlock, app: &mut App) {
 }
 
 fn focus_input(app: &mut App) {
+  app.input_context = crate::core::app::InputContext::GlobalSearch;
   app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
 }
 

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -119,6 +119,9 @@ pub fn handler(key: Key, app: &mut App) {
     }
     Key::Char('w') => open_add_to_playlist_dialog(app),
     Key::Char('x') => open_remove_from_playlist_dialog(app),
+    Key::Char('q') if app.is_playlist_track_filter_active() => {
+      app.clear_playlist_track_filter();
+    }
     Key::Char('s') => handle_save_track_event(app),
     Key::Char('S') => play_random_song(app),
     k if k == app.user_config.keys.jump_to_end => jump_to_end(app),
@@ -487,7 +490,7 @@ mod tests {
   use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
   use chrono::Utc;
-  use rspotify::model::{page::Page, track::SavedTrack};
+  use rspotify::model::{page::Page, playlist::PlaylistItem, track::SavedTrack, PlayableItem};
   use std::sync::mpsc::channel;
   use std::time::SystemTime;
 
@@ -495,6 +498,18 @@ mod tests {
     SavedTrack {
       added_at: Utc::now(),
       track: full_track(id, name),
+    }
+  }
+
+  #[allow(deprecated)]
+  fn playlist_item(id: &str, name: &str) -> PlaylistItem {
+    let track = PlayableItem::Track(full_track(id, name));
+    PlaylistItem {
+      added_at: Some(Utc::now()),
+      added_by: None,
+      is_local: false,
+      track: None,
+      item: Some(track),
     }
   }
 
@@ -629,6 +644,72 @@ mod tests {
       }
       other => panic!("unexpected event: {:?}", event_name(&other)),
     }
+  }
+
+  #[test]
+  fn filtered_playlist_down_wraps_without_fetching_next_page() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(
+      PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+        .unwrap()
+        .into_static(),
+    );
+    app.playlist_tracks = Some(Page {
+      href: "https://example.com/playlists/test/items".to_string(),
+      items: vec![],
+      limit: 2,
+      next: Some("https://example.com/playlists/test/items?next".to_string()),
+      offset: 0,
+      previous: None,
+      total: 4,
+    });
+    app.active_playlist_track_filter = Some("track".to_string());
+    app.track_table.tracks = vec![
+      full_track("0000000000000000000001", "Track 1"),
+      full_track("0000000000000000000002", "Track 2"),
+    ];
+    app.track_table.selected_index = 1;
+
+    handler(Key::Down, &mut app);
+
+    assert_eq!(app.track_table.selected_index, 0);
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn q_clears_playlist_filter_and_restores_cached_rows() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), SystemTime::now());
+    let playlist_id = PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static();
+    let first_page = Page {
+      href: "https://example.com/playlists/test/items".to_string(),
+      items: vec![
+        playlist_item("0000000000000000000001", "Track 1"),
+        playlist_item("0000000000000000000002", "Track 2"),
+      ],
+      limit: 2,
+      next: None,
+      offset: 0,
+      previous: None,
+      total: 2,
+    };
+
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(playlist_id);
+    app.playlist_track_pages.upsert_page_by_offset(first_page);
+    app.active_playlist_track_filter = Some("track 2".to_string());
+    app.track_table.tracks = vec![full_track("0000000000000000000002", "Track 2")];
+    app.playlist_track_positions = Some(vec![1]);
+
+    handler(Key::Char('q'), &mut app);
+
+    assert!(app.active_playlist_track_filter.is_none());
+    assert_eq!(app.track_table.tracks.len(), 2);
+    assert_eq!(app.playlist_track_positions, Some(vec![0, 1]));
   }
 
   #[test]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -211,10 +211,20 @@ fn reset_window_title(state: &mut WindowTitleState) -> Result<()> {
   Ok(())
 }
 
+fn back_key_clears_playlist_filter(app: &mut App, active_block: ActiveBlock) -> bool {
+  if active_block == ActiveBlock::TrackTable && app.is_playlist_track_filter_active() {
+    app.clear_playlist_track_filter();
+    true
+  } else {
+    false
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::core::app::NativeTrackInfo;
+  use crate::core::app::{NativeTrackInfo, TrackTableContext};
+  use rspotify::model::idtypes::PlaylistId;
   use std::{sync::mpsc::channel, time::SystemTime};
 
   fn app() -> App {
@@ -274,6 +284,27 @@ mod tests {
       Some(DEFAULT_WINDOW_TITLE)
     );
     assert_eq!(next_window_title(&mut state, &app), None);
+  }
+
+  #[test]
+  fn back_key_clears_playlist_filter_before_navigation_pop() {
+    let mut app = app();
+    app.track_table.context = Some(TrackTableContext::MyPlaylists);
+    app.playlist_track_table_id = Some(
+      PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+        .unwrap()
+        .into_static(),
+    );
+    app.active_playlist_track_filter = Some("query".to_string());
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+
+    assert!(back_key_clears_playlist_filter(
+      &mut app,
+      ActiveBlock::TrackTable
+    ));
+
+    assert!(app.active_playlist_track_filter.is_none());
+    assert_eq!(app.get_current_route().id, RouteId::TrackTable);
   }
 }
 
@@ -561,30 +592,32 @@ pub async fn start_ui(
         } else if current_active_block == ActiveBlock::Input {
           handlers::input_handler(key, &mut app);
         } else if key == app.user_config.keys.back {
-          if current_active_block == ActiveBlock::Settings {
-            handlers::handle_app(key, &mut app);
-          } else if app.get_current_route().active_block == ActiveBlock::AnnouncementPrompt {
-            if let Some(dismissed_id) = app.dismiss_active_announcement() {
-              app.user_config.mark_announcement_seen(dismissed_id);
-              if let Err(error) = app.user_config.save_config() {
-                app.handle_error(anyhow!(
-                  "Failed to persist dismissed announcement: {}",
-                  error
-                ));
+          if !back_key_clears_playlist_filter(&mut app, current_active_block) {
+            if current_active_block == ActiveBlock::Settings {
+              handlers::handle_app(key, &mut app);
+            } else if app.get_current_route().active_block == ActiveBlock::AnnouncementPrompt {
+              if let Some(dismissed_id) = app.dismiss_active_announcement() {
+                app.user_config.mark_announcement_seen(dismissed_id);
+                if let Err(error) = app.user_config.save_config() {
+                  app.handle_error(anyhow!(
+                    "Failed to persist dismissed announcement: {}",
+                    error
+                  ));
+                }
               }
-            }
 
-            if app.active_announcement.is_none() {
-              app.pop_navigation_stack();
-            }
-          } else if app.get_current_route().active_block != ActiveBlock::Input {
-            let pop_result = match app.pop_navigation_stack() {
-              Some(ref x) if x.id == RouteId::Search => app.pop_navigation_stack(),
-              Some(x) => Some(x),
-              None => None,
-            };
-            if pop_result.is_none() {
-              app.push_navigation_stack(RouteId::ExitPrompt, ActiveBlock::ExitPrompt);
+              if app.active_announcement.is_none() {
+                app.pop_navigation_stack();
+              }
+            } else if app.get_current_route().active_block != ActiveBlock::Input {
+              let pop_result = match app.pop_navigation_stack() {
+                Some(ref x) if x.id == RouteId::Search => app.pop_navigation_stack(),
+                Some(x) => Some(x),
+                None => None,
+              };
+              if pop_result.is_none() {
+                app.push_navigation_stack(RouteId::ExitPrompt, ActiveBlock::ExitPrompt);
+              }
             }
           }
         } else {

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -111,7 +111,7 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
     vec![
       String::from("Move selection right"),
       String::from("l | <Right Arrow Key> | <Ctrl+f>"),
-      String::from("General"),
+      String::from("General (Ctrl+f searches inside playlist track tables)"),
     ],
     vec![
       String::from("Move selection to top of list"),
@@ -233,6 +233,16 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("Remove selected track from current playlist"),
       String::from("x"),
       String::from("Track table (playlist views)"),
+    ],
+    vec![
+      String::from("Search tracks in current playlist"),
+      String::from("<Ctrl+f>"),
+      String::from("Track table (playlist views)"),
+    ],
+    vec![
+      String::from("Clear playlist track search filter"),
+      key_bindings.back.to_string(),
+      String::from("Track table (filtered playlist views)"),
     ],
     vec![
       String::from("Start playback or enter album/artist/playlist"),

--- a/src/tui/ui/search.rs
+++ b/src/tui/ui/search.rs
@@ -1,4 +1,4 @@
-use crate::core::app::{ActiveBlock, App, SearchResultBlock};
+use crate::core::app::{ActiveBlock, App, InputContext, SearchResultBlock};
 use ratatui::{
   layout::{Constraint, Layout, Rect},
   style::Style,
@@ -74,12 +74,17 @@ pub fn draw_input_and_help_box(f: &mut Frame<'_>, app: &App, layout_chunk: Rect)
   };
   app.input_scroll_offset.set(scroll_offset);
 
+  let input_title = match app.input_context {
+    InputContext::PlaylistTrackSearch => "Search Playlist",
+    InputContext::GlobalSearch => "Search",
+  };
+
   let input = Paragraph::new(lines).scroll((0, scroll_offset)).block(
     Block::default()
       .borders(Borders::ALL)
       .border_type(border_type)
       .title(Span::styled(
-        "Search",
+        input_title,
         get_color(highlight_state, app.user_config.theme),
       ))
       .style(app.user_config.theme.base_style())

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -415,11 +415,25 @@ pub fn draw_song_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     })
     .collect::<Vec<TableItem>>();
 
+  let title = if app.is_playlist_track_table_context() {
+    if let Some(query) = app.pending_playlist_track_search.as_ref() {
+      format!("Songs (searching: {query}...)")
+    } else {
+      app
+        .active_playlist_track_filter
+        .as_ref()
+        .map(|query| format!("Songs (filtered: {query})"))
+        .unwrap_or_else(|| "Songs".to_string())
+    }
+  } else {
+    "Songs".to_string()
+  };
+
   draw_table(
     f,
     app,
     layout_chunk,
-    ("Songs", &header),
+    (&title, &header),
     &items,
     app.track_table.selected_index,
     highlight_state,


### PR DESCRIPTION
This pull request adds a new feature for searching tracks within a playlist, along with supporting UI and backend changes. Users can now press `<Ctrl+f>` in a playlist track table to search for tracks by title, artist, or album, with case-insensitive and multi-term matching. The search is performed client-side, provides loading feedback for large playlists, and allows clearing the filter with `q` or the configured back key. The implementation includes state management, search logic, integration with the event system, and comprehensive tests.

**Playlist Track Search Feature:**

* Added playlist-internal track search, activated with `<Ctrl+f>`, supporting client-side, case-insensitive matching across track title, artists, and album. Search results are sorted and preserve original playlist order; loading feedback is shown during large scans, and the filter can be cleared to restore the cached playlist view (`CHANGELOG.md`, `src/core/app.rs`, `src/infra/network/library.rs`, `src/tui/handlers/input.rs`).

**Backend and Event System Integration:**

* Introduced new `IoEvent::SearchPlaylistTracks` and corresponding handler in the network layer, enabling asynchronous search requests and results application (`src/infra/network/mod.rs`, `src/infra/network/library.rs`, `src/core/app.rs`). 

**State Management Enhancements:**

* Added new state fields and methods to `App` for tracking the active playlist filter, pending searches, and input context, ensuring correct UI and data restoration when searches are cleared or playlist context changes (`src/core/app.rs`). [[1]](diffhunk://#diff-d69494577e25788f34d7939ac2469556214ff93a79c50c1d8845d7217b9916dcR695) 

**Search Logic and Matching:**

* Implemented case-insensitive, multi-term matching for playlist track search, scanning across title, artist, and album fields, with tests verifying matching and non-matching behavior (`src/infra/network/library.rs`). 

**Testing:**

* Added and extended tests to cover playlist search result application, filter clearing, and search term logic, ensuring robust behavior for edge cases and UI state restoration (`src/core/app.rs`, `src/infra/network/library.rs`). 