### PR TITLE
Fix silent native streaming (Spotify CDN HTTP 530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Native streaming silent playback (HTTP 530)**: Native audio no longer fails silently when Spotify's CDN returns HTTP 530 for the first of the candidate URLs it hands out. spotatui now builds librespot from a maintained fork ([spotatui-librespot](https://github.com/LargeModGames/spotatui-librespot)) that backports upstream [PR #1722](https://github.com/librespot-org/librespot/pull/1722) ([#1725](https://github.com/librespot-org/librespot/issues/1725)), falling back to the next CDN URL on any non-206 response. Repeated unavailable tracks now also halt playback instead of stampeding the queue and risking a rate-limit.
 - **Native streaming startup device recovery**: Startup now trusts the local `spotatui` Connect device id, preserves saved external devices, activates the native device when Spotify reports no active playback, and renders an actionable idle playbar so paused native sessions restore without manually opening the device selector ([#301](https://github.com/LargeModGames/spotatui/issues/301)).
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,7 +2442,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "aes",
  "bytes",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "aes",
  "base64",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3090,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "log",
  "oauth2",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "alsa 0.10.0",
  "cpal 0.16.0",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=28bcb231fe26f4db682eb85d1f7ae43aa1a83896#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,8 +2979,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fe76acb49f58165484303edf0e7bd778f0e6d96f5c59e9d6b6fde1a90d36ff"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "aes",
  "bytes",
@@ -2999,8 +2998,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2a21e9e19b906c6676b1a515fc5529d5414f69049f5a167dfb2ea3206e5a27"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -3019,8 +3017,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168bbe1c416980ddd9a969ebd6b50fb6c924eb1a3ded194285fa8ec0e2b1c68b"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "aes",
  "base64",
@@ -3076,8 +3073,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9c688aa2acd3ed2498e31a95d6f2be49c0f18128db8958450ffd628aa88532"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3094,8 +3090,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686417d49c9d2c363392ffe28d6e469daca20a82dc414740930e078f5829661"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "log",
  "oauth2",
@@ -3108,8 +3103,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88258620bf3e6808ea1fadd11639648d77c06280b9f5a4c9d14ea79f6f998af6"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "alsa 0.10.0",
  "cpal 0.16.0",
@@ -3141,8 +3135,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e01f0b2d39f83fa162eb91d4a16313bcf99e77daf258abe8f7b7bcb1160b084"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?branch=spotatui#28bcb231fe26f4db682eb85d1f7ae43aa1a83896"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,14 +148,15 @@ priority = "optional"
 # Native streaming fix: librespot 0.8.0 + backport of upstream PR #1722, which falls back
 # to the next CDN URL when one returns a non-206 status. Some Spotify CDN nodes return
 # HTTP 530, which broke native audio entirely; the official client just tries the next URL.
-# Pinned to our maintained fork (spotatui-librespot) until a fixed librespot is published to crates.io; Cargo.lock
-# pins the exact commit. Note: crates.io publishes ignore [patch], so `cargo install` users
-# need the upstream release.
+# Pinned to our maintained fork (spotatui-librespot) until a fixed librespot is published to
+# crates.io. Pinned by immutable `rev` (not a branch) so release builds stay reproducible even
+# as the `spotatui` branch advances. Note: crates.io publishes ignore [patch], so `cargo install`
+# users need the upstream release.
 [patch.crates-io]
-librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
-librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }
+librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "28bcb231fe26f4db682eb85d1f7ae43aa1a83896" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,18 @@ license-file = ["LICENSE", "4"]
 depends = "$auto"
 section = "utils"
 priority = "optional"
+
+# Native streaming fix: librespot 0.8.0 + backport of upstream PR #1722, which falls back
+# to the next CDN URL when one returns a non-206 status. Some Spotify CDN nodes return
+# HTTP 530, which broke native audio entirely; the official client just tries the next URL.
+# Pinned to our maintained fork (spotatui-librespot) until a fixed librespot is published to crates.io; Cargo.lock
+# pins the exact commit. Note: crates.io publishes ignore [patch], so `cargo install` users
+# need the upstream release.
+[patch.crates-io]
+librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }
+librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", branch = "spotatui" }

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ spotatui can play audio directly without needing spotifyd or the official Spotif
 - Works with media keys, MPRIS (Linux), and macOS Now Playing
 - Premium account required
 - Context-backed native playback prefers Spotify-visible playback starts when it is safe to do so, while raw URI-list playback stays on the stable direct native path
+- Runs on our maintained [librespot fork](https://github.com/LargeModGames/spotatui-librespot), which backports upstream fixes for Spotify's evolving audio delivery (e.g. the HTTP 530 CDN issue that silenced native playback)
 
 > **Known limitation — `error audio key 0 1`:** Since late 2025, Spotify rejects librespot's audio-key requests for some accounts (more common on newer accounts), so native playback can't decrypt audio and fails. This is an upstream Spotify change that affects every librespot-based client (not just spotatui) and can't be fixed here. When it happens, spotatui shows a status-bar message — press `d` and pick an official Spotify Connect device (the desktop or mobile Spotify app) to keep listening. Accounts created before ~2020 are typically unaffected.
 
@@ -296,7 +297,7 @@ After that there is not much to it.
 
 - [ratatui](https://github.com/ratatui-org/ratatui) - Terminal UI framework
 - [rspotify](https://github.com/ramsayleung/rspotify) - Spotify Web API client
-- [librespot](https://github.com/librespot-org/librespot) - Spotify Connect streaming
+- [librespot](https://github.com/librespot-org/librespot) - Spotify Connect streaming (via our maintained fork [spotatui-librespot](https://github.com/LargeModGames/spotatui-librespot), which backports fixes for Spotify's CDN changes)
 - [tokio](https://github.com/tokio-rs/tokio) - Async runtime
 - [crossterm](https://github.com/crossterm-rs/crossterm) - Terminal manipulation
 - [clap](https://github.com/clap-rs/clap) - CLI argument parsing

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -564,6 +564,14 @@ async fn handle_player_events(
           track_id, consecutive_unavailable
         );
 
+        // Once several consecutive tracks fail to load (genuinely unavailable,
+        // e.g. region-locked or the audio-key block), halt playback instead of
+        // letting librespot auto-skip through the entire queue at machine speed;
+        // that stampede hammers Spotify and can get the account rate-limited.
+        if consecutive_unavailable >= UNAVAILABLE_ESCALATION_THRESHOLD {
+          player.pause();
+        }
+
         // Emit on the threshold transitions only (== not >=) so we don't spam the
         // same message on every auto-skip during an account-wide failure.
         if consecutive_unavailable == 1 {
@@ -575,7 +583,7 @@ async fn handle_player_events(
         } else if consecutive_unavailable == UNAVAILABLE_ESCALATION_THRESHOLD {
           let mut app = app.lock().await;
           app.set_status_message(
-            "Native playback keeps failing — a known upstream Spotify limitation on some accounts that can't be fixed in spotatui. Press 'd' to switch to an official Spotify Connect device.",
+            "Several tracks in a row couldn't be played natively, so playback was stopped. They may be unavailable on your account or region. Press 'd' to switch to an official Spotify Connect device.",
             20,
           );
         }


### PR DESCRIPTION
## Problem
Native streaming showed tracks as "playing" but produced no audio: librespot 0.8.0 logged `Unable to load encrypted file: FailedPrecondition, StatusCode(530)` and skipped every track.

## Root cause
Spotify `storage-resolve` returns several CDN URLs per track. The first can return HTTP 530 (Cloudflare "origin unreachable") while the others serve valid audio. librespot 0.8.0 only falls back to the next URL on connection errors, not on a non-206 HTTP status, so it aborted on the first 530. Upstream issue #1725 / PR #1722 (open, unmerged, unreleased).

## Fix
- Point librespot at our maintained fork `LargeModGames/spotatui-librespot` (branch `spotatui`) via `[patch.crates-io]`. It backports PR #1722 onto the v0.8.0 tag: the 206 check moves inside the CDN-URL retry loop, so a non-206 (530) falls through to the next URL. `Cargo.lock` pins the exact commit.
- Halt native playback after repeated consecutive Unavailable tracks instead of letting librespot stampede the queue (which can rate-limit the account); reword the now-stale status message.
- CHANGELOG + README updated.

## Verification
Built with default features; confirmed audible playback on a Premium account. Logs show `Fetching <url> returned 530 ... trying next` then a successful fetch, with no `Unable to load encrypted file`.

## Notes
- The slim CI build (`--no-default-features --features telemetry`) does not compile librespot, so the patch is unused there (harmless warning).
- `cargo install` from crates.io still gets unpatched librespot (crates.io ignores `[patch]`); GitHub-release/CI/source builds get the fix. Drop the patch and bump the version once upstream ships a fixed librespot release.