### PR TITLE
fix: don't panic on F13–F24 function keys

### DIFF
--- a/src/tui/event/key.rs
+++ b/src/tui/event/key.rs
@@ -70,11 +70,7 @@ pub enum Key {
 impl Key {
   /// Returns the function key corresponding to the given number
   ///
-  /// 1 -> F1, etc...
-  ///
-  /// # Panics
-  ///
-  /// If `n == 0 || n > 12`
+  /// 1 -> F1, etc... Unmapped keys (F13+) return `Unknown`.
   pub fn from_f(n: u8) -> Key {
     match n {
       0 => Key::F0,
@@ -90,7 +86,7 @@ impl Key {
       10 => Key::F10,
       11 => Key::F11,
       12 => Key::F12,
-      _ => panic!("unknown function key: F{}", n),
+      _ => Key::Unknown,
     }
   }
 }


### PR DESCRIPTION
## Summary

Pressing a function key above F12 (F13–F24) crashed the whole TUI. `Key::from_f` only mapped F0–F12 and panicked on anything higher, but crossterm emits `KeyCode::F(n)` up to `n = 24`. Every function key is routed through `from_f`, so an unmapped one — e.g. F24 triggered by a global hotkey while spotatui is focused — took the app down.

This maps the unmapped range to the existing `Key::Unknown` catch-all so unhandled function keys are ignored like any other unbound key. spotatui binds nothing to F13–F24, so no new enum variants are needed.

## Changes

- `src/tui/event/key.rs`: `from_f` returns `Key::Unknown` for `n > 12` instead of `panic!`; dropped the now-inaccurate `# Panics` doc line.

## Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
- `cargo test --no-default-features --features telemetry` (326 passed)

Fixes #332
