### PR TITLE
feat: add setting to disable media key controls (#309)

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3479,6 +3479,14 @@ impl App {
           value: SettingValue::Bool(self.user_config.behavior.keepawake_enabled),
         },
         SettingItem {
+          id: "behavior.enable_media_keys".to_string(),
+          name: "Media Key Controls".to_string(),
+          description:
+            "Let OS media keys, headphone buttons, and remote controls (playerctl, Now Playing) control playback"
+              .to_string(),
+          value: SettingValue::Bool(self.user_config.behavior.enable_media_keys),
+        },
+        SettingItem {
           id: "behavior.startup_behavior".to_string(),
           name: "Startup Behavior".to_string(),
           description: "Playback state when spotatui starts: continue, play, or pause".to_string(),
@@ -3985,6 +3993,11 @@ impl App {
         "behavior.keepawake_enabled" => {
           if let SettingValue::Bool(v) = &setting.value {
             self.user_config.behavior.keepawake_enabled = *v;
+          }
+        }
+        "behavior.enable_media_keys" => {
+          if let SettingValue::Bool(v) = &setting.value {
+            self.user_config.behavior.enable_media_keys = *v;
           }
         }
         "behavior.enable_announcements" => {

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -760,6 +760,7 @@ pub struct BehaviorConfigString {
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: Option<u16>,
   pub keepawake_enabled: Option<bool>,
+  pub enable_media_keys: Option<bool>,
   pub sync_token: Option<String>,
 }
 
@@ -805,6 +806,10 @@ pub struct BehaviorConfig {
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: u16,
   pub keepawake_enabled: bool,
+  /// When false, spotatui ignores OS media-control commands (headphone
+  /// play/pause/skip buttons, media keys, MPRIS/SMTC/Now Playing, playerctl).
+  /// It still publishes track metadata to the OS; it just stops reacting.
+  pub enable_media_keys: bool,
   pub sync_token: Option<String>,
 }
 
@@ -936,6 +941,7 @@ impl UserConfig {
         #[cfg(feature = "cover-art")]
         playbar_cover_art_size_percent: 100,
         keepawake_enabled: true,
+        enable_media_keys: true,
         sync_token: None,
       },
       path_to_config: None,
@@ -1288,6 +1294,9 @@ impl UserConfig {
     if let Some(keepawake_enabled) = behavior_config.keepawake_enabled {
       self.behavior.keepawake_enabled = keepawake_enabled;
     }
+    if let Some(enable_media_keys) = behavior_config.enable_media_keys {
+      self.behavior.enable_media_keys = enable_media_keys;
+    }
     Ok(())
   }
 
@@ -1451,6 +1460,7 @@ impl UserConfig {
       #[cfg(feature = "cover-art")]
       playbar_cover_art_size_percent: Some(self.behavior.playbar_cover_art_size_percent),
       keepawake_enabled: Some(self.behavior.keepawake_enabled),
+      enable_media_keys: Some(self.behavior.enable_media_keys),
     };
 
     // Helper to convert Key to config string

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1319,6 +1319,9 @@ async fn handle_mpris_events(
   use std::sync::atomic::Ordering;
 
   while let Some(event) = event_rx.recv().await {
+    if !app.lock().await.user_config.behavior.enable_media_keys {
+      continue;
+    }
     match event {
       MprisEvent::PlayPause => {
         #[cfg(feature = "streaming")]
@@ -1509,6 +1512,9 @@ async fn handle_macos_media_events(
   use std::sync::atomic::Ordering;
 
   while let Some(event) = event_rx.recv().await {
+    if !app.lock().await.user_config.behavior.enable_media_keys {
+      continue;
+    }
     let Some(player) = player::active_streaming_player(&app).await else {
       continue;
     };
@@ -1555,6 +1561,9 @@ async fn handle_windows_media_events(
   use smtc_tokio::WindowsMediaEvent;
 
   while let Some(event) = event_rx.recv().await {
+    if !app.lock().await.user_config.behavior.enable_media_keys {
+      continue;
+    }
     let player_opt = player::active_streaming_player(&app).await;
 
     let is_native_loaded = app.lock().await.native_track_info.is_some();


### PR DESCRIPTION
Closes #309.

## Problem

Someone with flaky headphones relied on spotatui *not* reacting to media-key requests. Their headphones randomly fire pause/play, and ignoring those was a feature for them. Then #229 added OS media-key support and there was no way to turn it back off.

## Changes

Adds a `behavior.enable_media_keys` setting (default `true`, so nothing changes for existing users) and a **Media Key Controls** toggle in Settings, Behavior. When it's off, spotatui ignores incoming OS media-control commands: media keys, headphone buttons, MPRIS / SMTC / Now Playing, playerctl, etc. It still publishes track metadata to the OS, it just stops *reacting* to control commands.

The check is gated live at the top of all three OS event handlers (`handle_mpris_events` on Linux, `handle_macos_media_events` on macOS, `handle_windows_media_events` on Windows), all of which read the shared `App`. So flipping it in the TUI takes effect on save, no restart needed.

- `src/core/user_config.rs`: new field on `BehaviorConfig` and `BehaviorConfigString`, default true, load/save wiring (absent key stays true)
- `src/core/app.rs`: settings list item plus `apply_settings_changes` arm
- `src/runtime.rs`: identical `enable_media_keys` guard in the three media handlers

## Verification

- `cargo fmt --all`
- `cargo build` (default features, compiles the MPRIS guard; the macOS/Windows guards are `target_os`-gated and identical by construction)
- `cargo clippy --no-default-features --features telemetry -- -D warnings`, clean
- `cargo test --no-default-features --features telemetry`, 252 passed

## Note

With live-gating spotatui still registers as a media player, so the OS routes the key to it and it's silently ignored (playback just keeps going), which is exactly the spurious-pause fix that was asked for. It does *not* pass the key through to a different app; that'd need init-gating and a restart, and isn't what this issue wants.