### PR TITLE
feat: add miniplayer mode

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -234,6 +234,7 @@ pub enum ActiveBlock {
   Artists,
   LyricsView,
   CoverArtView,
+  MiniPlayer,
   Dialog(DialogContext),
 
   AnnouncementPrompt,
@@ -253,6 +254,7 @@ pub enum RouteId {
   Artist,
   LyricsView,
   CoverArtView,
+  MiniPlayer,
   Error,
   Home,
   RecentlyPlayed,
@@ -3252,6 +3254,12 @@ impl App {
           description: "Open lyrics view".to_string(),
           value: SettingValue::Key(key_to_string(&self.user_config.keys.lyrics_view)),
         },
+        SettingItem {
+          id: "keys.miniplayer_view".to_string(),
+          name: "Miniplayer View".to_string(),
+          description: "Toggle full-screen playbar view".to_string(),
+          value: SettingValue::Key(key_to_string(&self.user_config.keys.miniplayer_view)),
+        },
         #[cfg(feature = "cover-art")]
         SettingItem {
           id: "keys.cover_art_view".to_string(),
@@ -3699,6 +3707,13 @@ impl App {
           if let SettingValue::Key(v) = &setting.value {
             if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
               self.user_config.keys.lyrics_view = key;
+            }
+          }
+        }
+        "keys.miniplayer_view" => {
+          if let SettingValue::Key(v) = &setting.value {
+            if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
+              self.user_config.keys.miniplayer_view = key;
             }
           }
         }

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -48,6 +48,30 @@ pub fn fullscreen_view_layout(behavior: &BehaviorConfig, area: Rect) -> (Rect, O
   (content_area, Some(playbar_area))
 }
 
+/// Returns the compact playbar area used by the full-screen miniplayer.
+///
+/// The normal playbar layout is optimized for a short strip. Miniplayer keeps
+/// that same playbar renderer, but constrains it to a centered stage so wide
+/// terminals do not stretch track metadata across a mostly empty full screen.
+pub fn miniplayer_playbar_area(area: Rect) -> Rect {
+  let horizontal_margin = if area.width >= 100 { 4 } else { 1 };
+  let vertical_margin = if area.height >= 30 { 4 } else { 1 };
+
+  let available_width = area.width.saturating_sub(horizontal_margin * 2);
+  let available_height = area.height.saturating_sub(vertical_margin * 2);
+  let width = available_width.min(120).max(available_width.min(1));
+  let height = available_height.min(18).max(available_height.min(1));
+
+  Rect {
+    x: area.x.saturating_add(area.width.saturating_sub(width) / 2),
+    y: area
+      .y
+      .saturating_add(area.height.saturating_sub(height) / 2),
+    width,
+    height,
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -160,5 +184,19 @@ mod tests {
 
     assert_eq!(content, Rect::new(2, 4, 80, 18));
     assert_eq!(playbar, Some(Rect::new(2, 22, 80, 6)));
+  }
+
+  #[test]
+  fn miniplayer_playbar_area_is_compact_and_centered_on_large_terminals() {
+    let area = Rect::new(0, 0, 180, 50);
+
+    assert_eq!(miniplayer_playbar_area(area), Rect::new(30, 16, 120, 18));
+  }
+
+  #[test]
+  fn miniplayer_playbar_area_uses_available_space_on_small_terminals() {
+    let area = Rect::new(0, 0, 60, 12);
+
+    assert_eq!(miniplayer_playbar_area(area), Rect::new(1, 1, 58, 10));
   }
 }

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -606,6 +606,7 @@ pub struct KeyBindingsString {
   audio_analysis: Option<String>,
   #[serde(alias = "basic_view")]
   lyrics_view: Option<String>,
+  miniplayer_view: Option<String>,
   cover_art_view: Option<String>,
   add_item_to_queue: Option<String>,
   show_queue: Option<String>,
@@ -643,6 +644,7 @@ pub struct KeyBindings {
   pub copy_album_url: Key,
   pub audio_analysis: Key,
   pub lyrics_view: Key,
+  pub miniplayer_view: Key,
   pub cover_art_view: Key,
   pub add_item_to_queue: Key,
   pub show_queue: Key,
@@ -800,6 +802,7 @@ impl UserConfig {
         copy_album_url: Key::Char('C'),
         audio_analysis: Key::Char('v'),
         lyrics_view: Key::Char('B'),
+        miniplayer_view: Key::Char('T'),
         cover_art_view: Key::Char('G'),
         add_item_to_queue: Key::Char('z'),
         show_queue: Key::Char('Q'),
@@ -921,6 +924,7 @@ impl UserConfig {
     to_keys!(copy_album_url);
     to_keys!(audio_analysis);
     to_keys!(lyrics_view);
+    to_keys!(miniplayer_view);
     to_keys!(cover_art_view);
     to_keys!(add_item_to_queue);
     to_keys!(show_queue);
@@ -1321,6 +1325,7 @@ impl UserConfig {
       copy_album_url: Some(key_to_config_string(self.keys.copy_album_url)),
       audio_analysis: Some(key_to_config_string(self.keys.audio_analysis)),
       lyrics_view: Some(key_to_config_string(self.keys.lyrics_view)),
+      miniplayer_view: Some(key_to_config_string(self.keys.miniplayer_view)),
       cover_art_view: Some(key_to_config_string(self.keys.cover_art_view)),
       add_item_to_queue: Some(key_to_config_string(self.keys.add_item_to_queue)),
       show_queue: Some(key_to_config_string(self.keys.show_queue)),
@@ -1562,6 +1567,48 @@ mod tests {
     // Missing field defaults to None (not overriding the config default)
     let config: BehaviorConfigString = serde_yaml::from_str("{}").unwrap();
     assert_eq!(config.startup_behavior, None);
+  }
+
+  #[test]
+  fn miniplayer_keybinding_loads_from_yaml() {
+    use super::{KeyBindingsString, UserConfig};
+    use crate::tui::event::Key;
+
+    let keybindings: KeyBindingsString = serde_yaml::from_str("miniplayer_view: ctrl-t").unwrap();
+    let mut config = UserConfig::new();
+    config.load_keybindings(keybindings).unwrap();
+
+    assert_eq!(config.keys.miniplayer_view, Key::Ctrl('t'));
+  }
+
+  #[test]
+  fn miniplayer_keybinding_saves_to_yaml() {
+    use super::{UserConfig, UserConfigPaths};
+    use crate::tui::event::Key;
+    use std::fs;
+
+    let config_dir = std::env::temp_dir().join(format!(
+      "spotatui-miniplayer-config-test-{}-{}",
+      std::process::id(),
+      std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+    fs::create_dir_all(&config_dir).unwrap();
+    let config_file_path = config_dir.join("config.yml");
+
+    let mut config = UserConfig::new();
+    config.path_to_config = Some(UserConfigPaths {
+      config_file_path: config_file_path.clone(),
+    });
+    config.keys.miniplayer_view = Key::Ctrl('t');
+    config.save_config().unwrap();
+
+    let saved = fs::read_to_string(&config_file_path).unwrap();
+    assert!(saved.contains("miniplayer_view: ctrl-t"));
+
+    fs::remove_dir_all(config_dir).unwrap();
   }
 
   #[cfg(feature = "cover-art")]

--- a/src/tui/handlers/miniplayer.rs
+++ b/src/tui/handlers/miniplayer.rs
@@ -1,0 +1,12 @@
+use super::playbar;
+use crate::core::app::App;
+use crate::tui::event::Key;
+
+pub fn handler(key: Key, app: &mut App) {
+  if key == app.user_config.keys.back {
+    app.pop_navigation_stack();
+    return;
+  }
+
+  playbar::handle_action_key(key, app);
+}

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -18,6 +18,7 @@ mod home;
 mod input;
 mod library;
 mod lyrics_view;
+mod miniplayer;
 mod mouse;
 mod party;
 mod playbar;
@@ -177,6 +178,13 @@ pub fn handle_app(key: Key, app: &mut App) {
     _ if key == app.user_config.keys.lyrics_view => {
       app.push_navigation_stack(RouteId::LyricsView, ActiveBlock::LyricsView);
     }
+    _ if key == app.user_config.keys.miniplayer_view => {
+      if is_input_mode(app) {
+        handle_block_events(key, app);
+      } else {
+        toggle_miniplayer(app);
+      }
+    }
     #[cfg(feature = "cover-art")]
     _ if key == app.user_config.keys.cover_art_view => {
       app.push_navigation_stack(RouteId::CoverArtView, ActiveBlock::CoverArtView);
@@ -325,6 +333,9 @@ fn handle_block_events(key: Key, app: &mut App) {
     ActiveBlock::LyricsView => {
       lyrics_view::handler(key, app);
     }
+    ActiveBlock::MiniPlayer => {
+      miniplayer::handler(key, app);
+    }
     ActiveBlock::CoverArtView => {
       #[cfg(feature = "cover-art")]
       cover_art_view::handler(key, app);
@@ -384,7 +395,7 @@ fn handle_escape(app: &mut App) {
     ActiveBlock::Party => {
       app.pop_navigation_stack();
     }
-    ActiveBlock::LyricsView | ActiveBlock::CoverArtView => {
+    ActiveBlock::LyricsView | ActiveBlock::CoverArtView | ActiveBlock::MiniPlayer => {
       app.pop_navigation_stack();
     }
     // These are global views that have no active/inactive distinction so do nothing
@@ -405,6 +416,14 @@ fn handle_escape(app: &mut App) {
     _ => {
       app.set_current_route_state(Some(ActiveBlock::Empty), None);
     }
+  }
+}
+
+fn toggle_miniplayer(app: &mut App) {
+  if app.get_current_route().id == RouteId::MiniPlayer {
+    app.pop_navigation_stack();
+  } else {
+    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
   }
 }
 
@@ -565,6 +584,68 @@ mod tests {
 
     // In input mode, 'F' should be added to the input buffer
     assert_eq!(app.input, vec!['F']);
+  }
+
+  #[test]
+  fn miniplayer_key_pushes_miniplayer_from_normal_route() {
+    let mut app = App::default();
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+
+    handle_app(Key::Char('T'), &mut app);
+
+    let route = app.get_current_route();
+    assert_eq!(route.id, RouteId::MiniPlayer);
+    assert_eq!(route.active_block, ActiveBlock::MiniPlayer);
+  }
+
+  #[test]
+  fn miniplayer_key_exits_when_already_in_miniplayer() {
+    let mut app = App::default();
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
+
+    handle_app(Key::Char('T'), &mut app);
+
+    let route = app.get_current_route();
+    assert_eq!(route.id, RouteId::TrackTable);
+    assert_eq!(route.active_block, ActiveBlock::TrackTable);
+  }
+
+  #[test]
+  fn miniplayer_key_is_not_intercepted_in_input_mode() {
+    let mut app = App::default();
+    app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
+
+    handle_app(Key::Char('T'), &mut app);
+
+    assert_eq!(app.input, vec!['T']);
+    assert_ne!(app.get_current_route().id, RouteId::MiniPlayer);
+  }
+
+  #[test]
+  fn back_key_exits_miniplayer_handler() {
+    let mut app = App::default();
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
+
+    handle_app(app.user_config.keys.back, &mut app);
+
+    let route = app.get_current_route();
+    assert_eq!(route.id, RouteId::TrackTable);
+    assert_eq!(route.active_block, ActiveBlock::TrackTable);
+  }
+
+  #[test]
+  fn miniplayer_does_not_inherit_playbar_layout_navigation() {
+    let mut app = App::default();
+    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
+
+    handle_app(Key::Up, &mut app);
+
+    let route = app.get_current_route();
+    assert_eq!(route.id, RouteId::MiniPlayer);
+    assert_eq!(route.active_block, ActiveBlock::MiniPlayer);
   }
 
   #[cfg(target_os = "macos")]

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -3,7 +3,8 @@ use crate::core::app::{
   ActiveBlock, App, RouteId, SettingValue, SettingsCategory, LIBRARY_OPTIONS,
 };
 use crate::core::layout::{
-  fullscreen_view_layout, library_constraints, playbar_constraint, sidebar_constraints,
+  fullscreen_view_layout, library_constraints, miniplayer_playbar_area, playbar_constraint,
+  sidebar_constraints,
 };
 use crate::tui::event::Key;
 use crate::tui::ui::player::playbar_control_at;
@@ -30,12 +31,32 @@ pub fn handler(mouse: MouseEvent, app: &mut App) {
   }
 
   if current_route_id == RouteId::LyricsView {
-    handle_fullscreen_view_mouse(ActiveBlock::LyricsView, mouse, app);
+    handle_fullscreen_playbar_mouse(
+      ActiveBlock::LyricsView,
+      fullscreen_view_playbar_area(app),
+      mouse,
+      app,
+    );
     return;
   }
 
   if current_route_id == RouteId::CoverArtView {
-    handle_fullscreen_view_mouse(ActiveBlock::CoverArtView, mouse, app);
+    handle_fullscreen_playbar_mouse(
+      ActiveBlock::CoverArtView,
+      fullscreen_view_playbar_area(app),
+      mouse,
+      app,
+    );
+    return;
+  }
+
+  if current_route_id == RouteId::MiniPlayer {
+    handle_fullscreen_playbar_mouse(
+      ActiveBlock::MiniPlayer,
+      miniplayer_view_playbar_area(app),
+      mouse,
+      app,
+    );
     return;
   }
 
@@ -185,8 +206,13 @@ fn handle_settings_mouse(mouse: MouseEvent, app: &mut App) {
   }
 }
 
-fn handle_fullscreen_view_mouse(focus_block: ActiveBlock, mouse: MouseEvent, app: &mut App) {
-  let Some(playbar_area) = fullscreen_view_playbar_area(app) else {
+fn handle_fullscreen_playbar_mouse(
+  focus_block: ActiveBlock,
+  playbar_area: Option<Rect>,
+  mouse: MouseEvent,
+  app: &mut App,
+) {
+  let Some(playbar_area) = playbar_area else {
     return;
   };
 
@@ -359,6 +385,7 @@ fn is_main_layout_mouse_interactive(active_block: ActiveBlock) -> bool {
       | ActiveBlock::Analysis
       | ActiveBlock::LyricsView
       | ActiveBlock::CoverArtView
+      | ActiveBlock::MiniPlayer
       | ActiveBlock::AnnouncementPrompt
       | ActiveBlock::ExitPrompt
       | ActiveBlock::Settings
@@ -814,6 +841,19 @@ fn fullscreen_view_playbar_area(app: &App) -> Option<Rect> {
   playbar_area
 }
 
+fn miniplayer_view_playbar_area(app: &App) -> Option<Rect> {
+  if app.size.width == 0 || app.size.height == 0 {
+    return None;
+  }
+
+  Some(miniplayer_playbar_area(Rect::new(
+    0,
+    0,
+    app.size.width,
+    app.size.height,
+  )))
+}
+
 fn main_layout_areas(app: &App) -> Option<MainLayoutAreas> {
   if app.size.width == 0 || app.size.height == 0 {
     return None;
@@ -1248,6 +1288,32 @@ mod tests {
     assert_eq!(route.id, RouteId::LyricsView);
     assert_eq!(route.active_block, ActiveBlock::LyricsView);
     assert_eq!(route.hovered_block, ActiveBlock::LyricsView);
+  }
+
+  #[test]
+  fn click_miniplayer_control_triggers_action_and_keeps_miniplayer_focus() {
+    let mut app = App::default();
+    app.size = Size {
+      width: 160,
+      height: 50,
+    };
+    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
+    with_playbar_context(&mut app);
+
+    let playbar_area = miniplayer_playbar_area(Rect::new(0, 0, app.size.width, app.size.height));
+    let (x, y) = find_playbar_control_click(&app, playbar_area, PlaybarControl::PlayPause);
+    assert!(!app.is_loading);
+
+    handler(
+      mouse_event(MouseEventKind::Down(MouseButton::Left), x, y),
+      &mut app,
+    );
+
+    assert!(app.is_loading);
+    let route = app.get_current_route();
+    assert_eq!(route.id, RouteId::MiniPlayer);
+    assert_eq!(route.active_block, ActiveBlock::MiniPlayer);
+    assert_eq!(route.hovered_block, ActiveBlock::MiniPlayer);
   }
 
   #[test]

--- a/src/tui/handlers/playbar.rs
+++ b/src/tui/handlers/playbar.rs
@@ -10,14 +10,24 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::up_event(k) => {
       app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::MyPlaylists));
     }
-    Key::Char('s') => {
+    k => {
+      handle_action_key(k, app);
+    }
+  };
+}
+
+pub(crate) fn handle_action_key(key: Key, app: &mut App) -> bool {
+  match key {
+    k if k == app.user_config.keys.like_track => {
       handle_control(PlaybarControl::Like, app);
+      true
     }
     Key::Char('w') => {
       add_currently_playing_track_to_playlist(app);
+      true
     }
-    _ => {}
-  };
+    _ => false,
+  }
 }
 
 pub(crate) fn handle_control(control: PlaybarControl, app: &mut App) {

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -363,6 +363,7 @@ pub async fn start_ui(
           ActiveBlock::SelectDevice => ui::draw_device_list(f, &app),
           ActiveBlock::Analysis => ui::audio_analysis::draw(f, &app),
           ActiveBlock::LyricsView => ui::draw_lyrics_view(f, &app),
+          ActiveBlock::MiniPlayer => ui::draw_miniplayer(f, &app),
           #[cfg(feature = "cover-art")]
           ActiveBlock::CoverArtView => ui::draw_cover_art_view(f, &app),
           ActiveBlock::AnnouncementPrompt => ui::draw_announcement_prompt(f, &app),

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -153,6 +153,11 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       key_bindings.lyrics_view.to_string(),
       String::from("General"),
     ],
+    vec![
+      String::from("Toggle miniplayer view"),
+      key_bindings.miniplayer_view.to_string(),
+      String::from("General"),
+    ],
     #[cfg(feature = "cover-art")]
     vec![
       String::from("Go to cover art view"),

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -26,6 +26,7 @@ pub use self::home::draw_home;
 pub use self::library::draw_user_block;
 #[cfg(feature = "cover-art")]
 pub use self::player::draw_cover_art_view;
+pub use self::player::draw_miniplayer;
 pub use self::player::{draw_device_list, draw_lyrics_view, draw_playbar};
 pub use self::popups::{
   draw_announcement_prompt, draw_dialog, draw_error_screen, draw_exit_prompt, draw_help_menu,
@@ -133,6 +134,7 @@ pub fn draw_routes(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     | RouteId::Analysis
     | RouteId::LyricsView
     | RouteId::CoverArtView
+    | RouteId::MiniPlayer
     | RouteId::AnnouncementPrompt
     | RouteId::ExitPrompt
     | RouteId::Settings

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -1,6 +1,6 @@
 use crate::core::{
   app::{ActiveBlock, App},
-  layout::fullscreen_view_layout,
+  layout::{fullscreen_view_layout, miniplayer_playbar_area},
 };
 use ratatui::{
   layout::{Alignment, Constraint, Layout, Position, Rect},
@@ -433,6 +433,11 @@ pub fn draw_cover_art_view(f: &mut Frame<'_>, app: &App) {
   }
 }
 
+pub fn draw_miniplayer(f: &mut Frame<'_>, app: &App) {
+  let area = miniplayer_playbar_area(f.area());
+  draw_playbar(f, app, area);
+}
+
 #[cfg(feature = "cover-art")]
 fn draw_cover_art_content(f: &mut Frame<'_>, app: &App, area: Rect) {
   use ratatui::widgets::Clear;
@@ -711,8 +716,14 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
 
       let current_route = app.get_current_route();
       let highlight_state = (
-        current_route.active_block == ActiveBlock::PlayBar,
-        current_route.hovered_block == ActiveBlock::PlayBar,
+        matches!(
+          current_route.active_block,
+          ActiveBlock::PlayBar | ActiveBlock::MiniPlayer
+        ),
+        matches!(
+          current_route.hovered_block,
+          ActiveBlock::PlayBar | ActiveBlock::MiniPlayer
+        ),
       );
 
       let title_block = Block::default()


### PR DESCRIPTION
This pull request introduces a new "Miniplayer" full-screen playbar view to the application, along with full keyboard and mouse support, configuration, and tests. The changes touch the core app logic, user configuration, layout, event handling, and UI, ensuring the miniplayer is seamlessly integrated and behaves consistently with other full-screen views.

**Key changes include:**

### Miniplayer View Integration

* Added `MiniPlayer` variants to the `ActiveBlock` and `RouteId` enums, enabling navigation and state management for the new view. 
* Implemented the `toggle_miniplayer` function and related event handling in `src/tui/handlers/mod.rs`, allowing users to enter or exit the miniplayer view via a configurable keybinding, with proper stack navigation and escape handling.
* Added the `draw_miniplayer` rendering call to the UI runner, ensuring the miniplayer is displayed when active.

### Keybinding and Configuration

* Introduced a new configurable keybinding (`miniplayer_view`) in `UserConfig` and related structs, including YAML serialization/deserialization, default assignment, and settings UI integration. 
* Added documentation and help text for the miniplayer keybinding in the help UI.

### Layout and Mouse Support

* Added `miniplayer_playbar_area` layout function to center and size the playbar appropriately in the miniplayer view, with tests for various terminal sizes. 
* Updated mouse event handling to support playbar interactions in the miniplayer view, including area calculation and focus management.

### Event Handling and Playbar Logic

* Added a dedicated handler for the miniplayer view, delegating key events to the playbar controls and supporting navigation.
* Refactored playbar event handling to allow action keys to be triggered from the miniplayer view as well.

### Tests

* Added comprehensive tests for miniplayer navigation, keybinding configuration, and mouse interaction, ensuring robust behavior and no regressions. 