### PR TITLE
fix(mpris): implement volume Set and sync Volume property to D-Bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Native streaming silent playback (HTTP 530)**: Native audio no longer fails silently when Spotify's CDN returns HTTP 530 for the first of the candidate URLs it hands out. spotatui now builds librespot from a maintained fork ([spotatui-librespot](https://github.com/LargeModGames/spotatui-librespot)) that backports upstream [PR #1722](https://github.com/librespot-org/librespot/pull/1722) ([#1725](https://github.com/librespot-org/librespot/issues/1725)), falling back to the next CDN URL on any non-206 response. Repeated unavailable tracks now also halt playback instead of stampeding the queue and risking a rate-limit.
 - **Native streaming startup device recovery**: Startup now trusts the local `spotatui` Connect device id, preserves saved external devices, activates the native device when Spotify reports no active playback, and renders an actionable idle playbar so paused native sessions restore without manually opening the device selector ([#301](https://github.com/LargeModGames/spotatui/issues/301)).
+- **MPRIS volume control**: `playerctl volume` (and other MPRIS clients) can now actually set spotatui's volume — previously only reads worked, since no `connect_set_volume` handler was ever registered. Volume changes made via the native streaming fast path (keyboard, Lua) now also sync back to the MPRIS `Volume` property immediately, so relative adjustments like `playerctl volume 0.05+` no longer compute from a stale cached value ([#327](https://github.com/LargeModGames/spotatui/issues/327)).
 
 ### Added
 

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -2080,6 +2080,14 @@ impl App {
           self.user_config.behavior.volume_percent = next_volume;
           let _ = self.user_config.save_config();
           self.pending_volume = Some(next_volume);
+
+          // Notify MPRIS clients of the change (VolumeChanged is never emitted by
+          // librespot for local mixer changes, so this is the only way the
+          // Volume D-Bus property stays in sync)
+          #[cfg(all(feature = "mpris", target_os = "linux"))]
+          if let Some(ref mpris) = self.mpris_manager {
+            mpris.set_volume(next_volume);
+          }
           return;
         }
       }
@@ -2118,6 +2126,14 @@ impl App {
           self.user_config.behavior.volume_percent = next_volume;
           let _ = self.user_config.save_config();
           self.pending_volume = Some(next_volume);
+
+          // Notify MPRIS clients of the change (VolumeChanged is never emitted by
+          // librespot for local mixer changes, so this is the only way the
+          // Volume D-Bus property stays in sync)
+          #[cfg(all(feature = "mpris", target_os = "linux"))]
+          if let Some(ref mpris) = self.mpris_manager {
+            mpris.set_volume(next_volume);
+          }
           return;
         }
       }
@@ -2161,6 +2177,14 @@ impl App {
           self.user_config.behavior.volume_percent = next_volume_u8;
           let _ = self.user_config.save_config();
           self.pending_volume = Some(next_volume_u8);
+
+          // Notify MPRIS clients of the change (VolumeChanged is never emitted by
+          // librespot for local mixer changes, so this is the only way the
+          // Volume D-Bus property stays in sync)
+          #[cfg(all(feature = "mpris", target_os = "linux"))]
+          if let Some(ref mpris) = self.mpris_manager {
+            mpris.set_volume(next_volume_u8);
+          }
           return;
         }
       }

--- a/src/infra/mpris.rs
+++ b/src/infra/mpris.rs
@@ -25,6 +25,7 @@ pub enum MprisEvent {
   SetPosition(i64), // Absolute position in microseconds
   SetShuffle(bool),
   SetLoopStatus(LoopStatusEvent),
+  SetVolume(u8), // 0-100
 }
 
 /// Loop status from MPRIS (matches mpris_server::LoopStatus)
@@ -150,6 +151,12 @@ impl MprisManager {
         let tx = event_tx.clone();
         player.connect_set_shuffle(move |_player, shuffle| {
           let _ = tx.send(MprisEvent::SetShuffle(shuffle));
+        });
+
+        let tx = event_tx.clone();
+        player.connect_set_volume(move |_player, volume| {
+          let percent = (volume * 100.0).round().clamp(0.0, 100.0) as u8;
+          let _ = tx.send(MprisEvent::SetVolume(percent));
         });
 
         let tx = event_tx.clone();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1496,6 +1496,10 @@ async fn handle_mpris_events(
         }
         app_lock.dispatch(IoEvent::Repeat(repeat_state));
       }
+      MprisEvent::SetVolume(volume_percent) => {
+        let mut app_lock = app.lock().await;
+        app_lock.set_volume_percent(volume_percent);
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

Fixes #327. `playerctl` (and other MPRIS clients) could read spotatui's volume but not set it:

- `player.connect_set_volume(...)` was never registered in `src/infra/mpris.rs`, unlike `connect_set_shuffle`/`connect_set_loop_status` which are — so incoming D-Bus `Set` requests on the `Volume` property had nowhere to go and were silently dropped (`mpris_server`'s default handler just iterates an empty callback list and returns `Ok(())`).
- Even once wired up, volume changes made through the native streaming fast path (keyboard, Lua's `spotatui.set_volume()`) never synced back to the MPRIS `Volume` property. The only code that did this (`PlayerEvent::VolumeChanged` in `src/infra/player/events.rs`) depends on librespot's `Player::emit_volume_changed_event()`, which spotatui never calls. So `playerctl volume 0.05+` always computed its delta from the same stale cached value, and volume only ever bounced within a fixed +/-5% band instead of accumulating.

Changes:
- `src/infra/mpris.rs`: added `MprisEvent::SetVolume(u8)`, registered `player.connect_set_volume(...)` (converts the D-Bus `0.0-1.0` float to a `0-100` percent).
- `src/runtime.rs`: routes `MprisEvent::SetVolume` through `App::set_volume_percent(...)`, the same entry point Lua's `spotatui.set_volume()` already uses.
- `src/core/app.rs`: pushes `mpris.set_volume(...)` back to D-Bus in the native-streaming fast-path branches of `set_volume_percent`, `increase_volume`, and `decrease_volume`, mirroring the existing `mpris.set_shuffle(...)`/`mpris.set_loop_status(...)` calls already present there.
- `CHANGELOG.md`: added an entry under `Unreleased -> Fixed`.

Not related to #150 (that was the MPRIS D-Bus service failing to register at all; closed, unrelated). Here the service registers fine, reads/play/pause/next/previous/shuffle/loop all work — only volume writes were affected, and always have been since MPRIS support was first added (confirmed via the full git history of `mpris.rs`).

# Testing

Ran the exact commands from `.github/workflows/ci.yml` (default features, `--locked`), plus the slim build from `CONTRIBUTING.md`:

- `cargo check --locked`
- `cargo test --locked` (378 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --locked -- -D warnings`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
- `cargo test --no-default-features --features telemetry` (252 passed)
- `cargo build --features "mpris,streaming,alsa-backend"`

All clean, no warnings.

# Additional notes

I was not able to exercise this end-to-end with a live `playerctl`/D-Bus session in my environment (no session bus / audio device / Spotify session available), so this is verified by build/lint/test only, not a live manual test. Would appreciate a sanity check from someone who can run `playerctl --player=spotatui volume 0.05+` against a real session before merging.

No existing test coverage exists for `mpris.rs` or the volume functions in `app.rs` (hard to unit test without a live session bus / mixer), so this PR doesn't add new tests — happy to add coverage if there's a preferred approach for testing MPRIS interactions in this codebase.
