### PR TITLE
refactor(c7): migrate recently-played to domain CursorPaged<TrackInfo>

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -14,7 +14,6 @@ use rspotify::{
     device::DevicePayload,
     idtypes::{ArtistId, PlaylistId, ShowId, TrackId},
     page::{CursorBasedPage, Page},
-    playing::PlayHistory,
     playlist::{PlaylistItem, SimplifiedPlaylist},
     show::{FullShow, Show, SimplifiedEpisode, SimplifiedShow},
     track::{FullTrack, SavedTrack, SimplifiedTrack},
@@ -787,7 +786,9 @@ pub struct App {
   pub active_playlist_track_filter: Option<String>,
   pub pending_playlist_track_search: Option<String>,
   pub playlists: Option<Page<SimplifiedPlaylist>>,
-  pub recently_played: SpotifyResultAndSelectedIndex<Option<CursorBasedPage<PlayHistory>>>,
+  pub recently_played: SpotifyResultAndSelectedIndex<
+    Option<crate::core::pagination::CursorPaged<crate::core::plugin_api::TrackInfo>>,
+  >,
   pub recommendations_seed: String,
   pub recommendations_context: Option<RecommendationsContext>,
   pub search_results: SearchResult,

--- a/src/infra/network/user.rs
+++ b/src/infra/network/user.rs
@@ -3,6 +3,8 @@ use super::Network;
 use crate::core::app::{ActiveBlock, DiscoverTimeRange, RouteId};
 use anyhow::anyhow;
 
+use crate::core::plugin_api::TrackInfo;
+use crate::infra::network::mapping::map_cursor_page;
 use rand::seq::SliceRandom;
 use rspotify::model::{
   artist::FullArtist,
@@ -223,8 +225,9 @@ impl UserNetwork for Network {
       .await
     {
       Ok(recently_played) => {
+        let domain_page = map_cursor_page(&recently_played, |ph| TrackInfo::from(&ph.track));
         let mut app = self.app.lock().await;
-        app.recently_played.result = Some(recently_played);
+        app.recently_played.result = Some(domain_page);
         app.push_navigation_stack(RouteId::RecentlyPlayed, ActiveBlock::RecentlyPlayed);
       }
       Err(e) => {

--- a/src/tui/handlers/recently_played.rs
+++ b/src/tui/handlers/recently_played.rs
@@ -4,7 +4,7 @@ use crate::core::app::RecommendationsContext;
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
 use rspotify::model::idtypes::PlayableId;
-use rspotify::prelude::Id;
+use rspotify::model::TrackId;
 
 pub fn handler(key: Key, app: &mut App) {
   match key {
@@ -50,10 +50,12 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Char('s') => {
       if let Some(recently_played_result) = &app.recently_played.result.clone() {
         if let Some(selected_track) = recently_played_result.items.get(app.recently_played.index) {
-          if let Some(track_id) = &selected_track.track.id {
-            app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
-              track_id.clone().into_static(),
-            )));
+          if let Some(ref id_str) = selected_track.id {
+            if let Ok(track_id) = TrackId::from_id(id_str.as_str()) {
+              app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
+                track_id.into_static(),
+              )));
+            }
           };
         };
       };
@@ -61,32 +63,47 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Char('w') => open_add_to_playlist_for_selected_recent_track(app),
     Key::Enter => {
       if let Some(recently_played_result) = &app.recently_played.result.clone() {
+        let selected = app.recently_played.index;
+        // Build uri list while tracking the remapped offset for the selected track.
+        // Tracks without a valid id (e.g. local files) are omitted from the uri list,
+        // so the offset into the resulting vec must be recomputed, not taken verbatim
+        // from `app.recently_played.index`.
+        let mut remapped_offset: Option<usize> = None;
+        let mut uri_index = 0usize;
         let track_uris: Vec<PlayableId<'static>> = recently_played_result
           .items
           .iter()
-          .filter_map(|item| {
-            item
-              .track
+          .enumerate()
+          .filter_map(|(orig_index, item)| {
+            let playable = item
               .id
               .as_ref()
-              .map(|track_id| PlayableId::Track(track_id.clone().into_static()))
+              .and_then(|id_str| TrackId::from_id(id_str.as_str()).ok())
+              .map(|track_id| PlayableId::Track(track_id.into_static()));
+            if playable.is_some() {
+              if orig_index == selected {
+                remapped_offset = Some(uri_index);
+              }
+              uri_index += 1;
+            }
+            playable
           })
           .collect();
 
         app.dispatch(IoEvent::StartPlayback(
           None,
           Some(track_uris),
-          Some(app.recently_played.index),
+          remapped_offset,
         ));
       };
     }
     Key::Char('r') => {
       if let Some(recently_played_result) = &app.recently_played.result.clone() {
         if let Some(selected_track) = recently_played_result.items.get(app.recently_played.index) {
-          if let Some(track_id) = &selected_track.track.id {
+          if let Some(ref id_str) = selected_track.id {
             app.recommendations_context = Some(RecommendationsContext::Song);
-            app.recommendations_seed = selected_track.track.name.clone();
-            app.get_recommendations_for_track_id(track_id.id().to_string());
+            app.recommendations_seed = selected_track.name.clone();
+            app.get_recommendations_for_track_id(id_str.clone());
           };
         };
       };
@@ -94,10 +111,12 @@ pub fn handler(key: Key, app: &mut App) {
     _ if key == app.user_config.keys.add_item_to_queue => {
       if let Some(recently_played_result) = &app.recently_played.result.clone() {
         if let Some(selected_track) = recently_played_result.items.get(app.recently_played.index) {
-          if let Some(track_id) = &selected_track.track.id {
-            app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
-              track_id.clone().into_static(),
-            )));
+          if let Some(ref id_str) = selected_track.id {
+            if let Ok(track_id) = TrackId::from_id(id_str.as_str()) {
+              app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
+                track_id.into_static(),
+              )));
+            }
           };
         };
       };
@@ -114,8 +133,12 @@ fn open_add_to_playlist_for_selected_recent_track(app: &mut App) {
     return;
   };
 
-  let track_id = selected_track.track.id.clone().map(|id| id.into_static());
-  app.begin_add_track_to_playlist_flow(track_id, selected_track.track.name.clone());
+  let track_id = selected_track
+    .id
+    .as_ref()
+    .and_then(|id_str| TrackId::from_id(id_str.as_str()).ok())
+    .map(|id| id.into_static());
+  app.begin_add_track_to_playlist_flow(track_id, selected_track.name.clone());
 }
 
 #[cfg(test)]

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -652,17 +652,12 @@ pub fn draw_recently_played_table(f: &mut Frame<'_>, app: &App, layout_chunk: Re
       .items
       .iter()
       .map(|item| TableItem {
-        id: item
-          .track
-          .id
-          .as_ref()
-          .map(|id| id.id().to_string())
-          .unwrap_or_else(|| "".to_string()),
+        id: item.id.clone().unwrap_or_default(),
         format: vec![
           "".to_string(),
-          item.track.name.to_owned(),
-          create_artist_string(&item.track.artists),
-          millis_to_minutes(item.track.duration.num_milliseconds() as u128),
+          item.name.clone(),
+          item.artists.join(", "),
+          millis_to_minutes(item.duration_ms as u128),
         ],
       })
       .collect::<Vec<TableItem>>();


### PR DESCRIPTION
## Summary

- Removes `rspotify::model::PlayHistory` from `app.recently_played` in `src/core/app.rs`; field now holds `SpotifyResultAndSelectedIndex<Option<CursorPaged<TrackInfo>>>` using the Wave 0 domain pagination type
- Conversion from `CursorBasedPage<PlayHistory>` to `CursorPaged<TrackInfo>` happens at the infra boundary in `get_recently_played` (`src/infra/network/user.rs`) via the foundation `map_cursor_page` helper
- `draw_recently_played_table` (`src/tui/ui/tables.rs`) reads `TrackInfo` fields directly (`id`, `name`, `artists.join(", ")`, `duration_ms`)
- Handler (`src/tui/handlers/recently_played.rs`) re-parses stored String ids to `TrackId`/`PlayableId` at dispatch sites as per architecture spec

## Bug fix included

The `Key::Enter` handler previously built a `track_uris` vec with `filter_map` (dropping tracks with `None` ids, e.g. local files common in the recently-played API response) but passed the raw `app.recently_played.index` as the playback offset into the now-shorter vec. This caused the wrong track to start playing when any local file appeared before the cursor position. The fix remaps the offset to the compressed uri list position using `enumerate`.

## Test plan

- [x] `cargo clippy --no-default-features --features telemetry -- -D warnings` passes clean
- [x] `cargo test --no-default-features --features telemetry` 261 tests pass
- [x] `cargo build` (full) compiles
- [x] `cargo fmt --all` applied