### PR TITLE
Fix ghost spotatui Connect devices accumulating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- **Ghost `spotatui` Connect devices**: The native streaming device id is now generated once and persisted in the streaming cache, and the old librespot session is shut down whenever the player is replaced, so app restarts and streaming recoveries no longer leave a trail of dead `spotatui` entries in Spotify's device list ([#297](https://github.com/LargeModGames/spotatui/issues/297)).
 - **Native device selection and playback startup**: Made the local `spotatui` Connect device selectable when Spotify's devices API omits it, recovered stale native streaming sessions after long idle, fixed `Esc`/`Enter` handling in the device selector, and avoided `NO_ACTIVE_DEVICE` playback failures when native streaming is connected but no Spotify playback context is active ([#292](https://github.com/LargeModGames/spotatui/issues/292)).
 - **Search box no longer traps focus on submit**: Pressing `Enter` to run a search now always moves focus to the results list, including when re-searching while already on the Search screen (previously focus stayed stuck in the input box) ([#191](https://github.com/LargeModGames/spotatui/issues/191)).
 - **Cover-art load failures are non-fatal**: A failed album-image fetch is now logged and ignored instead of surfacing a blocking error and aborting the now-playing update, so playback metadata keeps updating when artwork can't be loaded ([#142](https://github.com/LargeModGames/spotatui/issues/142)).

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1403,6 +1403,9 @@ impl App {
       return false;
     }
 
+    // Stop the old spirc before dropping our reference so the dead session
+    // doesn't linger as a ghost Connect device (#297).
+    player.shutdown();
     self.streaming_player = None;
     self.is_streaming_active = false;
     self.native_activation_pending = false;

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -92,6 +92,13 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
         let recovered_player = Arc::new(recovered_player);
         {
           let mut app = ctx.app.lock().await;
+          // A disconnected old player may still be referenced here; shut its
+          // spirc down before replacing it so it can't leave a ghost device (#297).
+          if let Some(old) = app.streaming_player.take() {
+            if !Arc::ptr_eq(&old, &recovered_player) {
+              old.shutdown();
+            }
+          }
           app.streaming_player = Some(Arc::clone(&recovered_player));
           app.set_status_message("Native streaming recovered.", 6);
           if request.reselect_device {
@@ -633,6 +640,8 @@ async fn disconnect_streaming_player(
   let reselect_device = allow_reselect_device && current_playback_matches_native(&app_lock, player);
 
   app_lock.streaming_player = None;
+  // Stop the old Connect session so it doesn't linger as a ghost device (#297).
+  player.shutdown();
   app_lock.is_streaming_active = false;
   app_lock.native_activation_pending = false;
   app_lock.native_device_id = None;

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -343,10 +343,15 @@ impl StreamingPlayer {
       resolve_streaming_credentials(&cache, auth_mode)?;
 
     // Create session configuration using spotify-player's client_id
-    let session_config = SessionConfig {
+    let mut session_config = SessionConfig {
       client_id: SPOTIFY_PLAYER_CLIENT_ID.to_string(),
       ..Default::default()
     };
+    // Reuse a persisted device id so every launch and recovery registers as the
+    // same Spotify Connect device instead of accumulating ghost entries (#297).
+    if let Some(device_id) = get_or_create_device_id(cache_path.as_deref()) {
+      session_config.device_id = device_id;
+    }
 
     // Create session (Spirc will handle connection)
     let session = Session::new(session_config, Some(cache));
@@ -674,6 +679,15 @@ impl StreamingPlayer {
   }
 }
 
+impl Drop for StreamingPlayer {
+  fn drop(&mut self) {
+    // Backstop: stop the spirc when the last reference drops so a replaced
+    // player can't linger as a ghost Connect device (#297). Idempotent.
+    self.spirc_alive.store(false, Ordering::Relaxed);
+    let _ = self.spirc.shutdown();
+  }
+}
+
 // Re-export PlayerEvent for use in other modules
 pub use librespot_playback::player::PlayerEvent;
 
@@ -687,9 +701,54 @@ fn should_retry_with_fresh_credentials(
   auth_error && used_cached && !already_retried
 }
 
+/// Stable Connect device id, persisted in the streaming cache dir so every
+/// launch and every in-app recovery registers as the same device (#297).
+fn get_or_create_device_id(cache_path: Option<&std::path::Path>) -> Option<String> {
+  let cache_path = cache_path?;
+  let id_file = cache_path.join("device_id");
+  if let Ok(existing) = std::fs::read_to_string(&id_file) {
+    let trimmed = existing.trim();
+    if !trimmed.is_empty() {
+      return Some(trimmed.to_string());
+    }
+  }
+  let id = new_device_id_string();
+  let _ = std::fs::create_dir_all(cache_path);
+  let _ = std::fs::write(&id_file, &id);
+  Some(id)
+}
+
+/// Hyphenated UUID-v4-shaped string, matching librespot's default device id format.
+fn new_device_id_string() -> String {
+  use rand::RngCore;
+  let mut b = [0u8; 16];
+  rand::thread_rng().fill_bytes(&mut b);
+  b[6] = (b[6] & 0x0f) | 0x40;
+  b[8] = (b[8] & 0x3f) | 0x80;
+  format!(
+    "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+    b[0],
+    b[1],
+    b[2],
+    b[3],
+    b[4],
+    b[5],
+    b[6],
+    b[7],
+    b[8],
+    b[9],
+    b[10],
+    b[11],
+    b[12],
+    b[13],
+    b[14],
+    b[15]
+  )
+}
+
 #[cfg(test)]
 mod tests {
-  use super::should_retry_with_fresh_credentials;
+  use super::{get_or_create_device_id, new_device_id_string, should_retry_with_fresh_credentials};
 
   #[test]
   fn auth_failure_with_cached_creds_triggers_retry() {
@@ -719,6 +778,43 @@ mod tests {
   #[test]
   fn success_never_triggers_retry() {
     assert!(!should_retry_with_fresh_credentials(false, true, false));
+  }
+
+  #[test]
+  fn device_id_string_is_uuid_v4_shaped() {
+    let id = new_device_id_string();
+    assert_eq!(id.len(), 36);
+    for (i, c) in id.char_indices() {
+      match i {
+        8 | 13 | 18 | 23 => assert_eq!(c, '-'),
+        14 => assert_eq!(c, '4'),
+        19 => assert!(matches!(c, '8' | '9' | 'a' | 'b')),
+        _ => assert!(c.is_ascii_hexdigit()),
+      }
+    }
+  }
+
+  #[test]
+  fn device_id_persists_across_calls() {
+    let dir = std::env::temp_dir().join(format!("spotatui_device_id_test_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let first = get_or_create_device_id(Some(&dir)).unwrap();
+    let second = get_or_create_device_id(Some(&dir)).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(
+      std::fs::read_to_string(dir.join("device_id"))
+        .unwrap()
+        .trim(),
+      first
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  #[test]
+  fn device_id_none_without_cache_path() {
+    assert!(get_or_create_device_id(None).is_none());
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the ghost-device symptom of #297 (also reported in #72): users accumulate multiple dead "spotatui" entries in Spotify's Connect device list. Two root causes:

1. **Random device id per session.** `SessionConfig::default()` in librespot 0.8.0 generates a fresh UUID device id every time, so each app launch and each in-app streaming recovery registered a brand-new Connect device. The device id is now generated once, persisted to `<streaming_cache>/device_id`, and reused by every session.
2. **Old spirc never shut down.** Replacing `app.streaming_player` just dropped the Arc, leaving the old librespot session registered with Spotify. `player.shutdown()` is now called at all three replacement sites (`disconnect_streaming_player`, the recovery success branch, and `request_native_streaming_recovery_if_disconnected`), with an `impl Drop for StreamingPlayer` as a backstop.

This intentionally does not touch `src/infra/network/playback.rs`, so it should not conflict with #298, which covers the other #297 symptoms (404 NO_ACTIVE_DEVICE routing and silent resume).

Pre-existing ghost entries are not deleted; they age out of Spotify's list once nothing re-registers them.

## Testing

- `cargo check` (default features, compiles the streaming code): passed
- `cargo test` (default features): 249 passed, including 3 new unit tests for the device id helpers
- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`: passed
- `cargo test --no-default-features --features telemetry`: 233 passed

Note: the new unit tests only compile under default features (streaming), not in the CI telemetry lane.

Manual verification: run the app, restart a few times, and force a recovery (e.g. transfer playback away in the official client); the Connect picker should show exactly one "spotatui" whose device id matches the persisted file and the `Initializing Spirc with device_id=...` log line every time.