### PR TITLE
fix: scroll settings list to keep selection in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Native device selection and playback startup**: Made the local `spotatui` Connect device selectable when Spotify's devices API omits it, recovered stale native streaming sessions after long idle, fixed `Esc`/`Enter` handling in the device selector, and avoided `NO_ACTIVE_DEVICE` playback failures when native streaming is connected but no Spotify playback context is active ([#292](https://github.com/LargeModGames/spotatui/issues/292)).
 - **Search box no longer traps focus on submit**: Pressing `Enter` to run a search now always moves focus to the results list, including when re-searching while already on the Search screen (previously focus stayed stuck in the input box) ([#191](https://github.com/LargeModGames/spotatui/issues/191)).
 - **Cover-art load failures are non-fatal**: A failed album-image fetch is now logged and ignored instead of surfacing a blocking error and aborting the now-playing update, so playback metadata keeps updating when artwork can't be loaded ([#142](https://github.com/LargeModGames/spotatui/issues/142)).
+- **Settings list scrolls to follow the selection**: The Settings screen now renders its item list statefully, so the viewport scrolls to keep the highlighted setting in view instead of clipping items below the fold on shorter terminals (previously only fully visible when the terminal was tall enough to show every item). The selected row is now also marked with a `▶` indicator, matching the other list screens.
 
 ## [v0.38.6] 2026-05-28
 

--- a/src/tui/ui/settings.rs
+++ b/src/tui/ui/settings.rs
@@ -3,7 +3,7 @@ use ratatui::{
   layout::{Alignment, Constraint, Layout, Rect},
   style::{Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs},
+  widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs},
   Frame,
 };
 
@@ -162,7 +162,10 @@ fn draw_settings_list(f: &mut Frame<'_>, app: &App, area: Rect) {
       ),
     );
 
-  f.render_widget(list, area);
+  let mut state = ListState::default();
+  state.select(Some(app.settings_selected_index));
+
+  f.render_stateful_widget(list, area, &mut state);
 }
 
 fn format_terminal_input_caps(app: &App) -> String {


### PR DESCRIPTION

# Summary

The Settings screen list could not be scrolled past what initially fit on screen. Pressing Down moved the highlight through the visible rows, but the viewport never scrolled to reveal items below the fold, so the lower settings were unreachable on shorter terminals.

- The settings list was the only scrollable list in the app rendered *statelessly* (`f.render_widget`). A stateless ratatui `List` has no scroll offset, so it always draws from item 0 and never follows the selection. The visible highlight is faked by per-item span styling, so it moved on screen, but once the selection passed the viewport bottom the selected row went off-screen with no scroll.
- Fixed by rendering with a `ListState` seeded from `settings_selected_index` (`f.render_stateful_widget`), mirroring `discover.rs`, `util.rs`, and every other list screen, so ratatui recomputes the offset each frame to keep the selection visible.

Not actually platform-specific despite being reported on Windows: it only looked fine on Linux because that terminal was tall enough to show all 25 items at once.

# Testing

- cargo fmt --all
- cargo clippy --no-default-features --features telemetry -- -D warnings — clean
- cargo test --no-default-features --features telemetry — 233 passed; 0 failed
- Manual: opened Settings, shrank the terminal so items overflow, and confirmed the list now scrolls all the way down to "Announcements Feed URL" and back, keeping the highlighted row in view.

# Additional notes

- Stateful rendering activates the already-configured `▶ ` highlight symbol, so the selected row now shows the `▶` arrow and all rows gain a 2-column left gutter for it. This matches the other list screens; no other layout or logic changes.
