### PR TITLE
refactor(C9): migrate create-playlist tracks to domain TrackInfo type

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,3 +1,4 @@
+use crate::core::plugin_api::TrackInfo;
 use crate::core::sort::{SortContext, SortField, SortOrder, SortState};
 use crate::core::user_config::{color_to_string, normalize_tick_rate_milliseconds, UserConfig};
 use crate::infra::network::sync::{PartySession, PartyStatus};
@@ -990,8 +991,8 @@ pub struct App {
   pub create_playlist_name_idx: usize,
   pub create_playlist_name_cursor: u16,
   pub create_playlist_stage: CreatePlaylistStage,
-  pub create_playlist_tracks: Vec<FullTrack>,
-  pub create_playlist_search_results: Vec<FullTrack>,
+  pub create_playlist_tracks: Vec<TrackInfo>,
+  pub create_playlist_search_results: Vec<TrackInfo>,
   pub create_playlist_search_input: Vec<char>,
   pub create_playlist_search_idx: usize,
   pub create_playlist_search_cursor: u16,

--- a/src/infra/network/search.rs
+++ b/src/infra/network/search.rs
@@ -1,4 +1,5 @@
 use super::{IoEvent, Network};
+use crate::core::plugin_api::TrackInfo;
 use anyhow::anyhow;
 use rspotify::model::{
   artist::FullArtist, enums::Country, idtypes::AlbumId, page::Page, playlist::SimplifiedPlaylist,
@@ -165,8 +166,9 @@ impl SearchNetwork for Network {
       Ok(res) => res
         .tracks
         .items
-        .into_iter()
-        .filter_map(|t| if t.id.is_some() { Some(t) } else { None })
+        .iter()
+        .filter(|t| t.id.is_some())
+        .map(TrackInfo::from)
         .collect::<Vec<_>>(),
       Err(e) => {
         self.handle_error(anyhow!(e)).await;

--- a/src/tui/handlers/create_playlist.rs
+++ b/src/tui/handlers/create_playlist.rs
@@ -1,6 +1,7 @@
 use crate::core::app::{App, CreatePlaylistFocus, CreatePlaylistStage};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
+use rspotify::model::idtypes::TrackId;
 use unicode_width::UnicodeWidthChar;
 
 pub fn handler(key: Key, app: &mut App) {
@@ -183,10 +184,15 @@ fn handle_added_tracks_nav(key: Key, app: &mut App) {
 
 fn submit_playlist(app: &mut App) {
   let name: String = app.create_playlist_name.iter().collect();
-  let track_ids: Vec<rspotify::model::idtypes::TrackId<'static>> = app
+  let track_ids: Vec<TrackId<'static>> = app
     .create_playlist_tracks
     .iter()
-    .filter_map(|t| t.id.clone())
+    .filter_map(|t| {
+      t.id
+        .as_deref()
+        .and_then(|id| TrackId::from_id(id).ok())
+        .map(|tid| tid.into_static())
+    })
     .collect();
 
   app.dispatch(IoEvent::CreateNewPlaylist(name, track_ids));

--- a/src/tui/ui/create_playlist.rs
+++ b/src/tui/ui/create_playlist.rs
@@ -136,11 +136,7 @@ fn draw_add_tracks_stage(f: &mut Frame<'_>, app: &App, area: Rect) {
     .create_playlist_search_results
     .iter()
     .map(|t| {
-      let artist = t
-        .artists
-        .first()
-        .map(|a| a.name.as_str())
-        .unwrap_or("Unknown");
+      let artist = t.artists.first().map(|a| a.as_str()).unwrap_or("Unknown");
       ListItem::new(format!("{} — {}", t.name, artist)).style(theme.base_style())
     })
     .collect();
@@ -181,11 +177,7 @@ fn draw_add_tracks_stage(f: &mut Frame<'_>, app: &App, area: Rect) {
     .create_playlist_tracks
     .iter()
     .map(|t| {
-      let artist = t
-        .artists
-        .first()
-        .map(|a| a.name.as_str())
-        .unwrap_or("Unknown");
+      let artist = t.artists.first().map(|a| a.as_str()).unwrap_or("Unknown");
       ListItem::new(format!("{} — {}", t.name, artist)).style(theme.base_style())
     })
     .collect();


### PR DESCRIPTION
## Summary

- Replaces `Vec<FullTrack>` with `Vec<TrackInfo>` for `create_playlist_tracks` and `create_playlist_search_results` in `App`
- Network layer (`search_tracks_for_playlist`) now maps fetched `FullTrack` results to `TrackInfo` before storing, keeping rspotify types confined to `infra/network/`
- UI (`create_playlist.rs`) and handler (`create_playlist.rs`) updated to read domain fields (`TrackInfo.name`, `TrackInfo.artists: Vec<String>`)
- Dispatch site rebuilds `Vec<TrackId>` from `TrackInfo.id` (base62 strings) when submitting the playlist to the API; residual rspotify at the dispatch site is expected per the slice spec

## Test plan

- [ ] `cargo clippy --no-default-features --features telemetry -- -D warnings` passes clean
- [ ] `cargo test --no-default-features --features telemetry` passes (261 tests)
- [ ] `cargo build` (full build with streaming) passes
- [ ] `cargo fmt --all` applied