### PR TITLE
refactor(artist): migrate Artist struct and app.artists to domain types (C2 slice)

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -12,7 +12,7 @@ use rspotify::{
     artist::FullArtist,
     context::{CurrentPlaybackContext, CurrentUserQueue},
     device::DevicePayload,
-    idtypes::{ArtistId, PlaylistId, ShowId, TrackId},
+    idtypes::{AlbumId, ArtistId, PlaylistId, ShowId, TrackId},
     page::{CursorBasedPage, Page},
     playing::PlayHistory,
     playlist::{PlaylistItem, SimplifiedPlaylist},
@@ -540,9 +540,9 @@ pub struct SelectedFullAlbum {
 pub struct Artist {
   pub artist_id: String,
   pub artist_name: String,
-  pub albums: Page<SimplifiedAlbum>,
-  pub related_artists: Vec<FullArtist>,
-  pub top_tracks: Vec<FullTrack>,
+  pub albums: crate::core::pagination::Paged<crate::core::plugin_api::AlbumInfo>,
+  pub related_artists: Vec<crate::core::plugin_api::ArtistInfo>,
+  pub top_tracks: Vec<crate::core::plugin_api::TrackInfo>,
   pub selected_album_index: usize,
   pub selected_related_artist_index: usize,
   pub selected_top_track_index: usize,
@@ -747,7 +747,7 @@ pub struct App {
   pub audio_capture_active: bool,
   pub home_scroll: u16,
   pub user_config: UserConfig,
-  pub artists: Vec<FullArtist>,
+  pub artists: Vec<crate::core::plugin_api::ArtistInfo>,
   pub artist: Option<Artist>,
   pub album_table_context: AlbumTableContext,
   pub saved_album_tracks_index: usize,
@@ -3027,8 +3027,10 @@ impl App {
       ActiveBlock::ArtistBlock => {
         if let Some(artist) = &self.artist {
           if let Some(selected_album) = artist.albums.items.get(artist.selected_album_index) {
-            if let Some(album_id) = selected_album.id.clone() {
-              self.dispatch(IoEvent::CurrentUserSavedAlbumDelete(album_id.into_static()));
+            if let Some(id_str) = &selected_album.id {
+              if let Ok(album_id) = AlbumId::from_id(id_str.as_str()) {
+                self.dispatch(IoEvent::CurrentUserSavedAlbumDelete(album_id.into_static()));
+              }
             }
           }
         }
@@ -3053,8 +3055,10 @@ impl App {
       ActiveBlock::ArtistBlock => {
         if let Some(artist) = &self.artist {
           if let Some(selected_album) = artist.albums.items.get(artist.selected_album_index) {
-            if let Some(album_id) = selected_album.id.clone() {
-              self.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+            if let Some(id_str) = &selected_album.id {
+              if let Ok(album_id) = AlbumId::from_id(id_str.as_str()) {
+                self.dispatch(IoEvent::CurrentUserSavedAlbumAdd(album_id.into_static()));
+              }
             }
           }
         }
@@ -3138,10 +3142,11 @@ impl App {
       ActiveBlock::ArtistBlock => {
         if let Some(artist) = &self.artist {
           let selected_artis = &artist.related_artists[artist.selected_related_artist_index];
-          self.dispatch(IoEvent::UserUnfollowArtists(vec![selected_artis
-            .id
-            .clone()
-            .into_static()]));
+          if let Some(id_str) = &selected_artis.id {
+            if let Ok(artist_id) = ArtistId::from_id(id_str.as_str()) {
+              self.dispatch(IoEvent::UserUnfollowArtists(vec![artist_id.into_static()]));
+            }
+          }
         }
       }
       _ => (),
@@ -3165,10 +3170,11 @@ impl App {
       ActiveBlock::ArtistBlock => {
         if let Some(artist) = &self.artist {
           let selected_artis = &artist.related_artists[artist.selected_related_artist_index];
-          self.dispatch(IoEvent::UserFollowArtists(vec![selected_artis
-            .id
-            .clone()
-            .into_static()]));
+          if let Some(id_str) = &selected_artis.id {
+            if let Ok(artist_id) = ArtistId::from_id(id_str.as_str()) {
+              self.dispatch(IoEvent::UserFollowArtists(vec![artist_id.into_static()]));
+            }
+          }
         }
       }
       _ => (),

--- a/src/infra/network/metadata.rs
+++ b/src/infra/network/metadata.rs
@@ -3,6 +3,8 @@ use crate::core::app::{
   ActiveBlock, Artist, ArtistBlock, EpisodeTableContext, RouteId, ScrollableResultPages,
   SelectedFullShow, SelectedShow,
 };
+use crate::core::plugin_api::{AlbumInfo, ArtistInfo, TrackInfo};
+use crate::infra::network::mapping::map_page;
 use anyhow::anyhow;
 use reqwest::Method;
 use rspotify::model::{
@@ -120,7 +122,9 @@ impl MetadataNetwork for Network {
       offset += limit;
     }
 
-    let albums = Page {
+    // Convert rspotify types to domain types before storing — conversion stays
+    // inside infra/network per the multi-source boundary contract.
+    let albums_rspotify_page = Page {
       items: album_items,
       href: String::new(),
       limit,
@@ -129,14 +133,18 @@ impl MetadataNetwork for Network {
       previous: None,
       total: 0,
     };
+    let albums = map_page(&albums_rspotify_page, |a| AlbumInfo::from(a));
+    let domain_related_artists: Vec<ArtistInfo> =
+      related_artists.iter().map(ArtistInfo::from).collect();
+    let domain_top_tracks: Vec<TrackInfo> = top_tracks.iter().map(TrackInfo::from).collect();
 
     let mut app = self.app.lock().await;
     app.artist = Some(Artist {
       artist_id: artist_id_str,
       artist_name: input_artist_name,
       albums,
-      related_artists,
-      top_tracks,
+      related_artists: domain_related_artists,
+      top_tracks: domain_top_tracks,
       selected_album_index: 0,
       selected_related_artist_index: 0,
       selected_top_track_index: 0,
@@ -362,8 +370,9 @@ impl MetadataNetwork for Network {
   }
 
   async fn set_artists_to_table(&mut self, artists: Vec<FullArtist>) {
+    let domain_artists: Vec<ArtistInfo> = artists.iter().map(ArtistInfo::from).collect();
     let mut app = self.app.lock().await;
-    app.artists = artists;
+    app.artists = domain_artists;
   }
 
   async fn get_album_for_track(&mut self, track_id: TrackId<'static>) {

--- a/src/tui/handlers/artist.rs
+++ b/src/tui/handlers/artist.rs
@@ -1,8 +1,11 @@
 use super::common_key_events;
-use crate::core::app::{ActiveBlock, App, ArtistBlock, RecommendationsContext, TrackTableContext};
+use crate::core::app::{ActiveBlock, App, ArtistBlock, RecommendationsContext};
 use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
-use rspotify::{model::PlayableId, prelude::*};
+use rspotify::model::{
+  idtypes::{AlbumId, ArtistId, TrackId},
+  PlayableId,
+};
 
 fn handle_down_press_on_selected_block(app: &mut App) {
   if let Some(artist) = &mut app.artist {
@@ -157,28 +160,33 @@ fn handle_low_press_on_selected_block(app: &mut App) {
 }
 
 fn handle_recommend_event_on_selected_block(app: &mut App) {
-  //recommendations.
   if let Some(artist) = &mut app.artist.clone() {
     match artist.artist_selected_block {
       ArtistBlock::TopTracks => {
         let selected_index = artist.selected_top_track_index;
         if let Some(track) = artist.top_tracks.get(selected_index) {
-          let track_id_list: Option<Vec<String>> =
-            track.id.as_ref().map(|id| vec![id.id().to_string()]);
+          // TrackInfo.id is Option<String> — wrap it in a Vec<String> if present.
+          let track_id_list: Option<Vec<String>> = track.id.as_ref().map(|id| vec![id.clone()]);
           app.recommendations_context = Some(RecommendationsContext::Song);
           app.recommendations_seed = track.name.clone();
-          app.get_recommendations_for_seed(None, track_id_list, Some(track.clone()));
+          // We cannot pass a FullTrack here (track_table is owned by another slice).
+          // Pass None so recommendations still work without a prepended seed track.
+          app.get_recommendations_for_seed(None, track_id_list, None);
         }
       }
       ArtistBlock::RelatedArtists => {
         let selected_index = artist.selected_related_artist_index;
-        let artist_id = &artist.related_artists[selected_index].id;
-        let artist_name = &artist.related_artists[selected_index].name;
-        let artist_id_list: Option<Vec<String>> = Some(vec![artist_id.id().to_string()]);
+        let related = &artist.related_artists[selected_index];
+        // ArtistInfo.id is Option<String>; only dispatch if an id is present to
+        // avoid a seed-less recommendation call that returns garbage results.
+        if let Some(id_str) = &related.id {
+          let artist_id_list: Option<Vec<String>> = Some(vec![id_str.clone()]);
+          let artist_name = related.name.clone();
 
-        app.recommendations_context = Some(RecommendationsContext::Artist);
-        app.recommendations_seed = artist_name.clone();
-        app.get_recommendations_for_seed(artist_id_list, None, None);
+          app.recommendations_context = Some(RecommendationsContext::Artist);
+          app.recommendations_seed = artist_name;
+          app.get_recommendations_for_seed(artist_id_list, None, None);
+        }
       }
       _ => {}
     }
@@ -190,6 +198,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
     match artist.artist_selected_block {
       ArtistBlock::TopTracks => {
         let selected_index = artist.selected_top_track_index;
+        // TrackInfo.id is Option<String>; re-parse to TrackId to build PlayableId.
         let top_tracks: Vec<PlayableId<'static>> = artist
           .top_tracks
           .iter()
@@ -197,7 +206,8 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
             track
               .id
               .as_ref()
-              .map(|id| PlayableId::Track(id.clone().into_static()))
+              .and_then(|id| TrackId::from_id(id.as_str()).ok())
+              .map(|tid| PlayableId::Track(tid.into_static()))
           })
           .collect();
         app.dispatch(IoEvent::StartPlayback(
@@ -213,18 +223,26 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
           .get(artist.selected_album_index)
           .cloned()
         {
-          app.track_table.context = Some(TrackTableContext::AlbumSearch);
-          app.dispatch(IoEvent::GetAlbumTracks(Box::new(selected_album)));
+          // AlbumInfo.id is Option<String>; re-parse to AlbumId to dispatch GetAlbum.
+          // GetAlbum fetches a FullAlbum and sets AlbumTableContext::Full — do NOT
+          // set track_table.context here, as GetAlbum does not use the track table.
+          if let Some(id_str) = &selected_album.id {
+            if let Ok(album_id) = AlbumId::from_id(id_str.as_str()) {
+              app.dispatch(IoEvent::GetAlbum(album_id.into_static()));
+            }
+          }
         }
       }
       ArtistBlock::RelatedArtists => {
         let selected_index = artist.selected_related_artist_index;
-        let artist_id = artist.related_artists[selected_index]
-          .id
-          .as_ref()
-          .into_static();
-        let artist_name = artist.related_artists[selected_index].name.clone();
-        app.get_artist(artist_id, artist_name);
+        let related = &artist.related_artists[selected_index];
+        let artist_name = related.name.clone();
+        // ArtistInfo.id is Option<String>; re-parse to ArtistId to navigate.
+        if let Some(id_str) = &related.id {
+          if let Ok(artist_id) = ArtistId::from_id(id_str.as_str()) {
+            app.get_artist(artist_id.into_static(), artist_name);
+          }
+        }
       }
       ArtistBlock::Empty => {}
     }
@@ -319,10 +337,13 @@ pub fn handler(key: Key, app: &mut App) {
         if let Some(artist) = &app.artist {
           if let ArtistBlock::TopTracks = artist.artist_selected_block {
             if let Some(track) = artist.top_tracks.get(artist.selected_top_track_index) {
-              if let Some(track_id) = &track.id {
-                app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
-                  track_id.clone().into_static(),
-                )));
+              // TrackInfo.id is Option<String>; re-parse to TrackId for the IoEvent.
+              if let Some(id_str) = &track.id {
+                if let Ok(track_id) = TrackId::from_id(id_str.as_str()) {
+                  app.dispatch(IoEvent::AddItemToQueue(PlayableId::Track(
+                    track_id.into_static(),
+                  )));
+                }
               }
             };
           }
@@ -341,7 +362,12 @@ fn open_add_to_playlist_for_selected_top_track(app: &mut App) {
     return;
   };
 
-  let track_id = track.id.clone().map(|id| id.into_static());
+  // TrackInfo.id is Option<String>; re-parse to TrackId for the flow.
+  let track_id = track
+    .id
+    .as_ref()
+    .and_then(|id| TrackId::from_id(id.as_str()).ok())
+    .map(|tid| tid.into_static());
   app.begin_add_track_to_playlist_flow(track_id, track.name.clone());
 }
 

--- a/src/tui/ui/artist.rs
+++ b/src/tui/ui/artist.rs
@@ -6,7 +6,7 @@ use ratatui::{
 use rspotify::model::PlayableItem;
 use rspotify::prelude::Id;
 
-use super::util::{create_artist_string, draw_selectable_list, get_artist_highlight_state};
+use super::util::{draw_selectable_list, get_artist_highlight_state, join_artist_names};
 
 pub fn draw_artist_albums(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   let [tracks_area, albums_area, related_artists_area] =
@@ -29,7 +29,7 @@ pub fn draw_artist_albums(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
             _ => None,
           };
 
-          if track_id == top_track.id.as_ref().map(|id| id.id().to_string()) {
+          if track_id.is_some() && track_id == top_track.id {
             name.push_str("▶ ");
           }
         };
@@ -55,14 +55,14 @@ pub fn draw_artist_albums(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       .map(|item| {
         let mut album_artist = String::new();
         if let Some(album_id) = &item.id {
-          if app.saved_album_ids_set.contains(album_id.id()) {
+          if app.saved_album_ids_set.contains(album_id.as_str()) {
             album_artist.push_str(&app.user_config.padded_liked_icon());
           }
         }
         album_artist.push_str(&format!(
           "{} - {} ({})",
           item.name.to_owned(),
-          create_artist_string(&item.artists),
+          join_artist_names(&item.artists),
           item.album_type.as_deref().unwrap_or("unknown")
         ));
         album_artist
@@ -84,8 +84,10 @@ pub fn draw_artist_albums(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       .iter()
       .map(|item| {
         let mut artist = String::new();
-        if app.followed_artist_ids_set.contains(item.id.id()) {
-          artist.push_str(&app.user_config.padded_liked_icon());
+        if let Some(artist_id) = &item.id {
+          if app.followed_artist_ids_set.contains(artist_id.as_str()) {
+            artist.push_str(&app.user_config.padded_liked_icon());
+          }
         }
         artist.push_str(&item.name.to_owned());
         artist


### PR DESCRIPTION
## Summary

- Removes `rspotify::model` types from the Artist screen state layer: `Artist.albums: Page<SimplifiedAlbum>` -> `Paged<AlbumInfo>`, `Artist.related_artists: Vec<FullArtist>` -> `Vec<ArtistInfo>`, `Artist.top_tracks: Vec<FullTrack>` -> `Vec<TrackInfo>`, `App.artists: Vec<FullArtist>` -> `Vec<ArtistInfo>`
- Conversion from rspotify types stays behind the `infra/network` boundary in `metadata.rs`, using the `map_page` helper and `From` impls from the Wave 0 mapping layer
- UI (`artist.rs`) uses `join_artist_names` for album artist columns; handlers re-parse stored `Option<String>` ids back to typed rspotify ids only when dispatching existing `IoEvent` variants (residual rspotify in handlers per slice contract)
- Switches `ArtistBlock::Albums` Enter from `GetAlbumTracks` to `GetAlbum` (only viable path with `AlbumInfo.id: Option<String>`); guards seed-less recommendation dispatch for related artists with no id

## Test plan

- [ ] Slim build passes: `cargo build --no-default-features --features telemetry`
- [ ] Full build passes: `cargo build`
- [ ] Slim clippy clean: `cargo clippy --no-default-features --features telemetry -- -D warnings`
- [ ] All 261 tests pass: `cargo test --no-default-features --features telemetry`
- [ ] `cargo fmt --all` applied