### PR TITLE
feat: option to list playlist folders at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Playlist Folders First setting**: A new `behavior.group_folders_first` toggle (Settings → "Playlist Folders First") lists your Spotify playlist folders at the top of the Playlists tab, above playlists, keeping each group's existing order. Off by default. Handy because folders keep their creation date and otherwise sink to the bottom of the recency-sorted list.
+
 ## [v0.40.1] 2026-07-04
 
 ### Changed

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1811,29 +1811,33 @@ impl App {
 
   /// Get the number of items visible in the current folder level.
   pub fn get_playlist_display_count(&self) -> usize {
-    self
-      .playlist_folder_items
-      .iter()
-      .filter(|item| self.is_playlist_item_visible_in_current_folder(item))
-      .count()
+    self.get_playlist_display_items().len()
   }
 
   /// Get a visible item by display index in the current folder.
   pub fn get_playlist_display_item_at(&self, display_index: usize) -> Option<&PlaylistFolderItem> {
     self
-      .playlist_folder_items
-      .iter()
-      .filter(|item| self.is_playlist_item_visible_in_current_folder(item))
+      .get_playlist_display_items()
+      .into_iter()
       .nth(display_index)
   }
 
   /// Get visible playlist items in the current folder (used by UI rendering).
+  ///
+  /// Single source of truth for the visible order: rendering and index-based
+  /// selection (keyboard + mouse) both go through it, so they can never
+  /// disagree. When `group_folders_first` is set, folders are hoisted to the
+  /// top via a stable sort, preserving each group's relative order.
   pub fn get_playlist_display_items(&self) -> Vec<&PlaylistFolderItem> {
-    self
+    let mut items: Vec<&PlaylistFolderItem> = self
       .playlist_folder_items
       .iter()
       .filter(|item| self.is_playlist_item_visible_in_current_folder(item))
-      .collect()
+      .collect();
+    if self.user_config.behavior.group_folders_first {
+      items.sort_by_key(|item| !matches!(item, PlaylistFolderItem::Folder(_)));
+    }
+    items
   }
 
   /// Get the playlist for a PlaylistFolderItem::Playlist variant
@@ -3978,6 +3982,12 @@ impl App {
           value: SettingValue::Bool(self.user_config.behavior.enforce_wide_search_bar),
         },
         SettingItem {
+          id: "behavior.group_folders_first".to_string(),
+          name: "Playlist Folders First".to_string(),
+          description: "List folders at the top of the Playlists tab".to_string(),
+          value: SettingValue::Bool(self.user_config.behavior.group_folders_first),
+        },
+        SettingItem {
           id: "behavior.disable_mouse_inputs".to_string(),
           name: "Disable Mouse Inputs".to_string(),
           description: "Disable mouse inputs for keyboard-only navigation".to_string(),
@@ -4491,6 +4501,11 @@ impl App {
         "behavior.enforce_wide_search_bar" => {
           if let SettingValue::Bool(v) = &setting.value {
             self.user_config.behavior.enforce_wide_search_bar = *v;
+          }
+        }
+        "behavior.group_folders_first" => {
+          if let SettingValue::Bool(v) = &setting.value {
+            self.user_config.behavior.group_folders_first = *v;
           }
         }
         "behavior.disable_mouse_inputs" => {
@@ -5072,6 +5087,57 @@ mod tests {
       track_number: 1,
       r#type: rspotify::model::Type::Track,
     }
+  }
+
+  #[test]
+  fn group_folders_first_hoists_folders_stably_and_only_when_enabled() {
+    fn folder(name: &str) -> PlaylistFolderItem {
+      PlaylistFolderItem::Folder(PlaylistFolder {
+        name: name.to_string(),
+        current_id: 0,
+        target_id: 1,
+      })
+    }
+    fn playlist(index: usize) -> PlaylistFolderItem {
+      PlaylistFolderItem::Playlist {
+        index,
+        current_id: 0,
+      }
+    }
+    // Interleaved: playlist, folder A, playlist, folder B (all at root level).
+    let mut app = App {
+      playlist_folder_items: vec![playlist(0), folder("A"), playlist(1), folder("B")],
+      ..Default::default()
+    };
+
+    // Off (default): order is untouched.
+    app.user_config.behavior.group_folders_first = false;
+    let names: Vec<&str> = app
+      .get_playlist_display_items()
+      .iter()
+      .map(|i| match i {
+        PlaylistFolderItem::Folder(f) => f.name.as_str(),
+        PlaylistFolderItem::Playlist { .. } => "P",
+      })
+      .collect();
+    assert_eq!(names, vec!["P", "A", "P", "B"]);
+
+    // On: folders float to the top; both groups keep their relative order.
+    app.user_config.behavior.group_folders_first = true;
+    let names: Vec<&str> = app
+      .get_playlist_display_items()
+      .iter()
+      .map(|i| match i {
+        PlaylistFolderItem::Folder(f) => f.name.as_str(),
+        PlaylistFolderItem::Playlist { .. } => "P",
+      })
+      .collect();
+    assert_eq!(names, vec!["A", "B", "P", "P"]);
+    // Selection index resolves against the same reordered list.
+    assert!(matches!(
+      app.get_playlist_display_item_at(0),
+      Some(PlaylistFolderItem::Folder(_))
+    ));
   }
 
   #[cfg(feature = "streaming")]

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -748,6 +748,7 @@ pub struct BehaviorConfigString {
   pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
   pub enforce_wide_search_bar: Option<bool>,
+  pub group_folders_first: Option<bool>,
   pub enable_global_song_count: Option<bool>,
   pub disable_mouse_inputs: Option<bool>,
   pub enable_discord_rpc: Option<bool>,
@@ -801,6 +802,7 @@ pub struct BehaviorConfig {
   pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
   pub enforce_wide_search_bar: bool,
+  pub group_folders_first: bool,
   pub enable_global_song_count: bool,
   pub disable_mouse_inputs: bool,
   pub enable_discord_rpc: bool,
@@ -957,6 +959,7 @@ impl UserConfig {
         enable_text_emphasis: true,
         show_loading_indicator: true,
         enforce_wide_search_bar: false,
+        group_folders_first: false,
         enable_global_song_count: true,
         disable_mouse_inputs: false,
         enable_discord_rpc: true,
@@ -1214,6 +1217,10 @@ impl UserConfig {
 
     if let Some(wide_search_bar) = behavior_config.enforce_wide_search_bar {
       self.behavior.enforce_wide_search_bar = wide_search_bar;
+    }
+
+    if let Some(group_folders_first) = behavior_config.group_folders_first {
+      self.behavior.group_folders_first = group_folders_first;
     }
 
     if let Some(liked_icon) = behavior_config.liked_icon {
@@ -1536,6 +1543,7 @@ impl UserConfig {
       enable_text_emphasis: Some(self.behavior.enable_text_emphasis),
       show_loading_indicator: Some(self.behavior.show_loading_indicator),
       enforce_wide_search_bar: Some(self.behavior.enforce_wide_search_bar),
+      group_folders_first: Some(self.behavior.group_folders_first),
       enable_global_song_count: Some(self.behavior.enable_global_song_count),
       disable_mouse_inputs: Some(self.behavior.disable_mouse_inputs),
       enable_discord_rpc: Some(self.behavior.enable_discord_rpc),

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -1161,6 +1161,51 @@ mod tests {
   }
 
   #[test]
+  fn reconcile_restores_selection_against_folders_first_order() {
+    use crate::core::app::{App, PlaylistFolder, PlaylistFolderItem};
+    use crate::core::test_helpers::playlist_info;
+
+    // Root order: P0, folderA, P1, folderB. Restore selection to P1.
+    let mut app = App::default();
+    app.all_playlists = vec![
+      playlist_info("00000000000000000000p0", "P0", "me", false),
+      playlist_info("00000000000000000000p1", "P1", "me", false),
+    ];
+    app.playlist_folder_items = vec![
+      PlaylistFolderItem::Playlist {
+        index: 0,
+        current_id: 0,
+      },
+      PlaylistFolderItem::Folder(PlaylistFolder {
+        name: "A".to_string(),
+        current_id: 0,
+        target_id: 1,
+      }),
+      PlaylistFolderItem::Playlist {
+        index: 1,
+        current_id: 0,
+      },
+      PlaylistFolderItem::Folder(PlaylistFolder {
+        name: "B".to_string(),
+        current_id: 0,
+        target_id: 2,
+      }),
+    ];
+    app.user_config.behavior.group_folders_first = true;
+
+    reconcile_playlist_selection(&mut app, Some("00000000000000000000p1"), 0, None);
+
+    // Sorted view is [A, B, P0, P1]; P1 lives at display index 3, and the
+    // restored index must resolve back to P1 (not P0 at the unsorted index 2).
+    let idx = app.selected_playlist_index.expect("selection restored");
+    assert_eq!(idx, 3);
+    assert!(matches!(
+      app.get_playlist_display_item_at(idx),
+      Some(PlaylistFolderItem::Playlist { index: 1, .. })
+    ));
+  }
+
+  #[test]
   fn next_saved_tracks_offset_uses_page_limit() {
     let page = saved_tracks_page(20, 20, true);
     assert_eq!(next_saved_tracks_offset(&page), Some(40));
@@ -1297,9 +1342,8 @@ fn reconcile_playlist_selection(
 
   if let Some(playlist_id) = preferred_playlist_id {
     let visible_playlist_index = app
-      .playlist_folder_items
-      .iter()
-      .filter(|item| app.is_playlist_item_visible_in_current_folder(item))
+      .get_playlist_display_items()
+      .into_iter()
       .enumerate()
       .find_map(|(display_idx, item)| match item {
         PlaylistFolderItem::Playlist { index, .. } => app
@@ -1330,9 +1374,8 @@ fn reconcile_playlist_selection(
     if let Some(folder_id) = target_folder {
       app.current_playlist_folder_id = folder_id;
       let display_idx = app
-        .playlist_folder_items
-        .iter()
-        .filter(|item| app.is_playlist_item_visible_in_current_folder(item))
+        .get_playlist_display_items()
+        .into_iter()
         .enumerate()
         .find_map(|(idx, item)| match item {
           PlaylistFolderItem::Playlist { index, .. } => app


### PR DESCRIPTION
## Summary

Adds a `behavior.group_folders_first` toggle (Settings → "Playlist Folders First") that lists your Spotify playlist folders at the top of the Playlists tab, above playlists, keeping each group's existing order. **Off by default.** Handy because folders keep their creation date and otherwise sink to the bottom of the recency-sorted list.

## Implementation

The reorder lives in `get_playlist_display_items()` — the single source of truth for the visible list — as a stable `sort_by_key` that hoists `Folder` items. `get_playlist_display_count()` and `get_playlist_display_item_at()` delegate to it, so rendering and index-based selection (keyboard + mouse) can't desync. No-op where there are no folders (slim/Web-API builds, non-Spotify sources), so nothing changes when the toggle is off.

## Testing

- New unit test: folders hoist stably only when enabled; selection index resolves against the reordered list.
- `cargo fmt --all`, `cargo clippy --no-default-features --features telemetry -- -D warnings`, `cargo test --no-default-features --features telemetry` — all green (327 tests).
