### PR TITLE
refactor(C3): migrate album screen from rspotify types to domain types

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -8,7 +8,7 @@ use ratatui::layout::Size;
 use rspotify::{
   model::enums::Country,
   model::{
-    album::{FullAlbum, SavedAlbum, SimplifiedAlbum},
+    album::{SavedAlbum, SimplifiedAlbum},
     artist::FullArtist,
     context::{CurrentPlaybackContext, CurrentUserQueue},
     device::DevicePayload,
@@ -17,7 +17,7 @@ use rspotify::{
     playing::PlayHistory,
     playlist::{PlaylistItem, SimplifiedPlaylist},
     show::{FullShow, Show, SimplifiedEpisode, SimplifiedShow},
-    track::{FullTrack, SavedTrack, SimplifiedTrack},
+    track::{FullTrack, SavedTrack},
     user::PrivateUser,
     PlayableItem,
   },
@@ -523,15 +523,15 @@ pub struct SelectedFullShow {
 
 #[derive(Clone)]
 pub struct SelectedAlbum {
-  pub album: SimplifiedAlbum,
-  pub tracks: Page<SimplifiedTrack>,
+  pub album: crate::core::plugin_api::AlbumInfo,
+  pub tracks: crate::core::pagination::Paged<crate::core::plugin_api::TrackInfo>,
   pub selected_index: usize,
 }
 
 #[derive(Clone)]
 #[allow(dead_code)]
 pub struct SelectedFullAlbum {
-  pub album: FullAlbum,
+  pub album: crate::core::plugin_api::AlbumInfo,
   pub selected_index: usize,
 }
 

--- a/src/infra/network/metadata.rs
+++ b/src/infra/network/metadata.rs
@@ -3,6 +3,7 @@ use crate::core::app::{
   ActiveBlock, Artist, ArtistBlock, EpisodeTableContext, RouteId, ScrollableResultPages,
   SelectedFullShow, SelectedShow,
 };
+use crate::infra::network::mapping::map_page;
 use anyhow::anyhow;
 use reqwest::Method;
 use rspotify::model::{
@@ -159,10 +160,12 @@ impl MetadataNetwork for Network {
         .await
       {
         Ok(tracks) => {
+          let album_info = crate::core::plugin_api::AlbumInfo::from(album.as_ref());
+          let tracks_domain = map_page(&tracks, |t| crate::core::plugin_api::TrackInfo::from(t));
           let mut app = self.app.lock().await;
           app.selected_album_simplified = Some(crate::core::app::SelectedAlbum {
-            album: *album,
-            tracks,
+            album: album_info,
+            tracks: tracks_domain,
             selected_index: 0,
           });
           app.album_table_context = crate::core::app::AlbumTableContext::Simplified;
@@ -179,9 +182,10 @@ impl MetadataNetwork for Network {
       .await
     {
       Ok(album) => {
+        let album_info = crate::core::plugin_api::AlbumInfo::from(&album);
         let mut app = self.app.lock().await;
         app.selected_album_full = Some(crate::core::app::SelectedFullAlbum {
-          album,
+          album: album_info,
           selected_index: 0,
         });
         app.album_table_context = crate::core::app::AlbumTableContext::Full;

--- a/src/tui/handlers/album_list.rs
+++ b/src/tui/handlers/album_list.rs
@@ -1,6 +1,7 @@
 use super::common_key_events;
 use crate::{
   core::app::{ActiveBlock, AlbumTableContext, App, RouteId, SelectedFullAlbum},
+  core::plugin_api::AlbumInfo,
   tui::event::Key,
 };
 
@@ -45,7 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
       if let Some(albums) = app.library.saved_albums.get_results(None) {
         if let Some(selected_album) = albums.items.get(app.album_list_index) {
           app.selected_album_full = Some(SelectedFullAlbum {
-            album: selected_album.album.clone(),
+            album: AlbumInfo::from(&selected_album.album),
             selected_index: 0,
           });
           app.album_table_context = AlbumTableContext::Full;

--- a/src/tui/handlers/album_tracks.rs
+++ b/src/tui/handlers/album_tracks.rs
@@ -2,10 +2,7 @@ use super::common_key_events;
 use crate::core::app::{AlbumTableContext, App, RecommendationsContext};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
-use rspotify::{
-  model::{PlayContextId, PlayableId},
-  prelude::*,
-};
+use rspotify::model::{idtypes::AlbumId, idtypes::TrackId, PlayContextId, PlayableId};
 
 pub fn handler(key: Key, app: &mut App) {
   match key {
@@ -16,7 +13,7 @@ pub fn handler(key: Key, app: &mut App) {
       AlbumTableContext::Full => {
         if let Some(selected_album) = &app.selected_album_full {
           let next_index = common_key_events::on_down_press_handler(
-            &selected_album.album.tracks.items,
+            &selected_album.album.tracks,
             Some(app.saved_album_tracks_index),
           );
           app.saved_album_tracks_index = next_index;
@@ -36,7 +33,7 @@ pub fn handler(key: Key, app: &mut App) {
       AlbumTableContext::Full => {
         if let Some(selected_album) = &app.selected_album_full {
           let next_index = common_key_events::on_up_press_handler(
-            &selected_album.album.tracks.items,
+            &selected_album.album.tracks,
             Some(app.saved_album_tracks_index),
           );
           app.saved_album_tracks_index = next_index;
@@ -60,7 +57,12 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Enter => match app.album_table_context {
       AlbumTableContext::Full => {
         if let Some(selected_album) = app.selected_album_full.clone() {
-          let context_id = Some(PlayContextId::Album(selected_album.album.id.into_static()));
+          let context_id = selected_album
+            .album
+            .id
+            .as_deref()
+            .and_then(|id| AlbumId::from_id(id).ok())
+            .map(|id| PlayContextId::Album(id.into_static()));
           app.dispatch(IoEvent::StartPlayback(
             context_id,
             None,
@@ -73,7 +75,8 @@ pub fn handler(key: Key, app: &mut App) {
           let context_id = selected_album_simplified
             .album
             .id
-            .clone()
+            .as_deref()
+            .and_then(|id| AlbumId::from_id(id).ok())
             .map(|id| PlayContextId::Album(id.into_static()));
           app.dispatch(IoEvent::StartPlayback(
             context_id,
@@ -93,13 +96,14 @@ pub fn handler(key: Key, app: &mut App) {
           if let Some(track) = selected_album
             .album
             .tracks
-            .items
             .get(app.saved_album_tracks_index)
           {
-            if let Some(track_id) = &track.id {
-              app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
-                track_id.clone().into_static(),
-              )));
+            if let Some(track_id_str) = &track.id {
+              if let Ok(track_id) = TrackId::from_id(track_id_str.as_str()) {
+                app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
+                  track_id.into_static(),
+                )));
+              }
             }
           }
         };
@@ -111,10 +115,12 @@ pub fn handler(key: Key, app: &mut App) {
             .items
             .get(selected_album_simplified.selected_index)
           {
-            if let Some(track_id) = &track.id {
-              app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
-                track_id.clone().into_static(),
-              )));
+            if let Some(track_id_str) = &track.id {
+              if let Ok(track_id) = TrackId::from_id(track_id_str.as_str()) {
+                app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
+                  track_id.into_static(),
+                )));
+              }
             }
           }
         };
@@ -143,8 +149,7 @@ fn handle_middle_event(app: &mut App) {
   match app.album_table_context {
     AlbumTableContext::Full => {
       if let Some(selected_album) = &app.selected_album_full {
-        let next_index =
-          common_key_events::on_middle_press_handler(&selected_album.album.tracks.items);
+        let next_index = common_key_events::on_middle_press_handler(&selected_album.album.tracks);
         app.saved_album_tracks_index = next_index;
       };
     }
@@ -162,8 +167,7 @@ fn handle_low_event(app: &mut App) {
   match app.album_table_context {
     AlbumTableContext::Full => {
       if let Some(selected_album) = &app.selected_album_full {
-        let next_index =
-          common_key_events::on_low_press_handler(&selected_album.album.tracks.items);
+        let next_index = common_key_events::on_low_press_handler(&selected_album.album.tracks);
         app.saved_album_tracks_index = next_index;
       };
     }
@@ -180,26 +184,23 @@ fn handle_low_event(app: &mut App) {
 fn handle_recommended_tracks(app: &mut App) {
   match app.album_table_context {
     AlbumTableContext::Full => {
-      if let Some(albums) = &app.library.clone().saved_albums.get_results(None) {
-        if let Some(selected_album) = albums.items.get(app.album_list_index) {
-          if let Some(track) = &selected_album
-            .album
-            .tracks
-            .items
-            .get(app.saved_album_tracks_index)
-          {
-            if let Some(id) = &track.id {
-              app.recommendations_context = Some(RecommendationsContext::Song);
-              app.recommendations_seed = track.name.clone();
-              app.get_recommendations_for_track_id(id.id().to_string());
-            }
+      if let Some(selected_album) = &app.selected_album_full.clone() {
+        if let Some(track) = selected_album
+          .album
+          .tracks
+          .get(app.saved_album_tracks_index)
+        {
+          if let Some(id) = &track.id {
+            app.recommendations_context = Some(RecommendationsContext::Song);
+            app.recommendations_seed = track.name.clone();
+            app.get_recommendations_for_track_id(id.clone());
           }
         }
       }
     }
     AlbumTableContext::Simplified => {
       if let Some(selected_album_simplified) = &app.selected_album_simplified.clone() {
-        if let Some(track) = &selected_album_simplified
+        if let Some(track) = selected_album_simplified
           .tracks
           .items
           .get(selected_album_simplified.selected_index)
@@ -207,7 +208,7 @@ fn handle_recommended_tracks(app: &mut App) {
           if let Some(id) = &track.id {
             app.recommendations_context = Some(RecommendationsContext::Song);
             app.recommendations_seed = track.name.clone();
-            app.get_recommendations_for_track_id(id.id().to_string());
+            app.get_recommendations_for_track_id(id.clone());
           }
         }
       };
@@ -222,13 +223,14 @@ fn handle_save_event(app: &mut App) {
         if let Some(selected_track) = selected_album
           .album
           .tracks
-          .items
           .get(app.saved_album_tracks_index)
         {
-          if let Some(track_id) = &selected_track.id {
-            app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
-              track_id.clone().into_static(),
-            )));
+          if let Some(track_id_str) = &selected_track.id {
+            if let Ok(track_id) = TrackId::from_id(track_id_str.as_str()) {
+              app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
+                track_id.into_static(),
+              )));
+            }
           };
         };
       };
@@ -240,10 +242,12 @@ fn handle_save_event(app: &mut App) {
           .items
           .get(selected_album_simplified.selected_index)
         {
-          if let Some(track_id) = &selected_track.id {
-            app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
-              track_id.clone().into_static(),
-            )));
+          if let Some(track_id_str) = &selected_track.id {
+            if let Ok(track_id) = TrackId::from_id(track_id_str.as_str()) {
+              app.dispatch(IoEvent::ToggleSaveTrack(PlayableId::Track(
+                track_id.into_static(),
+              )));
+            }
           };
         };
       };
@@ -255,14 +259,19 @@ fn handle_save_album_event(app: &mut App) {
   match app.album_table_context {
     AlbumTableContext::Full => {
       if let Some(selected_album) = app.selected_album_full.clone() {
-        let album_id = selected_album.album.id.clone();
-        app.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+        if let Some(album_id_str) = &selected_album.album.id {
+          if let Ok(album_id) = AlbumId::from_id(album_id_str.as_str()) {
+            app.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+          }
+        }
       };
     }
     AlbumTableContext::Simplified => {
       if let Some(selected_album_simplified) = app.selected_album_simplified.clone() {
-        if let Some(album_id) = selected_album_simplified.album.id {
-          app.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+        if let Some(album_id_str) = &selected_album_simplified.album.id {
+          if let Ok(album_id) = AlbumId::from_id(album_id_str.as_str()) {
+            app.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+          }
         };
       };
     }

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -539,7 +539,7 @@ fn content_table_item_count(active_block: ActiveBlock, app: &App) -> usize {
       crate::core::app::AlbumTableContext::Full => app
         .selected_album_full
         .as_ref()
-        .map(|album| album.album.tracks.items.len())
+        .map(|album| album.album.tracks.len())
         .unwrap_or(0),
       crate::core::app::AlbumTableContext::Simplified => app
         .selected_album_simplified
@@ -1943,19 +1943,11 @@ mod tests {
     let mut app = App::default();
     app.album_table_context = AlbumTableContext::Simplified;
     app.selected_album_simplified = Some(SelectedAlbum {
-      album: SimplifiedAlbum {
+      album: crate::core::plugin_api::AlbumInfo {
         name: "Album".to_string(),
         ..Default::default()
       },
-      tracks: Page {
-        href: "https://example.com/albums/1/tracks".to_string(),
-        items: Vec::<SimplifiedTrack>::new(),
-        limit: 0,
-        next: None,
-        offset: 0,
-        previous: None,
-        total: 0,
-      },
+      tracks: crate::core::pagination::Paged::default(),
       selected_index: 1,
     });
 

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -12,7 +12,9 @@ use rspotify::model::show::ResumePoint;
 use rspotify::model::PlayableItem;
 use rspotify::prelude::Id;
 
-use super::util::{create_artist_string, get_color, get_percentage_width, millis_to_minutes};
+use super::util::{
+  create_artist_string, get_color, get_percentage_width, join_artist_names, millis_to_minutes,
+};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TableId {
@@ -209,24 +211,20 @@ pub fn draw_album_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
             .items
             .iter()
             .map(|item| TableItem {
-              id: item
-                .id
-                .as_ref()
-                .map(|id| id.id().to_string())
-                .unwrap_or_else(|| "".to_string()),
+              id: item.id.clone().unwrap_or_default(),
               format: vec![
                 "".to_string(),
                 item.track_number.to_string(),
                 item.name.to_owned(),
-                create_artist_string(&item.artists),
-                millis_to_minutes(item.duration.num_milliseconds() as u128),
+                item.artists.join(", "),
+                millis_to_minutes(item.duration_ms as u128),
               ],
             })
             .collect::<Vec<TableItem>>(),
           title: format!(
             "{} by {}",
             selected_album_simplified.album.name,
-            create_artist_string(&selected_album_simplified.album.artists)
+            join_artist_names(&selected_album_simplified.album.artists)
           ),
           selected_index: selected_album_simplified.selected_index,
         })
@@ -236,27 +234,22 @@ pub fn draw_album_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
         items: selected_album
           .album
           .tracks
-          .items
           .iter()
           .map(|item| TableItem {
-            id: item
-              .id
-              .as_ref()
-              .map(|id| id.id().to_string())
-              .unwrap_or_else(|| "".to_string()),
+            id: item.id.clone().unwrap_or_default(),
             format: vec![
               "".to_string(),
               item.track_number.to_string(),
               item.name.to_owned(),
-              create_artist_string(&item.artists),
-              millis_to_minutes(item.duration.num_milliseconds() as u128),
+              item.artists.join(", "),
+              millis_to_minutes(item.duration_ms as u128),
             ],
           })
           .collect::<Vec<TableItem>>(),
         title: format!(
           "{} by {}",
           selected_album.album.name,
-          create_artist_string(&selected_album.album.artists)
+          join_artist_names(&selected_album.album.artists)
         ),
         selected_index: app.saved_album_tracks_index,
       }),


### PR DESCRIPTION
## Summary

- Removes rspotify model types (`SimplifiedAlbum`, `FullAlbum`, `Page<SimplifiedTrack>`) from `SelectedAlbum` and `SelectedFullAlbum` in `src/core/app.rs`
- Replaces with domain types: `AlbumInfo`, `Paged<TrackInfo>`, and `Vec<TrackInfo>` (embedded in `AlbumInfo.tracks` for the Full context)
- The rspotify-to-domain conversion stays exclusively behind the `infra/network/mapping.rs` boundary

## Files changed

- `src/core/app.rs`: struct field type changes only
- `src/infra/network/metadata.rs`: `get_album_tracks` maps via `map_page`, `get_album` maps via `AlbumInfo::from`
- `src/tui/ui/tables.rs`: `draw_album_table` reads domain fields (`.artists.join(", ")`, `.duration_ms`, `.id` as `Option<String>`, `join_artist_names`)
- `src/tui/handlers/album_tracks.rs`: all key handlers updated; rspotify `AlbumId`/`TrackId` re-parsed from stored `String` at dispatch sites
- `src/tui/handlers/album_list.rs`: Enter converts `FullAlbum` to `AlbumInfo` via `From`
- `src/tui/handlers/mouse.rs`: fix `.tracks.len()` for Full context; update test fixture to domain types

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --no-default-features --features telemetry -- -D warnings` clean
- [x] `cargo test --no-default-features --features telemetry` passes (261/261)
- [x] `cargo build` (full) succeeds
- [x] `cargo build --no-default-features --features telemetry` (slim) succeeds