### PR TITLE
feat(queue): native cross-source play queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **Native cross-source play queue**: Press `z` on any track to add it to a native queue that plays across sources (Spotify, Local Files, Subsonic, and YouTube in one FIFO; internet radio is excluded since a live stream is not a finite track). Queued tracks play before the underlying playlist/album context, then that context resumes where it left off. Open the queue with `Shift+Q`: remove the selected item with `x` (rebindable via `remove_from_queue`, default `x`), reorder it with `J`/`K`, or press `Enter` to skip ahead and play it now. The Queue screen also previews what resumes from the underlying context once the queue drains. The queue survives restarts (persisted in `last_session.yml`). Spotify tracks queue through native (librespot) streaming; when you are controlling an external Spotify Connect device instead, `z` keeps the previous Web-API "add to Spotify's queue" behavior ([#206](https://github.com/LargeModGames/spotatui/issues/206)).
 - **Playlist Folders First setting**: A new `behavior.group_folders_first` toggle (Settings → "Playlist Folders First") lists your Spotify playlist folders at the top of the Playlists tab, above playlists, keeping each group's existing order. Off by default. Handy because folders keep their creation date and otherwise sink to the bottom of the recency-sorted list.
 
 ## [v0.40.1] 2026-07-04

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ There is also a CLI that is able to do most of the stuff the UI does. Use `spota
 
 See [Keybindings Wiki](https://github.com/LargeModGames/spotatui/wiki/Keybindings) for the full list of keyboard shortcuts.
 
+**Play queue**: press `z` on any track to add it to a native queue that plays across all sources (Spotify, Local Files, Subsonic, YouTube) before your current playlist/album context resumes. Open the queue with `Shift+Q` to remove an item (`x`, configurable via `remove_from_queue`), reorder it (`J`/`K`), or press `Enter` to skip ahead and play it now.
+
 Here are some example to get you excited.
 ```
 spotatui --completions zsh # Prints shell completions for zsh to stdout (bash, power-shell and more are supported)

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -3056,16 +3056,31 @@ impl App {
   /// `EnsurePlaybackContinues`), `false` to let the normal continue-playback path
   /// run. Two cases:
   ///
-  /// - **A queued Spotify track just ended** (`queue_owns_playback`): advance to
-  ///   the next queued item (or resume when the queue drains).
+  /// - **A queued Spotify track just ended** (`queue_now_is_spotify`): clear the
+  ///   slot *now* — before the advance is processed — so the Spirc self-advance
+  ///   guard can't see the stale slot on the next `TrackChanged` and reissue the
+  ///   finished track over the next item's download window. Pause librespot
+  ///   (Spirc may already be loading its own next track) and advance the queue.
+  /// - **A stray librespot `EndOfTrack` while a decoded queued track owns the
+  ///   sink** (`queue_owns_playback` without a Spotify slot): consume it without
+  ///   touching the queue — advancing would skip the audible decoded track, and
+  ///   `EnsurePlaybackContinues` would resume Spotify over it.
   /// - **A context track ended with items waiting** (queue idle, non-empty):
   ///   snapshot the Spotify context for resume, `pause()` the streaming player to
   ///   preempt Spirc's own auto-advance, then advance the queue.
   #[cfg(feature = "streaming")]
   pub(crate) fn handle_native_spotify_track_end(&mut self) -> bool {
-    if self.queue_owns_playback() {
+    if self.queue_now_is_spotify() {
+      self.queue_now = None;
+      self.spotify_queue_guard_reloads = 0;
+      if let Some(player) = self.streaming_player.as_ref() {
+        player.pause();
+      }
       self.song_progress_ms = 0;
       self.dispatch(IoEvent::AdvanceNativeQueue);
+      return true;
+    }
+    if self.queue_owns_playback() {
       return true;
     }
     if !self.native_queue.is_empty() {
@@ -5874,6 +5889,34 @@ mod tests {
       matches!(rx.recv().unwrap(), IoEvent::AdvanceNativeQueue),
       "expected AdvanceNativeQueue to be dispatched first"
     );
+  }
+
+  /// When the queued Spotify track ends, the slot must be cleared *before* the
+  /// advance is dispatched — a stale slot lets the Spirc self-advance guard
+  /// reissue the finished track over the next item's download window (heard as
+  /// "the Spotify song keeps playing while the YouTube track downloads").
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn spotify_slot_end_clears_slot_before_advancing() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+    app.spotify_queue_guard_reloads = 1;
+
+    assert!(app.handle_native_spotify_track_end());
+
+    assert!(!app.queue_owns_playback(), "the ended slot is cleared");
+    assert_eq!(app.spotify_queue_guard_reloads, 0);
+    assert!(
+      app
+        .spotify_queue_guard_reload_uri("some-other-track-id")
+        .is_none(),
+      "an empty slot must never reissue the finished track"
+    );
+    assert!(matches!(rx.recv().unwrap(), IoEvent::AdvanceNativeQueue));
   }
 
   #[cfg(feature = "streaming")]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -847,6 +847,13 @@ pub struct App {
   /// [`Self::queue_owns_playback`] accessor.
   #[cfg(any(feature = "streaming", feature = "audio-decode"))]
   pub queue_now: Option<crate::infra::queue::QueueNowPlaying>,
+  /// Bounded retry guard for the native-Spotify queue slot. When a queued
+  /// Spotify track is playing via a direct `player.load` (no Spirc context) and
+  /// Spirc self-advances to a different track, the player-event handler reissues
+  /// the queued track and increments this. Reset to 0 each time a new Spotify
+  /// queue slot is published; capped so a genuinely-gone track can't loop.
+  #[cfg(feature = "streaming")]
+  pub spotify_queue_guard_reloads: u8,
   #[cfg(feature = "cover-art")]
   pub cover_art: crate::tui::cover_art::CoverArt,
   /// Status of the current track's cover art, driving the placeholder message.
@@ -1230,6 +1237,8 @@ impl Default for App {
       queue_suspended: None,
       #[cfg(any(feature = "streaming", feature = "audio-decode"))]
       queue_now: None,
+      #[cfg(feature = "streaming")]
+      spotify_queue_guard_reloads: 0,
       input: vec![],
       input_idx: 0,
       input_cursor_position: 0,
@@ -2784,6 +2793,13 @@ impl App {
     let name = track.name.clone();
     self.native_queue.push(track);
     self.set_status_message(format!("Queued: {name}"), 3);
+    // Keep the Spotify mirror queue ([`Self::queue`]) current while a native
+    // Spotify context is playing: it is the snapshot source for the resume
+    // target when this newly-queued item later suspends the context.
+    #[cfg(feature = "streaming")]
+    if self.is_native_streaming_active_for_playback() && !self.queue_owns_playback() {
+      self.dispatch(IoEvent::GetQueue);
+    }
   }
 
   /// Whether the native queue's playback slot currently owns the output (either a
@@ -2937,6 +2953,103 @@ impl App {
         station: radio.station,
       });
     }
+  }
+
+  /// Snapshot how to resume the underlying native-Spotify context once the
+  /// native queue drains, and record it in [`Self::queue_suspended`]. Skip
+  /// semantics: `resume_track_uri` is the head of the Spotify mirror queue
+  /// ([`Self::queue`]) — i.e. the *next* track Spirc would have played — so the
+  /// context resumes at its next track, matching Spotify's own queue behavior.
+  /// Either field is `None` when the corresponding state is unknown; the resume
+  /// handler degrades gracefully (context-only, or track-only, or "finished").
+  #[cfg(feature = "streaming")]
+  pub(crate) fn suspend_native_spotify_context_for_queue(&mut self) {
+    let context_uri = self
+      .current_playback_context
+      .as_ref()
+      .and_then(|ctx| ctx.context.as_ref())
+      .map(|c| c.uri.clone());
+    let resume_track_uri = self
+      .queue
+      .as_ref()
+      .and_then(|q| q.queue.first())
+      .and_then(|item| match item {
+        crate::core::plugin_api::PlayableInfo::Track(t) => t.uri.clone(),
+        crate::core::plugin_api::PlayableInfo::Episode(e) => e.uri.clone(),
+      });
+    self.queue_suspended = Some(crate::core::queue::SuspendedContext::Spotify {
+      context_uri,
+      resume_track_uri,
+    });
+  }
+
+  /// Handle a native-streaming `EndOfTrack` while the native queue is in play.
+  ///
+  /// Returns `true` when the queue took over (an `AdvanceNativeQueue` was
+  /// dispatched, so the caller must **not** fall back to
+  /// `EnsurePlaybackContinues`), `false` to let the normal continue-playback path
+  /// run. Two cases:
+  ///
+  /// - **A queued Spotify track just ended** (`queue_owns_playback`): advance to
+  ///   the next queued item (or resume when the queue drains).
+  /// - **A context track ended with items waiting** (queue idle, non-empty):
+  ///   snapshot the Spotify context for resume, `pause()` the streaming player to
+  ///   preempt Spirc's own auto-advance, then advance the queue.
+  #[cfg(feature = "streaming")]
+  pub(crate) fn handle_native_spotify_track_end(&mut self) -> bool {
+    if self.queue_owns_playback() {
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::AdvanceNativeQueue);
+      return true;
+    }
+    if !self.native_queue.is_empty() {
+      self.suspend_native_spotify_context_for_queue();
+      // Preempt Spirc: after a direct `player.load`, Spirc may try to advance to
+      // the next context track on its own. Pausing first stops that before the
+      // queue slot takes the sink.
+      if let Some(player) = self.streaming_player.as_ref() {
+        player.pause();
+      }
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::AdvanceNativeQueue);
+      return true;
+    }
+    false
+  }
+
+  /// Spirc self-advance guard for the native-Spotify queue slot.
+  ///
+  /// A queued Spotify track plays via a direct `player.load` (no Spirc context),
+  /// so Spirc may try to advance to the next context track on its own when the
+  /// queued track ends. Given the base62 id of the track librespot just switched
+  /// to, this returns `Some(uri)` to reissue the queued track (Spirc fought
+  /// back), or `None` to leave playback alone. Bounded by
+  /// [`Self::spotify_queue_guard_reloads`] so a genuinely-gone track can't wedge
+  /// a reload loop; the budget resets whenever the queued track is confirmed
+  /// playing. See Risk #1 in the plan — the mitigation is pending a live
+  /// experiment and cannot be verified without a real Spotify session.
+  #[cfg(feature = "streaming")]
+  pub(crate) fn spotify_queue_guard_reload_uri(
+    &mut self,
+    playing_base62_id: &str,
+  ) -> Option<String> {
+    let queued_uri = match self.queue_now.as_ref()? {
+      #[cfg(feature = "audio-decode")]
+      QueueNowPlaying::Decoded(_) => return None,
+      QueueNowPlaying::Spotify { track } => track.uri.clone(),
+    }?;
+    let queued_id = queued_uri.rsplit(':').next().unwrap_or(queued_uri.as_str());
+    if queued_id == playing_base62_id {
+      // The queued track is (re)confirmed playing: clear the retry budget.
+      self.spotify_queue_guard_reloads = 0;
+      return None;
+    }
+    const MAX_RELOADS: u8 = 2;
+    if self.spotify_queue_guard_reloads >= MAX_RELOADS {
+      return None;
+    }
+    self.spotify_queue_guard_reloads += 1;
+    Some(queued_uri)
   }
 
   /// Whether any decoded-audio source (local file, Subsonic, internet radio, or
@@ -3291,6 +3404,19 @@ impl App {
     // Use native streaming player for instant control (bypasses event channel latency)
     #[cfg(feature = "streaming")]
     if self.is_native_streaming_active_for_playback() {
+      // A native-Spotify context is playing with items waiting in the queue:
+      // suspend it (skip semantics) and hand the sink to the queue instead of
+      // Spirc-advancing the context. (`queue_owns_playback` is already handled
+      // above, so here the context, not a queued track, is playing.)
+      if !self.native_queue.is_empty() {
+        self.suspend_native_spotify_context_for_queue();
+        if let Some(player) = self.streaming_player.as_ref() {
+          player.pause();
+        }
+        self.song_progress_ms = 0;
+        self.dispatch(IoEvent::AdvanceNativeQueue);
+        return;
+      }
       if let Some(ref player) = self.streaming_player {
         player.activate();
         player.next();
@@ -5553,6 +5679,132 @@ mod tests {
       currently_playing_type: CurrentlyPlayingType::Track,
       actions: Actions::default(),
     }
+  }
+
+  #[cfg(feature = "streaming")]
+  #[allow(deprecated)]
+  fn context_playing(context_uri: &str) -> CurrentPlaybackContext {
+    use rspotify::model::{context::Context, Type};
+    let mut ctx = make_external_context();
+    ctx.context = Some(Context {
+      uri: context_uri.to_string(),
+      href: String::new(),
+      external_urls: HashMap::new(),
+      _type: Type::Playlist,
+    });
+    ctx
+  }
+
+  /// The suspension snapshot records the context's uri and, as the resume target,
+  /// the head of the Spotify mirror queue (the *next* track Spirc would play).
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn suspend_native_spotify_context_snapshots_context_and_next_track() {
+    use crate::core::plugin_api::PlayableInfo;
+    use crate::core::queue::SuspendedContext;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.current_playback_context = Some(context_playing("spotify:playlist:ctx123"));
+    app.queue = Some(QueueState {
+      currently_playing: Some(PlayableInfo::Track(queue_track(
+        Some("spotify:track:current"),
+        "Current",
+      ))),
+      queue: vec![
+        PlayableInfo::Track(queue_track(Some("spotify:track:next1"), "Next One")),
+        PlayableInfo::Track(queue_track(Some("spotify:track:next2"), "Next Two")),
+      ],
+    });
+
+    app.suspend_native_spotify_context_for_queue();
+
+    match app.queue_suspended {
+      Some(SuspendedContext::Spotify {
+        context_uri,
+        resume_track_uri,
+      }) => {
+        assert_eq!(context_uri.as_deref(), Some("spotify:playlist:ctx123"));
+        assert_eq!(resume_track_uri.as_deref(), Some("spotify:track:next1"));
+      }
+      other => panic!("expected a Spotify suspension, got {other:?}"),
+    }
+  }
+
+  /// With no mirror queue or context, the snapshot degrades to all-None (the
+  /// resume handler then finishes the queue rather than panicking).
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn suspend_native_spotify_context_degrades_to_none_without_state() {
+    use crate::core::queue::SuspendedContext;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+
+    app.suspend_native_spotify_context_for_queue();
+
+    match app.queue_suspended {
+      Some(SuspendedContext::Spotify {
+        context_uri,
+        resume_track_uri,
+      }) => {
+        assert!(context_uri.is_none());
+        assert!(resume_track_uri.is_none());
+      }
+      other => panic!("expected a Spotify suspension, got {other:?}"),
+    }
+  }
+
+  /// When the native queue slot owns playback, `next_track` advances the queue
+  /// instead of driving the streaming player's own `next`.
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn next_track_advances_native_queue_when_queue_owns_playback() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    app.next_track();
+
+    // The first dispatched event is the queue advance, not a Spotify NextTrack.
+    assert!(
+      matches!(rx.recv().unwrap(), IoEvent::AdvanceNativeQueue),
+      "expected AdvanceNativeQueue to be dispatched first"
+    );
+  }
+
+  /// The Spirc self-advance guard reissues the queued track only when Spirc has
+  /// switched away from it, and only within its bounded retry budget.
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn spotify_queue_guard_reissues_only_on_mismatch_and_within_budget() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    // Same track (base62 id): no reissue, budget stays clear.
+    assert_eq!(app.spotify_queue_guard_reload_uri("queued"), None);
+    assert_eq!(app.spotify_queue_guard_reloads, 0);
+
+    // Spirc switched away: reissue our track, up to the cap, then stop.
+    assert_eq!(
+      app.spotify_queue_guard_reload_uri("other").as_deref(),
+      Some("spotify:track:queued")
+    );
+    assert_eq!(
+      app.spotify_queue_guard_reload_uri("other").as_deref(),
+      Some("spotify:track:queued")
+    );
+    assert_eq!(app.spotify_queue_guard_reload_uri("other"), None);
+    assert_eq!(app.spotify_queue_guard_reloads, 2);
+
+    // The queued track being confirmed playing again resets the budget.
+    assert_eq!(app.spotify_queue_guard_reload_uri("queued"), None);
+    assert_eq!(app.spotify_queue_guard_reloads, 0);
   }
 
   #[test]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -831,6 +831,14 @@ pub struct App {
   pub devices: Option<DevicePayload>,
   pub queue: Option<QueueState>,
   pub queue_selected_index: usize,
+  /// The native cross-source playback queue (FIFO). Unlike [`Self::queue`]
+  /// (a read-only mirror of Spotify's Web-API queue), this is owned by the app
+  /// and holds tracks from any source. Phase 2 consumes it for playback.
+  pub native_queue: Vec<TrackInfo>,
+  /// How to resume the underlying per-source context after the native queue
+  /// drains. Populated by the Phase 2 playback engine; unused in Phase 1.
+  #[allow(dead_code)]
+  pub queue_suspended: Option<crate::core::queue::SuspendedContext>,
   #[cfg(feature = "cover-art")]
   pub cover_art: crate::tui::cover_art::CoverArt,
   /// Status of the current track's cover art, driving the placeholder message.
@@ -1210,6 +1218,8 @@ impl Default for App {
       devices: None,
       queue: None,
       queue_selected_index: 0,
+      native_queue: Vec::new(),
+      queue_suspended: None,
       input: vec![],
       input_idx: 0,
       input_cursor_position: 0,
@@ -1472,6 +1482,23 @@ impl App {
       });
     }
     None
+  }
+
+  /// Snapshot the full session to persist: the active non-Spotify playback (if
+  /// any) plus the native queue. Returns `None` only when there is nothing to
+  /// save (no active source *and* an empty queue), so the caller clears the
+  /// session file — preserving the existing Some→None clear semantics.
+  pub fn current_persisted_session(
+    &self,
+  ) -> Option<crate::core::persisted_playback::PersistedSession> {
+    let playback = self.current_persisted_playback();
+    if playback.is_none() && self.native_queue.is_empty() {
+      return None;
+    }
+    Some(crate::core::persisted_playback::PersistedSession {
+      playback,
+      queue: self.native_queue.clone(),
+    })
   }
 
   #[allow(dead_code)]
@@ -2625,6 +2652,53 @@ impl App {
 
     // No match - not the active device
     false
+  }
+
+  /// Whether Spotify playback is happening on an *external* Connect device
+  /// (i.e. a Spotify context exists and it is not our own native streaming
+  /// device). When true, `z` on a Spotify track keeps today's Web-API
+  /// `AddItemToQueue` behavior instead of routing to the native queue. Under a
+  /// build without native streaming, any Spotify context is external by
+  /// definition.
+  pub fn spotify_external_device_active(&self) -> bool {
+    #[cfg(feature = "streaming")]
+    {
+      self.current_playback_context.is_some() && !self.is_native_streaming_active_for_playback()
+    }
+    #[cfg(not(feature = "streaming"))]
+    {
+      self.current_playback_context.is_some()
+    }
+  }
+
+  /// Add a track to the native cross-source queue.
+  ///
+  /// Rejects tracks with no URI and radio streams (a live stream is not a finite
+  /// track). Spotify tracks on an external Connect device keep today's Web-API
+  /// queue behavior (there is no native sink to play them through); everything
+  /// else is pushed onto [`Self::native_queue`].
+  pub fn add_track_to_native_queue(&mut self, track: TrackInfo) {
+    let Some(uri) = track.uri.clone() else {
+      self.set_status_message("Cannot queue: track has no URI", 3);
+      return;
+    };
+    if uri.starts_with("radio:") {
+      self.set_status_message("Radio stations can't be queued", 3);
+      return;
+    }
+    // A Spotify track controlled on an external device has no native sink to
+    // play through, so fall back to the Spotify Web-API queue.
+    if matches!(
+      crate::core::queue::queue_item_source(&uri),
+      crate::core::queue::QueueItemSource::Spotify
+    ) && self.spotify_external_device_active()
+    {
+      self.dispatch(IoEvent::AddItemToQueue(uri));
+      return;
+    }
+    let name = track.name.clone();
+    self.native_queue.push(track);
+    self.set_status_message(format!("Queued: {name}"), 3);
   }
 
   /// Whether any decoded-audio source (local file, Subsonic, internet radio, or
@@ -4297,6 +4371,12 @@ impl App {
           value: SettingValue::Key(key_to_string(&self.user_config.keys.show_queue)),
         },
         SettingItem {
+          id: "keys.remove_from_queue".to_string(),
+          name: "Remove from Queue".to_string(),
+          description: "Remove the selected track from the queue".to_string(),
+          value: SettingValue::Key(key_to_string(&self.user_config.keys.remove_from_queue)),
+        },
+        SettingItem {
           id: "keys.like_track".to_string(),
           name: "Like Track".to_string(),
           description: "Toggle saved state for the currently playing track or episode"
@@ -4810,6 +4890,13 @@ impl App {
             }
           }
         }
+        "keys.remove_from_queue" => {
+          if let SettingValue::Key(v) = &setting.value {
+            if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
+              self.user_config.keys.remove_from_queue = key;
+            }
+          }
+        }
         "keys.like_track" => {
           if let SettingValue::Key(v) = &setting.value {
             if let Ok(key) = crate::core::user_config::parse_key_public(v.clone()) {
@@ -5086,6 +5173,106 @@ mod tests {
       preview_url: None,
       track_number: 1,
       r#type: rspotify::model::Type::Track,
+    }
+  }
+
+  fn queue_track(uri: Option<&str>, name: &str) -> TrackInfo {
+    TrackInfo {
+      uri: uri.map(|u| u.to_string()),
+      name: name.to_string(),
+      artists: vec!["Artist".to_string()],
+      album: "Album".to_string(),
+      duration_ms: 1000,
+      id: None,
+      album_id: None,
+      artist_refs: vec![],
+      is_playable: true,
+      is_local: false,
+      track_number: 0,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  #[test]
+  fn add_track_to_native_queue_pushes_normal_track() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.add_track_to_native_queue(queue_track(Some("subsonic:track:1"), "Song"));
+    assert_eq!(app.native_queue.len(), 1);
+    assert_eq!(app.native_queue[0].name, "Song");
+    // No Web-API dispatch for a non-Spotify item.
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn add_track_to_native_queue_rejects_missing_uri() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.add_track_to_native_queue(queue_track(None, "No URI"));
+    assert!(app.native_queue.is_empty());
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn add_track_to_native_queue_rejects_radio() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.add_track_to_native_queue(queue_track(Some("radio:https://example.com/live"), "Live"));
+    assert!(app.native_queue.is_empty());
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn add_track_to_native_queue_spotify_no_context_pushes_natively() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    // No playback context => not external => queue natively (Spotify tracks play
+    // via native streaming, wired in Phase 3).
+    app.add_track_to_native_queue(queue_track(Some("spotify:track:abc"), "Spotify Song"));
+    assert_eq!(app.native_queue.len(), 1);
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn add_track_to_native_queue_spotify_external_device_dispatches_web_api() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    // A Spotify context with no native streaming device reads as external.
+    app.current_playback_context = Some(make_external_context());
+    app.add_track_to_native_queue(queue_track(Some("spotify:track:abc"), "Spotify Song"));
+    // Routed to the Web-API queue; nothing pushed to the native queue.
+    assert!(app.native_queue.is_empty());
+    match rx.recv().unwrap() {
+      IoEvent::AddItemToQueue(uri) => assert_eq!(uri, "spotify:track:abc"),
+      _ => panic!("expected AddItemToQueue dispatch"),
+    }
+  }
+
+  #[allow(deprecated)]
+  fn make_external_context() -> CurrentPlaybackContext {
+    use rspotify::model::{
+      context::Actions, CurrentlyPlayingType, Device, DeviceType, RepeatState,
+    };
+    CurrentPlaybackContext {
+      device: Device {
+        id: Some("external".to_string()),
+        is_active: true,
+        is_private_session: false,
+        is_restricted: false,
+        name: "Phone".to_string(),
+        _type: DeviceType::Smartphone,
+        volume_percent: Some(50),
+      },
+      repeat_state: RepeatState::Off,
+      shuffle_state: false,
+      context: None,
+      timestamp: Utc::now(),
+      progress: None,
+      is_playing: true,
+      item: None,
+      currently_playing_type: CurrentlyPlayingType::Track,
+      actions: Actions::default(),
     }
   }
 

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -835,7 +835,7 @@ pub struct App {
   pub queue_selected_index: usize,
   /// The native cross-source playback queue (FIFO). Unlike [`Self::queue`]
   /// (a read-only mirror of Spotify's Web-API queue), this is owned by the app
-  /// and holds tracks from any source. Phase 2 consumes it for playback.
+  /// and holds tracks from any source.
   pub native_queue: Vec<TrackInfo>,
   /// How to resume the underlying per-source context after the native queue
   /// drains. Populated when a track is queued over an active context.
@@ -2803,15 +2803,35 @@ impl App {
   }
 
   /// Whether the native queue's playback slot currently owns the output (either a
-  /// decoded queued track or, in Phase 3, a native-streamed Spotify one). The
-  /// single gated entry point for every queue-ownership check; reduces to `false`
-  /// in a slim build where the slot cannot exist.
+  /// decoded queued track or a native-streamed Spotify one). The single gated
+  /// entry point for every queue-ownership check; reduces to `false` in a slim
+  /// build where the slot cannot exist.
   pub fn queue_owns_playback(&self) -> bool {
     #[cfg(any(feature = "streaming", feature = "audio-decode"))]
     {
       self.queue_now.is_some()
     }
     #[cfg(not(any(feature = "streaming", feature = "audio-decode")))]
+    {
+      false
+    }
+  }
+
+  /// Whether the queue slot is playing a Spotify track via native streaming.
+  /// While true, librespot owns the sink and any still-`Some` decoded
+  /// `*_playback` struct is a *suspended* context that must stay invisible to
+  /// the decoded-ownership predicates (`active_decoded_source`,
+  /// `active_decoded_player`, transport routing) — otherwise a space-bar toggle
+  /// or media key would resume the suspended player on top of librespot.
+  pub(crate) fn queue_now_is_spotify(&self) -> bool {
+    #[cfg(feature = "streaming")]
+    {
+      matches!(
+        self.queue_now.as_ref(),
+        Some(QueueNowPlaying::Spotify { .. })
+      )
+    }
+    #[cfg(not(feature = "streaming"))]
     {
       false
     }
@@ -2983,6 +3003,52 @@ impl App {
     });
   }
 
+  /// Suspend the native-Spotify context with **mid-track** semantics (the
+  /// Enter-jump path): resume at the track that was playing when the user
+  /// jumped, not the context's next one. Position is not preserved — the
+  /// Spotify resume path restarts the track. Pauses the streaming player so the
+  /// queued track doesn't play over it. A no-op unless native streaming is the
+  /// active playback device.
+  #[cfg(feature = "streaming")]
+  pub(crate) fn suspend_native_spotify_context_mid_track(&mut self) {
+    if !self.is_native_streaming_active_for_playback() {
+      return;
+    }
+    let context_uri = self
+      .current_playback_context
+      .as_ref()
+      .and_then(|ctx| ctx.context.as_ref())
+      .map(|c| c.uri.clone());
+    // Resume target: the *current* item. Fall back to the mirror queue's head
+    // (the context's next track) when the current item is unknown.
+    let resume_track_uri = self
+      .current_playback_context
+      .as_ref()
+      .and_then(|ctx| ctx.item.as_ref())
+      .and_then(|item| match item {
+        PlayableItem::Track(t) => t.id.as_ref().map(|id| id.uri()),
+        PlayableItem::Episode(e) => Some(e.id.uri()),
+        _ => None,
+      })
+      .or_else(|| {
+        self
+          .queue
+          .as_ref()
+          .and_then(|q| q.queue.first())
+          .and_then(|item| match item {
+            crate::core::plugin_api::PlayableInfo::Track(t) => t.uri.clone(),
+            crate::core::plugin_api::PlayableInfo::Episode(e) => e.uri.clone(),
+          })
+      });
+    self.queue_suspended = Some(crate::core::queue::SuspendedContext::Spotify {
+      context_uri,
+      resume_track_uri,
+    });
+    if let Some(player) = self.streaming_player.as_ref() {
+      player.pause();
+    }
+  }
+
   /// Handle a native-streaming `EndOfTrack` while the native queue is in play.
   ///
   /// Returns `true` when the queue took over (an `AdvanceNativeQueue` was
@@ -3073,6 +3139,11 @@ impl App {
     if self.queue_now_decoded_player().is_some() {
       return true;
     }
+    // A queued Spotify track owns the sink via librespot; any remaining
+    // `*_playback` below is a suspended context, not the active source.
+    if self.queue_now_is_spotify() {
+      return false;
+    }
     #[cfg(feature = "local-files")]
     if self.local_playback.is_some() {
       return true;
@@ -3118,6 +3189,11 @@ impl App {
     if let Some(p) = self.queue_now_decoded_player() {
       return Some(p);
     }
+    // A queued Spotify track owns the sink via librespot; any remaining
+    // `*_playback` below is a suspended context, not the active source.
+    if self.queue_now_is_spotify() {
+      return None;
+    }
     #[cfg(feature = "local-files")]
     if let Some(s) = &self.local_playback {
       return Some(&s.player);
@@ -3149,6 +3225,11 @@ impl App {
     if let Some(p) = self.queue_now_decoded_player() {
       return Some(p.position().as_millis());
     }
+    // A queued Spotify track owns the sink; librespot events drive progress and
+    // any remaining `*_playback` below is a suspended context.
+    if self.queue_now_is_spotify() {
+      return None;
+    }
     #[cfg(feature = "local-files")]
     if let Some(local) = &self.local_playback {
       return Some(local.player.position().as_millis());
@@ -3177,52 +3258,58 @@ impl App {
       return;
     }
 
-    // Local-file playback owns the session: toggle the local sink directly. The
-    // playbar reads pause state live from the player, so nothing else to update.
-    #[cfg(feature = "local-files")]
-    if let Some(local) = &self.local_playback {
-      if local.player.is_paused() {
-        local.player.resume();
-      } else {
-        local.player.pause();
+    // A queued Spotify track owns the sink via librespot: skip the per-source
+    // arms (any still-`Some` `*_playback` is a suspended context whose paused
+    // player must not be resumed on top of librespot) and fall through to the
+    // native-streaming control below.
+    if !self.queue_now_is_spotify() {
+      // Local-file playback owns the session: toggle the local sink directly. The
+      // playbar reads pause state live from the player, so nothing else to update.
+      #[cfg(feature = "local-files")]
+      if let Some(local) = &self.local_playback {
+        if local.player.is_paused() {
+          local.player.resume();
+        } else {
+          local.player.pause();
+        }
+        return;
       }
-      return;
-    }
 
-    // Subsonic playback owns the session the same way: toggle its sink directly.
-    #[cfg(feature = "subsonic")]
-    if let Some(subsonic) = &self.subsonic_playback {
-      if subsonic.player.is_paused() {
-        subsonic.player.resume();
-      } else {
-        subsonic.player.pause();
+      // Subsonic playback owns the session the same way: toggle its sink directly.
+      #[cfg(feature = "subsonic")]
+      if let Some(subsonic) = &self.subsonic_playback {
+        if subsonic.player.is_paused() {
+          subsonic.player.resume();
+        } else {
+          subsonic.player.pause();
+        }
+        return;
       }
-      return;
-    }
 
-    // YouTube playback owns the session the same way: toggle its sink directly.
-    #[cfg(feature = "youtube")]
-    if let Some(youtube) = &self.youtube_playback {
-      if youtube.player.is_paused() {
-        youtube.player.resume();
-      } else {
-        youtube.player.pause();
+      // YouTube playback owns the session the same way: toggle its sink directly.
+      #[cfg(feature = "youtube")]
+      if let Some(youtube) = &self.youtube_playback {
+        if youtube.player.is_paused() {
+          youtube.player.resume();
+        } else {
+          youtube.player.pause();
+        }
+        return;
       }
-      return;
-    }
 
-    // Internet-radio playback owns the session the same way: toggle its sink
-    // directly. Without this branch radio falls through to the streaming path,
-    // which only ever emits a bare resume — so Play/Pause could resume radio but
-    // never pause it.
-    #[cfg(feature = "internet-radio")]
-    if let Some(radio) = &self.radio_playback {
-      if radio.player.is_paused() {
-        radio.player.resume();
-      } else {
-        radio.player.pause();
+      // Internet-radio playback owns the session the same way: toggle its sink
+      // directly. Without this branch radio falls through to the streaming path,
+      // which only ever emits a bare resume — so Play/Pause could resume radio but
+      // never pause it.
+      #[cfg(feature = "internet-radio")]
+      if let Some(radio) = &self.radio_playback {
+        if radio.player.is_paused() {
+          radio.player.resume();
+        } else {
+          radio.player.pause();
+        }
+        return;
       }
-      return;
     }
 
     // Use native streaming player for instant control (bypasses event channel latency)
@@ -3290,6 +3377,14 @@ impl App {
 
   pub fn previous_track(&mut self) {
     info!("playing previous track or restarting current track");
+    // The native queue owns playback: a forward-only queue has no "previous",
+    // so restart the current queued track. The queue router intercepts the
+    // dispatched event for both decoded and Spotify queue slots.
+    if self.queue_owns_playback() {
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::PreviousTrack);
+      return;
+    }
     // A decoded source owns the session: route to its dispatcher, never to the
     // paused librespot. Preserve the ">= 3s restarts current, else previous"
     // semantics (radio no-ops both Seek and PreviousTrack).
@@ -3344,6 +3439,13 @@ impl App {
 
   pub fn force_previous_track(&mut self) {
     info!("force skipping to previous track");
+    // The native queue owns playback: restart the current queued track (the
+    // queue router intercepts the event for both slot kinds).
+    if self.queue_owns_playback() {
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::ForcePreviousTrack);
+      return;
+    }
     // A decoded source owns the session: route to its dispatcher, never to the
     // paused librespot. The source handles or no-ops ForcePreviousTrack.
     if self.active_decoded_source() {
@@ -5633,7 +5735,7 @@ mod tests {
     let (tx, rx) = channel();
     let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
     // No playback context => not external => queue natively (Spotify tracks play
-    // via native streaming, wired in Phase 3).
+    // via native streaming).
     app.add_track_to_native_queue(queue_track(Some("spotify:track:abc"), "Spotify Song"));
     assert_eq!(app.native_queue.len(), 1);
     assert!(rx.try_recv().is_err());
@@ -5771,6 +5873,66 @@ mod tests {
     assert!(
       matches!(rx.recv().unwrap(), IoEvent::AdvanceNativeQueue),
       "expected AdvanceNativeQueue to be dispatched first"
+    );
+  }
+
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn spotify_queue_slot_shadows_decoded_activity_checks() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    assert!(!app.active_decoded_source());
+    assert!(app.active_source_position_ms().is_none());
+  }
+
+  #[cfg(all(feature = "streaming", feature = "audio-decode"))]
+  #[test]
+  fn spotify_queue_slot_shadows_decoded_player_lookup() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    assert!(app.active_decoded_player().is_none());
+  }
+
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn toggle_playback_with_spotify_queue_slot_does_not_panic() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    app.toggle_playback();
+
+    assert!(app.queue_now_is_spotify());
+  }
+
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn previous_track_restarts_native_queue_when_queue_owns_playback() {
+    use crate::infra::queue::QueueNowPlaying;
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.queue_now = Some(QueueNowPlaying::Spotify {
+      track: queue_track(Some("spotify:track:queued"), "Queued"),
+    });
+
+    app.previous_track();
+
+    assert!(
+      matches!(rx.recv().unwrap(), IoEvent::PreviousTrack),
+      "expected PreviousTrack to be dispatched for the queue router"
     );
   }
 

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -7,6 +7,8 @@ use crate::core::source::Source;
 use crate::core::user_config::{color_to_string, normalize_tick_rate_milliseconds, UserConfig};
 use crate::infra::network::sync::{PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
+#[cfg(any(feature = "streaming", feature = "audio-decode"))]
+use crate::infra::queue::QueueNowPlaying;
 use crate::tui::event::Key;
 use anyhow::anyhow;
 use ratatui::layout::Size;
@@ -836,9 +838,15 @@ pub struct App {
   /// and holds tracks from any source. Phase 2 consumes it for playback.
   pub native_queue: Vec<TrackInfo>,
   /// How to resume the underlying per-source context after the native queue
-  /// drains. Populated by the Phase 2 playback engine; unused in Phase 1.
-  #[allow(dead_code)]
+  /// drains. Populated when a track is queued over an active context.
   pub queue_suspended: Option<crate::core::queue::SuspendedContext>,
+  /// What the native queue's playback slot is currently playing, if anything.
+  /// Overlays the per-source `*_playback` contexts without mutating them (those
+  /// are the context to resume). Gated to builds that can actually play a queued
+  /// track — every read goes through the unconditional
+  /// [`Self::queue_owns_playback`] accessor.
+  #[cfg(any(feature = "streaming", feature = "audio-decode"))]
+  pub queue_now: Option<crate::infra::queue::QueueNowPlaying>,
   #[cfg(feature = "cover-art")]
   pub cover_art: crate::tui::cover_art::CoverArt,
   /// Status of the current track's cover art, driving the placeholder message.
@@ -1220,6 +1228,8 @@ impl Default for App {
       queue_selected_index: 0,
       native_queue: Vec::new(),
       queue_suspended: None,
+      #[cfg(any(feature = "streaming", feature = "audio-decode"))]
+      queue_now: None,
       input: vec![],
       input_idx: 0,
       input_cursor_position: 0,
@@ -1437,6 +1447,33 @@ impl App {
   /// pause state straight from whichever source's player is active, mirroring
   /// the source-ownership order the runner tick uses. Spotify playback is not
   /// persisted here — its resume is handled by `startup_behavior` device logic.
+  /// The resume point (`resume_index`, `resume_position_ms`) recorded when the
+  /// active decoded context was suspended under the native queue, or `None` when
+  /// no decoded context is suspended. Only one context is ever active, so this
+  /// unambiguously describes it.
+  #[cfg(any(feature = "youtube", feature = "subsonic", feature = "local-files"))]
+  fn suspended_resume(&self) -> Option<(Option<usize>, u64)> {
+    match self.queue_suspended.as_ref()? {
+      #[cfg(feature = "local-files")]
+      crate::core::queue::SuspendedContext::Local {
+        resume_index,
+        resume_position_ms,
+      } => Some((*resume_index, *resume_position_ms)),
+      #[cfg(feature = "subsonic")]
+      crate::core::queue::SuspendedContext::Subsonic {
+        resume_index,
+        resume_position_ms,
+      } => Some((*resume_index, *resume_position_ms)),
+      #[cfg(feature = "youtube")]
+      crate::core::queue::SuspendedContext::YouTube {
+        resume_index,
+        resume_position_ms,
+      } => Some((*resume_index, *resume_position_ms)),
+      #[allow(unreachable_patterns)]
+      _ => None,
+    }
+  }
+
   pub fn current_persisted_playback(
     &self,
   ) -> Option<crate::core::persisted_playback::PersistedPlayback> {
@@ -1449,30 +1486,73 @@ impl App {
     use crate::core::persisted_playback::PersistedPlayback;
     #[cfg(feature = "youtube")]
     if let Some(s) = self.youtube_playback.as_ref() {
-      return Some(PersistedPlayback::YouTube {
-        tracks: s.tracks.clone(),
-        index: s.index,
-        position_ms: s.player.position().as_millis() as u64,
-        paused: s.player.is_paused(),
-      });
+      // While suspended under the queue, the context's player is playing a
+      // *queued* track, so read the resume point from `queue_suspended` instead
+      // of the (repurposed) live player. A `None` resume_index means the context
+      // was exhausted — don't persist it (the queue itself still persists).
+      match self.suspended_resume() {
+        Some((Some(index), position_ms)) => {
+          return Some(PersistedPlayback::YouTube {
+            tracks: s.tracks.clone(),
+            index,
+            position_ms,
+            paused: false,
+          });
+        }
+        Some((None, _)) => {}
+        None => {
+          return Some(PersistedPlayback::YouTube {
+            tracks: s.tracks.clone(),
+            index: s.index,
+            position_ms: s.player.position().as_millis() as u64,
+            paused: s.player.is_paused(),
+          });
+        }
+      }
     }
     #[cfg(feature = "subsonic")]
     if let Some(s) = self.subsonic_playback.as_ref() {
-      return Some(PersistedPlayback::Subsonic {
-        tracks: s.tracks.clone(),
-        index: s.index,
-        position_ms: s.player.position().as_millis() as u64,
-        paused: s.player.is_paused(),
-      });
+      match self.suspended_resume() {
+        Some((Some(index), position_ms)) => {
+          return Some(PersistedPlayback::Subsonic {
+            tracks: s.tracks.clone(),
+            index,
+            position_ms,
+            paused: false,
+          });
+        }
+        Some((None, _)) => {}
+        None => {
+          return Some(PersistedPlayback::Subsonic {
+            tracks: s.tracks.clone(),
+            index: s.index,
+            position_ms: s.player.position().as_millis() as u64,
+            paused: s.player.is_paused(),
+          });
+        }
+      }
     }
     #[cfg(feature = "local-files")]
     if let Some(s) = self.local_playback.as_ref() {
-      return Some(PersistedPlayback::Local {
-        queue: s.queue.clone(),
-        index: s.index,
-        position_ms: s.player.position().as_millis() as u64,
-        paused: s.player.is_paused(),
-      });
+      match self.suspended_resume() {
+        Some((Some(index), position_ms)) => {
+          return Some(PersistedPlayback::Local {
+            queue: s.queue.clone(),
+            index,
+            position_ms,
+            paused: false,
+          });
+        }
+        Some((None, _)) => {}
+        None => {
+          return Some(PersistedPlayback::Local {
+            queue: s.queue.clone(),
+            index: s.index,
+            position_ms: s.player.position().as_millis() as u64,
+            paused: s.player.is_paused(),
+          });
+        }
+      }
     }
     #[cfg(feature = "internet-radio")]
     if let Some(s) = self.radio_playback.as_ref() {
@@ -1492,13 +1572,18 @@ impl App {
     &self,
   ) -> Option<crate::core::persisted_playback::PersistedSession> {
     let playback = self.current_persisted_playback();
-    if playback.is_none() && self.native_queue.is_empty() {
+    let queue_now_track = self.queue_now_track();
+    if playback.is_none() && self.native_queue.is_empty() && queue_now_track.is_none() {
       return None;
     }
-    Some(crate::core::persisted_playback::PersistedSession {
-      playback,
-      queue: self.native_queue.clone(),
-    })
+    // A track playing through the queue slot has been popped off `native_queue`;
+    // prepend it so a mid-queue quit resumes it (it re-enters the queue on the
+    // next launch).
+    let mut queue = self.native_queue.clone();
+    if let Some(track) = queue_now_track {
+      queue.insert(0, track.clone());
+    }
+    Some(crate::core::persisted_playback::PersistedSession { playback, queue })
   }
 
   #[allow(dead_code)]
@@ -2701,6 +2786,159 @@ impl App {
     self.set_status_message(format!("Queued: {name}"), 3);
   }
 
+  /// Whether the native queue's playback slot currently owns the output (either a
+  /// decoded queued track or, in Phase 3, a native-streamed Spotify one). The
+  /// single gated entry point for every queue-ownership check; reduces to `false`
+  /// in a slim build where the slot cannot exist.
+  pub fn queue_owns_playback(&self) -> bool {
+    #[cfg(any(feature = "streaming", feature = "audio-decode"))]
+    {
+      self.queue_now.is_some()
+    }
+    #[cfg(not(any(feature = "streaming", feature = "audio-decode")))]
+    {
+      false
+    }
+  }
+
+  /// The queue slot's player when it is playing a *decoded* queued track (local /
+  /// Subsonic / YouTube). `None` for a Spotify slot or an empty slot.
+  #[cfg(feature = "audio-decode")]
+  pub fn queue_now_decoded_player(&self) -> Option<&Arc<crate::infra::audio::LocalPlayer>> {
+    match self.queue_now.as_ref()? {
+      QueueNowPlaying::Decoded(d) => Some(&d.player),
+      #[cfg(feature = "streaming")]
+      QueueNowPlaying::Spotify { .. } => None,
+    }
+  }
+
+  /// Take the queue slot, returning its player when it was a decoded track (so
+  /// the caller can stop it). Clears [`Self::queue_now`] either way.
+  #[cfg(feature = "audio-decode")]
+  pub fn take_queue_now_decoded_player(&mut self) -> Option<Arc<crate::infra::audio::LocalPlayer>> {
+    match self.queue_now.take() {
+      Some(QueueNowPlaying::Decoded(d)) => Some(d.player),
+      _ => None,
+    }
+  }
+
+  /// The track currently playing through the queue slot, if any. Used by
+  /// persistence to prepend it back onto the saved queue so a mid-queue quit
+  /// doesn't lose the in-flight track.
+  fn queue_now_track(&self) -> Option<&TrackInfo> {
+    #[cfg(any(feature = "streaming", feature = "audio-decode"))]
+    {
+      match self.queue_now.as_ref()? {
+        #[cfg(feature = "audio-decode")]
+        QueueNowPlaying::Decoded(d) => Some(&d.track),
+        #[cfg(feature = "streaming")]
+        QueueNowPlaying::Spotify { track } => Some(track),
+      }
+    }
+    #[cfg(not(any(feature = "streaming", feature = "audio-decode")))]
+    {
+      None
+    }
+  }
+
+  /// A `"{name} - {artists}"` label for the track playing through the queue slot,
+  /// for the Queue screen's "Now playing" row. `None` when the slot is empty.
+  pub fn queue_now_display(&self) -> Option<String> {
+    let track = self.queue_now_track()?;
+    Some(format!("{} - {}", track.name, track.artists.join(", ")))
+  }
+
+  /// Suspend the active decoded context with **skip** semantics (resume at the
+  /// context's *next* track, position 0) and latch its `advancing` guard so the
+  /// runner tick leaves it alone. Radio is torn down (a live stream can't share
+  /// the sink) and its station stashed for reconnect. A no-op when no decoded
+  /// context is active. Called before handing the sink to the native queue.
+  pub(crate) fn suspend_active_decoded_context_for_skip(&mut self) {
+    #[cfg(feature = "local-files")]
+    if let Some(local) = self.local_playback.as_mut() {
+      let resume_index = crate::infra::local::next_index(local.index, local.queue.len());
+      local.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Local {
+        resume_index,
+        resume_position_ms: 0,
+      });
+      return;
+    }
+    #[cfg(feature = "subsonic")]
+    if let Some(s) = self.subsonic_playback.as_mut() {
+      let resume_index = crate::infra::subsonic::next_index(s.index, s.tracks.len());
+      s.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Subsonic {
+        resume_index,
+        resume_position_ms: 0,
+      });
+      return;
+    }
+    #[cfg(feature = "youtube")]
+    if let Some(s) = self.youtube_playback.as_mut() {
+      let resume_index = crate::infra::youtube::next_index(s.index, s.tracks.len());
+      s.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::YouTube {
+        resume_index,
+        resume_position_ms: 0,
+      });
+      return;
+    }
+    #[cfg(feature = "internet-radio")]
+    if let Some(radio) = self.radio_playback.take() {
+      radio.player.stop();
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Radio {
+        station: radio.station,
+      });
+    }
+  }
+
+  /// Suspend the active decoded context with **mid-track** semantics (resume the
+  /// *same* track at its live position) — the Enter-jump path. Radio has no
+  /// seekable position, so it is stashed for reconnect like the skip path.
+  pub(crate) fn suspend_active_decoded_context_mid_track(&mut self) {
+    #[cfg(feature = "local-files")]
+    if let Some(local) = self.local_playback.as_mut() {
+      let position_ms = local.player.position().as_millis() as u64;
+      let index = local.index;
+      local.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Local {
+        resume_index: Some(index),
+        resume_position_ms: position_ms,
+      });
+      return;
+    }
+    #[cfg(feature = "subsonic")]
+    if let Some(s) = self.subsonic_playback.as_mut() {
+      let position_ms = s.player.position().as_millis() as u64;
+      let index = s.index;
+      s.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Subsonic {
+        resume_index: Some(index),
+        resume_position_ms: position_ms,
+      });
+      return;
+    }
+    #[cfg(feature = "youtube")]
+    if let Some(s) = self.youtube_playback.as_mut() {
+      let position_ms = s.player.position().as_millis() as u64;
+      let index = s.index;
+      s.advancing = true;
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::YouTube {
+        resume_index: Some(index),
+        resume_position_ms: position_ms,
+      });
+      return;
+    }
+    #[cfg(feature = "internet-radio")]
+    if let Some(radio) = self.radio_playback.take() {
+      radio.player.stop();
+      self.queue_suspended = Some(crate::core::queue::SuspendedContext::Radio {
+        station: radio.station,
+      });
+    }
+  }
+
   /// Whether any decoded-audio source (local file, Subsonic, internet radio, or
   /// YouTube) currently owns the playback session.
   ///
@@ -2716,6 +2954,12 @@ impl App {
   /// source is playing. In a build with all source features off this reduces to
   /// `false`.
   fn active_decoded_source(&self) -> bool {
+    // The native queue slot playing a decoded track owns the sink even when no
+    // per-source `*_playback` context is set (e.g. queueing from an idle app).
+    #[cfg(feature = "audio-decode")]
+    if self.queue_now_decoded_player().is_some() {
+      return true;
+    }
     #[cfg(feature = "local-files")]
     if self.local_playback.is_some() {
       return true;
@@ -2757,6 +3001,10 @@ impl App {
     allow(dead_code)
   )]
   pub fn active_decoded_player(&self) -> Option<&std::sync::Arc<crate::infra::audio::LocalPlayer>> {
+    #[cfg(feature = "audio-decode")]
+    if let Some(p) = self.queue_now_decoded_player() {
+      return Some(p);
+    }
     #[cfg(feature = "local-files")]
     if let Some(s) = &self.local_playback {
       return Some(&s.player);
@@ -2784,6 +3032,10 @@ impl App {
   /// and seek keys become correct no-ops for radio. In a build with all seekable
   /// source features off this reduces to `None`.
   fn active_source_position_ms(&self) -> Option<u128> {
+    #[cfg(feature = "audio-decode")]
+    if let Some(p) = self.queue_now_decoded_player() {
+      return Some(p.position().as_millis());
+    }
     #[cfg(feature = "local-files")]
     if let Some(local) = &self.local_playback {
       return Some(local.player.position().as_millis());
@@ -2800,6 +3052,18 @@ impl App {
   }
 
   pub fn toggle_playback(&mut self) {
+    // The native queue slot owns the sink: toggle its player directly (covers the
+    // idle-app case where no per-source context is set).
+    #[cfg(feature = "audio-decode")]
+    if let Some(player) = self.queue_now_decoded_player() {
+      if player.is_paused() {
+        player.resume();
+      } else {
+        player.pause();
+      }
+      return;
+    }
+
     // Local-file playback owns the session: toggle the local sink directly. The
     // playbar reads pause state live from the player, so nothing else to update.
     #[cfg(feature = "local-files")]
@@ -3001,6 +3265,21 @@ impl App {
 
   pub fn next_track(&mut self) {
     info!("skipping to next track");
+    // The native queue owns playback: skip to the next queued item (or resume
+    // the suspended context when the queue drains).
+    if self.queue_owns_playback() {
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::AdvanceNativeQueue);
+      return;
+    }
+    // A decoded context is playing with items waiting in the queue: suspend it
+    // (skip semantics — resume at the context's next track) and start the queue.
+    if self.active_decoded_source() && !self.native_queue.is_empty() {
+      self.suspend_active_decoded_context_for_skip();
+      self.song_progress_ms = 0;
+      self.dispatch(IoEvent::AdvanceNativeQueue);
+      return;
+    }
     // A decoded source (local/subsonic/radio/youtube) owns the session: route to
     // its dispatcher, never to the paused librespot. The source handles or
     // no-ops NextTrack (radio has no queue).

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ pub mod layout;
 pub mod pagination;
 pub mod persisted_playback;
 pub mod plugin_api;
+pub mod queue;
 pub mod sort;
 pub mod source;
 #[cfg(test)]

--- a/src/core/persisted_playback.rs
+++ b/src/core/persisted_playback.rs
@@ -32,6 +32,25 @@ use std::path::{Path, PathBuf};
 
 const FILE_NAME: &str = "last_session.yml";
 
+/// The full persisted session: the active non-Spotify playback (if any) plus the
+/// native cross-source queue. Wraps [`PersistedPlayback`] so the queue can be
+/// persisted independently of whichever source (if any) owns playback.
+///
+/// `deny_unknown_fields` is load-bearing: [`load`] parses this wrapper *first*,
+/// and a legacy file is a bare top-level [`PersistedPlayback`] whose `source`
+/// tag key would otherwise be silently ignored here (serde ignores unknown
+/// fields by default), yielding an empty session and dropping the saved
+/// playback. Rejecting unknown fields forces the legacy file to fail this parse
+/// so [`load`] falls through to the legacy path.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct PersistedSession {
+  #[serde(default)]
+  pub playback: Option<PersistedPlayback>,
+  #[serde(default)]
+  pub queue: Vec<TrackInfo>,
+}
+
 /// Environment override for the session file location (used by tests, and
 /// available to users who keep their config elsewhere).
 pub const PATH_ENV: &str = "SPOTATUI_LAST_SESSION_PATH";
@@ -83,11 +102,26 @@ pub fn default_session_path() -> Result<PathBuf> {
 /// Load the persisted session. A missing file means "no session to resume"
 /// (`Ok(None)`); a malformed file is an error the caller logs and ignores
 /// (never crash startup over an auto-written file).
-pub fn load(path: &Path) -> Result<Option<PersistedPlayback>> {
+///
+/// Parses the current [`PersistedSession`] wrapper first, then falls back to a
+/// legacy top-level [`PersistedPlayback`] (files written before the queue
+/// existed), wrapping it with an empty queue. This is an explicit two-step
+/// parse — see the note on [`PersistedSession`] for why the ordering is safe.
+pub fn load(path: &Path) -> Result<Option<PersistedSession>> {
   match std::fs::read_to_string(path) {
-    Ok(contents) => serde_yaml::from_str(&contents)
-      .map(Some)
-      .with_context(|| format!("malformed session file: {}", path.display())),
+    Ok(contents) => {
+      if let Ok(session) = serde_yaml::from_str::<PersistedSession>(&contents) {
+        return Ok(Some(session));
+      }
+      serde_yaml::from_str::<PersistedPlayback>(&contents)
+        .map(|playback| {
+          Some(PersistedSession {
+            playback: Some(playback),
+            queue: Vec::new(),
+          })
+        })
+        .with_context(|| format!("malformed session file: {}", path.display()))
+    }
     Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
     Err(e) => Err(e).with_context(|| format!("reading {}", path.display())),
   }
@@ -95,7 +129,7 @@ pub fn load(path: &Path) -> Result<Option<PersistedPlayback>> {
 
 /// Save the session atomically (write a sibling tempfile, then rename) so a
 /// crash mid-write can't leave a half-written file that fails to parse.
-pub fn save(path: &Path, session: &PersistedPlayback) -> Result<()> {
+pub fn save(path: &Path, session: &PersistedSession) -> Result<()> {
   let yaml = serde_yaml::to_string(session).context("serializing playback session")?;
   if let Some(dir) = path.parent() {
     std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
@@ -138,6 +172,10 @@ mod tests {
     }
   }
 
+  fn session(playback: Option<PersistedPlayback>, queue: Vec<TrackInfo>) -> PersistedSession {
+    PersistedSession { playback, queue }
+  }
+
   #[test]
   fn missing_file_is_no_session() {
     let dir = tempfile::tempdir().unwrap();
@@ -146,17 +184,77 @@ mod tests {
   }
 
   #[test]
-  fn save_then_load_round_trips_a_youtube_queue() {
+  fn save_then_load_round_trips_a_youtube_playback() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("last_session.yml");
-    let session = PersistedPlayback::YouTube {
-      tracks: vec![track("youtube:aaa", "A"), track("youtube:bbb", "B")],
+    let s = session(
+      Some(PersistedPlayback::YouTube {
+        tracks: vec![track("youtube:aaa", "A"), track("youtube:bbb", "B")],
+        index: 1,
+        position_ms: 42_000,
+        paused: true,
+      }),
+      vec![],
+    );
+    save(&path, &s).unwrap();
+    assert_eq!(load(&path).unwrap(), Some(s));
+  }
+
+  #[test]
+  fn save_then_load_round_trips_playback_with_queue() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("last_session.yml");
+    let s = session(
+      Some(PersistedPlayback::Subsonic {
+        tracks: vec![track("subsonic:track:1", "Sub")],
+        index: 0,
+        position_ms: 5_000,
+        paused: false,
+      }),
+      vec![
+        track("spotify:track:xyz", "Queued A"),
+        track("file:///b.mp3", "Queued B"),
+      ],
+    );
+    save(&path, &s).unwrap();
+    assert_eq!(load(&path).unwrap(), Some(s));
+  }
+
+  #[test]
+  fn save_then_load_round_trips_queue_only_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("last_session.yml");
+    // No active playback source, but the native queue has items to persist.
+    let s = session(None, vec![track("spotify:track:only", "Just Queued")]);
+    save(&path, &s).unwrap();
+    let loaded = load(&path).unwrap().expect("should load");
+    assert!(loaded.playback.is_none());
+    assert_eq!(loaded.queue.len(), 1);
+    assert_eq!(loaded.queue[0].name, "Just Queued");
+  }
+
+  #[test]
+  fn legacy_top_level_playback_file_loads_with_empty_queue() {
+    // A file written before the queue existed is a bare top-level enum with a
+    // `source` tag; it must still resume playback (and load an empty queue).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("last_session.yml");
+    let legacy = PersistedPlayback::YouTube {
+      tracks: vec![
+        track("youtube:aaa", "Legacy A"),
+        track("youtube:bbb", "Legacy B"),
+      ],
       index: 1,
-      position_ms: 42_000,
+      position_ms: 12_345,
       paused: true,
     };
-    save(&path, &session).unwrap();
-    assert_eq!(load(&path).unwrap(), Some(session));
+    let legacy_yaml = serde_yaml::to_string(&legacy).unwrap();
+    std::fs::write(&path, legacy_yaml).unwrap();
+
+    let loaded = load(&path).unwrap().expect("legacy file should load");
+    assert!(loaded.queue.is_empty());
+    // The discriminating assertion: the legacy playback survives the fallback.
+    assert_eq!(loaded.playback, Some(legacy));
   }
 
   #[test]
@@ -165,12 +263,15 @@ mod tests {
     let path = dir.path().join("last_session.yml");
     save(
       &path,
-      &PersistedPlayback::Local {
-        queue: vec!["file:///music/a.mp3".to_string()],
-        index: 0,
-        position_ms: 0,
-        paused: false,
-      },
+      &session(
+        Some(PersistedPlayback::Local {
+          queue: vec!["file:///music/a.mp3".to_string()],
+          index: 0,
+          position_ms: 0,
+          paused: false,
+        }),
+        vec![],
+      ),
     )
     .unwrap();
     assert!(path.exists());

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -66,10 +66,10 @@ pub fn source_available(source: QueueItemSource) -> bool {
 /// valid, always-`None` type.
 #[derive(Debug, Clone)]
 pub enum SuspendedContext {
-  // Constructed in Phase 3 (Spirc preemption); defined now so the enum is
-  // stable and the resume path can already match it.
+  /// Snapshot of the native-Spotify context to resume once the queue drains:
+  /// the context uri and the resume-target track uri (the head of the Spotify
+  /// mirror queue at suspension time).
   #[cfg(feature = "streaming")]
-  #[allow(dead_code)]
   Spotify {
     context_uri: Option<String>,
     resume_track_uri: Option<String>,

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1,0 +1,131 @@
+//! Native cross-source playback queue: source identity and suspension records.
+//!
+//! The queue itself is a `Vec<TrackInfo>` on [`App`](crate::core::app::App); this
+//! module holds the small value types that classify a queue item by its source
+//! (URI scheme) and record how to resume the underlying per-source context once
+//! the queue drains. Phase 1 only populates and displays the queue — the
+//! playback engine that consumes these types lands in Phase 2, so several items
+//! here are intentionally unused until then.
+
+/// Which source a queue item plays through, derived from its URI scheme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueItemSource {
+  Spotify,
+  LocalFile,
+  Subsonic,
+  YouTube,
+}
+
+/// Classify a queue item by its URI scheme. Anything that is not a local file,
+/// Subsonic, or YouTube URI is treated as Spotify (the `spotify:track:` scheme).
+/// Radio URIs (`radio:`) are never queued, so they are rejected before reaching
+/// this function.
+pub fn queue_item_source(uri: &str) -> QueueItemSource {
+  if uri.starts_with("file:") {
+    QueueItemSource::LocalFile
+  } else if uri.starts_with("subsonic:") {
+    QueueItemSource::Subsonic
+  } else if uri.starts_with("youtube:") {
+    QueueItemSource::YouTube
+  } else {
+    QueueItemSource::Spotify
+  }
+}
+
+/// A short, human-readable tag for a queue item's source, shown in the Queue
+/// screen next to each row.
+pub fn source_label(source: QueueItemSource) -> &'static str {
+  match source {
+    QueueItemSource::Spotify => "Spotify",
+    QueueItemSource::LocalFile => "Local",
+    QueueItemSource::Subsonic => "Subsonic",
+    QueueItemSource::YouTube => "YouTube",
+  }
+}
+
+/// Whether this build can actually play a queue item from the given source.
+/// A slim build (no source features) can only play Spotify tracks via native
+/// streaming; each alternative source is gated on its own Cargo feature. Phase 2
+/// consults this to skip unplayable items with a status message instead of
+/// stalling the queue.
+#[allow(dead_code)]
+pub fn source_available(source: QueueItemSource) -> bool {
+  match source {
+    QueueItemSource::Spotify => cfg!(feature = "streaming"),
+    QueueItemSource::LocalFile => cfg!(feature = "local-files"),
+    QueueItemSource::Subsonic => cfg!(feature = "subsonic"),
+    QueueItemSource::YouTube => cfg!(feature = "youtube"),
+  }
+}
+
+/// How to resume the underlying per-source context after the native queue
+/// drains. Recorded when a track is queued over an active context (Phase 2).
+///
+/// `resume_index: None` means the context was exhausted, so it should be torn
+/// down rather than resumed. In a slim build (no source features) this enum has
+/// zero variants — the `App` field is `Option<SuspendedContext>`, so that is a
+/// valid, always-`None` type.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum SuspendedContext {
+  #[cfg(feature = "streaming")]
+  Spotify {
+    context_uri: Option<String>,
+    resume_track_uri: Option<String>,
+  },
+  #[cfg(feature = "local-files")]
+  Local {
+    resume_index: Option<usize>,
+    resume_position_ms: u64,
+  },
+  #[cfg(feature = "subsonic")]
+  Subsonic {
+    resume_index: Option<usize>,
+    resume_position_ms: u64,
+  },
+  #[cfg(feature = "youtube")]
+  YouTube {
+    resume_index: Option<usize>,
+    resume_position_ms: u64,
+  },
+  #[cfg(feature = "internet-radio")]
+  Radio,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn classifies_uri_schemes() {
+    assert_eq!(
+      queue_item_source("spotify:track:abc"),
+      QueueItemSource::Spotify
+    );
+    assert_eq!(
+      queue_item_source("file:///music/a.mp3"),
+      QueueItemSource::LocalFile
+    );
+    assert_eq!(
+      queue_item_source("subsonic:track:42"),
+      QueueItemSource::Subsonic
+    );
+    assert_eq!(
+      queue_item_source("youtube:5NV6Rdv1a3I"),
+      QueueItemSource::YouTube
+    );
+    // Unknown schemes fall back to Spotify.
+    assert_eq!(
+      queue_item_source("something-else"),
+      QueueItemSource::Spotify
+    );
+  }
+
+  #[test]
+  fn source_labels_are_stable() {
+    assert_eq!(source_label(QueueItemSource::Spotify), "Spotify");
+    assert_eq!(source_label(QueueItemSource::LocalFile), "Local");
+    assert_eq!(source_label(QueueItemSource::Subsonic), "Subsonic");
+    assert_eq!(source_label(QueueItemSource::YouTube), "YouTube");
+  }
+}

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -3,9 +3,7 @@
 //! The queue itself is a `Vec<TrackInfo>` on [`App`](crate::core::app::App); this
 //! module holds the small value types that classify a queue item by its source
 //! (URI scheme) and record how to resume the underlying per-source context once
-//! the queue drains. Phase 1 only populates and displays the queue — the
-//! playback engine that consumes these types lands in Phase 2, so several items
-//! here are intentionally unused until then.
+//! the queue drains.
 
 /// Which source a queue item plays through, derived from its URI scheme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,7 +43,7 @@ pub fn source_label(source: QueueItemSource) -> &'static str {
 
 /// Whether this build can actually play a queue item from the given source.
 /// A slim build (no source features) can only play Spotify tracks via native
-/// streaming; each alternative source is gated on its own Cargo feature. Phase 2
+/// streaming; each alternative source is gated on its own Cargo feature. The queue
 /// consults this to skip unplayable items with a status message instead of
 /// stalling the queue.
 pub fn source_available(source: QueueItemSource) -> bool {
@@ -58,7 +56,7 @@ pub fn source_available(source: QueueItemSource) -> bool {
 }
 
 /// How to resume the underlying per-source context after the native queue
-/// drains. Recorded when a track is queued over an active context (Phase 2).
+/// drains. Recorded when a track is queued over an active context.
 ///
 /// `resume_index: None` means the context was exhausted, so it should be torn
 /// down rather than resumed. In a slim build (no source features) this enum has

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -48,7 +48,6 @@ pub fn source_label(source: QueueItemSource) -> &'static str {
 /// streaming; each alternative source is gated on its own Cargo feature. Phase 2
 /// consults this to skip unplayable items with a status message instead of
 /// stalling the queue.
-#[allow(dead_code)]
 pub fn source_available(source: QueueItemSource) -> bool {
   match source {
     QueueItemSource::Spotify => cfg!(feature = "streaming"),
@@ -65,10 +64,12 @@ pub fn source_available(source: QueueItemSource) -> bool {
 /// down rather than resumed. In a slim build (no source features) this enum has
 /// zero variants — the `App` field is `Option<SuspendedContext>`, so that is a
 /// valid, always-`None` type.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum SuspendedContext {
+  // Constructed in Phase 3 (Spirc preemption); defined now so the enum is
+  // stable and the resume path can already match it.
   #[cfg(feature = "streaming")]
+  #[allow(dead_code)]
   Spotify {
     context_uri: Option<String>,
     resume_track_uri: Option<String>,
@@ -88,8 +89,14 @@ pub enum SuspendedContext {
     resume_index: Option<usize>,
     resume_position_ms: u64,
   },
+  /// A live radio stream can't be paused/resumed, so resuming it means
+  /// reconnecting. The suspended station row is kept to re-open the stream when
+  /// the queue drains (the radio session itself is torn down at suspension so
+  /// the queue slot can take the output device).
   #[cfg(feature = "internet-radio")]
-  Radio,
+  Radio {
+    station: crate::core::plugin_api::TrackInfo,
+  },
 }
 
 #[cfg(test)]

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -673,6 +673,7 @@ pub struct KeyBindingsString {
   cover_art_view: Option<String>,
   add_item_to_queue: Option<String>,
   show_queue: Option<String>,
+  remove_from_queue: Option<String>,
   open_settings: Option<String>,
   save_settings: Option<String>,
   listening_party: Option<String>,
@@ -716,6 +717,7 @@ pub struct KeyBindings {
   pub cover_art_view: Key,
   pub add_item_to_queue: Key,
   pub show_queue: Key,
+  pub remove_from_queue: Key,
   pub open_settings: Key,
   pub save_settings: Key,
   pub listening_party: Key,
@@ -937,6 +939,7 @@ impl UserConfig {
         cover_art_view: Key::Char('G'),
         add_item_to_queue: Key::Char('z'),
         show_queue: Key::Char('Q'),
+        remove_from_queue: Key::Char('x'),
         // On macOS, use Ctrl+, for settings since Alt+, produces ≤ on most keyboard layouts
         // On other platforms, keep Alt+, for consistency with many apps
         open_settings: if is_macos {
@@ -1087,6 +1090,7 @@ impl UserConfig {
     to_keys!(cover_art_view);
     to_keys!(add_item_to_queue);
     to_keys!(show_queue);
+    to_keys!(remove_from_queue);
     to_keys!(open_settings);
     to_keys!(save_settings);
     to_keys!(listening_party);
@@ -1665,6 +1669,7 @@ impl UserConfig {
       cover_art_view: Some(key_to_config_string(self.keys.cover_art_view)),
       add_item_to_queue: Some(key_to_config_string(self.keys.add_item_to_queue)),
       show_queue: Some(key_to_config_string(self.keys.show_queue)),
+      remove_from_queue: Some(key_to_config_string(self.keys.remove_from_queue)),
       open_settings: Some(key_to_config_string(self.keys.open_settings)),
       save_settings: Some(key_to_config_string(self.keys.save_settings)),
       listening_party: Some(key_to_config_string(self.keys.listening_party)),

--- a/src/infra/local/dispatch.rs
+++ b/src/infra/local/dispatch.rs
@@ -280,6 +280,25 @@ async fn start_local_queue(app: &Arc<Mutex<App>>, queue: Vec<String>, start_idx:
   }
 }
 
+/// Decode and play a single local file on `player`, returning its metadata.
+/// Extracted so the native queue engine can play a one-off `file://` track on a
+/// borrowed player without touching `local_playback`. Mirrors the core of
+/// [`play_index`] (tag read + blocking decode) with no session bookkeeping.
+#[cfg_attr(not(feature = "local-files"), allow(dead_code))]
+pub(crate) async fn play_single_file(
+  player: &Arc<LocalPlayer>,
+  uri: &str,
+) -> anyhow::Result<crate::core::plugin_api::TrackInfo> {
+  let path = file_uri_to_path(uri)?;
+  let decode_player = Arc::clone(player);
+  let info = tokio::task::spawn_blocking(move || {
+    let info = track_info_from_path(&path);
+    decode_player.play_file(&path).map(|()| info)
+  })
+  .await??;
+  Ok(info)
+}
+
 /// Play the queued track at `target`, reusing the already-published session's
 /// player and queue. Used by Next/Previous and the runner tick's auto-advance.
 ///
@@ -288,7 +307,7 @@ async fn start_local_queue(app: &Arc<Mutex<App>>, queue: Vec<String>, start_idx:
 /// `target` to the *following* track, so a single corrupt file is skipped past
 /// rather than retried forever. `advancing` is cleared in both arms once the new
 /// source is in the sink (or the play failed), reopening auto-advance.
-async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
+pub(crate) async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
   // Snapshot the player + URI under a short lock.
   let (player, uri) = {
     let mut guard = app.lock().await;

--- a/src/infra/media_metadata.rs
+++ b/src/infra/media_metadata.rs
@@ -156,6 +156,24 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
   feature = "youtube"
 ))]
 fn source_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
+  // The native queue slot playing a decoded track wins over every per-source
+  // context: it is what is actually audible, and it drives the playbar / MPRIS /
+  // cover art / lyrics via the shared track-change detector.
+  #[cfg(feature = "audio-decode")]
+  if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
+    return Some(source_snapshot(
+      d.track.name.clone(),
+      d.track.artists.clone(),
+      d.track.album.clone(),
+      d.track.duration_ms as u32,
+      d.track.uri.clone(),
+      d.track.image_url.clone(),
+      d.player.position().as_millis(),
+      !d.player.is_paused(),
+      app,
+    ));
+  }
+
   #[cfg(feature = "local-files")]
   if let Some(local) = app.local_playback.as_ref() {
     return Some(source_snapshot(

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -12,6 +12,7 @@ pub mod mpris;
 pub mod network;
 #[cfg(feature = "streaming")]
 pub mod player;
+pub mod queue;
 #[cfg(feature = "internet-radio")]
 pub mod radio;
 pub mod redirect_uri;

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -122,8 +122,9 @@ pub enum IoEvent {
   /// never reaches the Spotify network handler.
   AdvanceNativeQueue,
   /// Resume a suspended native-streaming Spotify context after the native queue
-  /// drains (context URI, resume-track URI). Implemented in Phase 3; the network
-  /// handler arm is a no-op until then.
+  /// drains (context URI, resume-track URI). Re-loads the context on the native
+  /// device via the existing `start_playback` machinery. `allow(dead_code)`:
+  /// only constructed under `streaming`, but the handler arm is unconditional.
   #[allow(dead_code)]
   ResumeSpotifyContext(Option<String>, Option<String>),
   IncrementGlobalSongCount,
@@ -629,8 +630,11 @@ impl Network {
       // Consumed by the queue router before it reaches the network; only lands
       // here if the router somehow let it through. No Spotify work to do.
       IoEvent::AdvanceNativeQueue => {}
-      // Phase 3 wires the actual context resume; a no-op for now.
-      IoEvent::ResumeSpotifyContext(..) => {}
+      IoEvent::ResumeSpotifyContext(context_uri, resume_track_uri) => {
+        self
+          .resume_spotify_context(context_uri, resume_track_uri)
+          .await;
+      }
       IoEvent::IncrementGlobalSongCount => {
         self.increment_global_song_count().await;
       }

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -116,6 +116,16 @@ pub enum IoEvent {
   /// Playable URI (track or episode) to enqueue.
   AddItemToQueue(String),
   GetQueue,
+  /// Advance the native cross-source queue: play the next queued item, or resume
+  /// the suspended per-source context when the queue drains. Consumed by
+  /// `infra::queue::dispatch::route_queue_event` (wired first in the pump); it
+  /// never reaches the Spotify network handler.
+  AdvanceNativeQueue,
+  /// Resume a suspended native-streaming Spotify context after the native queue
+  /// drains (context URI, resume-track URI). Implemented in Phase 3; the network
+  /// handler arm is a no-op until then.
+  #[allow(dead_code)]
+  ResumeSpotifyContext(Option<String>, Option<String>),
   IncrementGlobalSongCount,
   FetchGlobalSongCount,
   FetchAnnouncements,
@@ -616,6 +626,11 @@ impl Network {
       IoEvent::GetQueue => {
         self.get_queue().await;
       }
+      // Consumed by the queue router before it reaches the network; only lands
+      // here if the router somehow let it through. No Spotify work to do.
+      IoEvent::AdvanceNativeQueue => {}
+      // Phase 3 wires the actual context resume; a no-op for now.
+      IoEvent::ResumeSpotifyContext(..) => {}
       IoEvent::IncrementGlobalSongCount => {
         self.increment_global_song_count().await;
       }

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -50,6 +50,15 @@ pub trait PlaybackNetwork {
   #[cfg(feature = "streaming")]
   async fn auto_select_streaming_device(&mut self, device_name: String, persist_device_id: bool);
   async fn ensure_playback_continues(&mut self, previous_track_id: String);
+  /// Resume a native-Spotify context suspended under the native queue, targeting
+  /// the resume track via an offset URI. Falls back to playing just the track
+  /// when there is no context, and to a "Queue finished" status when neither is
+  /// known.
+  async fn resume_spotify_context(
+    &mut self,
+    context_uri: Option<String>,
+    resume_track_uri: Option<String>,
+  );
   #[allow(dead_code)]
   async fn add_item_to_queue(&mut self, item: PlayableId<'static>);
   async fn get_queue(&mut self);
@@ -1755,6 +1764,40 @@ impl PlaybackNetwork for Network {
     }
   }
 
+  async fn resume_spotify_context(
+    &mut self,
+    context_uri: Option<String>,
+    resume_track_uri: Option<String>,
+  ) {
+    use crate::infra::network::ids;
+    let context = context_uri.as_deref().and_then(ids::play_context_id);
+    let track = resume_track_uri.as_deref().and_then(ids::playable_id);
+
+    // Reuse the existing `start_playback` machinery (device activation/transfer
+    // included). Passing the resume track as a single-item `uris` alongside the
+    // context yields an offset-by-uri start (see `api_playback_offset_json` /
+    // `native_load_request`), i.e. the context resumes at that track. A plain
+    // `spirc.play()` can't do this after a direct `player.load`, which is why
+    // the context is re-loaded here.
+    match (context, track) {
+      (Some(context), Some(track)) => {
+        self
+          .start_playback(Some(context), Some(vec![track]), None)
+          .await;
+      }
+      (Some(context), None) => {
+        self.start_playback(Some(context), None, None).await;
+      }
+      (None, Some(track)) => {
+        self.start_playback(None, Some(vec![track]), None).await;
+      }
+      (None, None) => {
+        let mut app = self.app.lock().await;
+        app.set_status_message("Queue finished", 3);
+      }
+    }
+  }
+
   async fn add_item_to_queue(&mut self, item: PlayableId<'static>) {
     match self
       .spotify_api_request_json(
@@ -2255,5 +2298,35 @@ mod tests {
         api_device_is_native: false,
       },
     ));
+  }
+
+  /// With neither a context uri nor a resume track, resuming has nothing to do:
+  /// it reports the queue as finished rather than issuing a playback request.
+  #[tokio::test]
+  async fn resume_spotify_context_with_nothing_known_finishes_the_queue() {
+    use crate::core::app::App;
+    use crate::core::config::ClientConfig;
+    use crate::core::user_config::UserConfig;
+    use std::sync::mpsc::channel;
+    use std::time::SystemTime;
+
+    let (io_tx, _rx) = channel();
+    let app = std::sync::Arc::new(tokio::sync::Mutex::new(App::new(
+      io_tx,
+      UserConfig::new(),
+      Some(SystemTime::now()),
+    )));
+    // No Spotify client is needed: the both-None arm never reaches `spotify()`.
+    let mut network = Network::new(
+      None,
+      ClientConfig::new(),
+      &app,
+      std::env::temp_dir().join("spotatui_resume_context_test.json"),
+    );
+
+    network.resume_spotify_context(None, None).await;
+
+    let guard = app.lock().await;
+    assert_eq!(guard.status_message.as_deref(), Some("Queue finished"));
   }
 }

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -392,9 +392,24 @@ async fn handle_player_events(
         });
 
         app.song_progress_ms = 0;
-        app.last_track_id = Some(audio_item.track_id.to_string());
+        let playing_id = audio_item.track_id.to_string();
+        app.last_track_id = Some(playing_id.clone());
         app.instant_since_last_current_playback_poll = std::time::Instant::now();
         app.dispatch(IoEvent::GetCurrentPlayback);
+
+        // Spirc self-advance guard: a queued Spotify track plays via a direct
+        // `player.load` (no Spirc context), so Spirc can switch to the next
+        // context track on its own. If that happened, reissue the queued track
+        // (bounded). NOTE: pending the live experiment in the plan (Risk #1),
+        // this mitigation is unverified without a real Spotify session.
+        let reload_uri = app.spotify_queue_guard_reload_uri(&playing_id);
+        drop(app);
+        if let Some(uri) = reload_uri {
+          info!("spirc advanced off the queued track; reissuing {}", uri);
+          if let Err(e) = player.play_uri(&uri).await {
+            info!("failed to reissue queued Spotify track: {}", e);
+          }
+        }
       }
       PlayerEvent::Stopped { .. } => {
         #[cfg(all(feature = "mpris", target_os = "linux"))]
@@ -458,7 +473,15 @@ async fn handle_player_events(
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         if let Ok(mut app) = app.try_lock() {
           if !app.user_config.behavior.stop_after_current_track {
-            app.dispatch(IoEvent::EnsurePlaybackContinues(track_id.to_string()));
+            // The native queue takes priority: a queued Spotify track that just
+            // ended advances the queue; a context track that ended while items
+            // wait suspends the context (preempting Spirc's self-advance) and
+            // hands off to the queue. Only when neither applies do we fall back
+            // to the normal continue-playback path. A missed `try_lock` above
+            // falls through to that same fallback, never a panic.
+            if !app.handle_native_spotify_track_end() {
+              app.dispatch(IoEvent::EnsurePlaybackContinues(track_id.to_string()));
+            }
           }
         }
       }

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -216,6 +216,37 @@ async fn handle_player_events(
         track_id,
         position_ms,
       } => {
+        // While the native queue is mid-handoff or playing a *decoded* track,
+        // librespot must stay paused. The handoff pauses Spirc, but a
+        // self-advance load (or a stale-slot reissue) already in flight at that
+        // moment can complete afterwards and start audio over the queue slot —
+        // re-pause instead of accepting the state update. Librespot playing is
+        // legitimate here only when the slot itself is a Spotify track; with a
+        // decoded slot, or with a context suspended under the queue and no
+        // Spotify slot (the between-items window: the old slot is cleared, the
+        // next one not yet published), it never is. One-shot: a paused Spirc
+        // emits no further Playing events, so this can't ping-pong.
+        {
+          let stray_over_queue = {
+            let guard = app.lock().await;
+            let decoded_slot = {
+              #[cfg(feature = "audio-decode")]
+              {
+                guard.queue_now_decoded_player().is_some()
+              }
+              #[cfg(not(feature = "audio-decode"))]
+              {
+                false
+              }
+            };
+            !guard.queue_now_is_spotify() && (decoded_slot || guard.queue_suspended.is_some())
+          };
+          if stray_over_queue {
+            player.pause();
+            continue;
+          }
+        }
+
         // Playback is actually working: reset the failure streak.
         consecutive_unavailable = 0;
         shared_is_playing.store(true, Ordering::Relaxed);
@@ -458,7 +489,13 @@ async fn handle_player_events(
           windows_media.set_stopped();
         }
 
-        if let Ok(mut app) = app.try_lock() {
+        // Full `lock().await`, not `try_lock`: this arm decides whether the
+        // native queue takes over, and a dropped decision here strands the
+        // queue (nothing advances, nothing continues). The render loop holds
+        // the app mutex a large fraction of the time, so a single try_lock
+        // attempt loses this race routinely.
+        {
+          let mut app = app.lock().await;
           if let Some(ref mut ctx) = app.current_playback_context {
             ctx.is_playing = false;
           }
@@ -471,14 +508,14 @@ async fn handle_player_events(
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        if let Ok(mut app) = app.try_lock() {
+        {
+          let mut app = app.lock().await;
           if !app.user_config.behavior.stop_after_current_track {
             // The native queue takes priority: a queued Spotify track that just
             // ended advances the queue; a context track that ended while items
             // wait suspends the context (preempting Spirc's self-advance) and
             // hands off to the queue. Only when neither applies do we fall back
-            // to the normal continue-playback path. A missed `try_lock` above
-            // falls through to that same fallback, never a panic.
+            // to the normal continue-playback path.
             if !app.handle_native_spotify_track_end() {
               app.dispatch(IoEvent::EnsurePlaybackContinues(track_id.to_string()));
             }

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -544,6 +544,16 @@ impl StreamingPlayer {
     self.play_uri(&uri).await
   }
 
+  /// Hint the player to prefetch a track's audio so a subsequent
+  /// [`play_uri`](Self::play_uri) starts near-instantly. Used by the native
+  /// queue to warm its next Spotify item, matching the preloading Spirc does
+  /// within a context. Best-effort: an unparseable URI is silently ignored.
+  pub fn preload_uri(&self, uri: &str) {
+    if let Ok(spotify_uri) = SpotifyUri::from_uri(uri) {
+      self.player.preload(spotify_uri);
+    }
+  }
+
   /// Pause playback
   pub fn pause(&self) {
     // Prefer going through Spirc so Connect state stays consistent.

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -16,7 +16,14 @@ use tokio::sync::Mutex;
 
 use crate::core::app::App;
 use crate::core::plugin_api::TrackInfo;
-use crate::core::queue::{queue_item_source, source_available, source_label, QueueItemSource};
+#[cfg(any(
+  feature = "local-files",
+  feature = "subsonic",
+  feature = "youtube",
+  feature = "streaming"
+))]
+use crate::core::queue::QueueItemSource;
+use crate::core::queue::{queue_item_source, source_available, source_label};
 use crate::infra::network::IoEvent;
 
 #[cfg(feature = "audio-decode")]
@@ -176,19 +183,8 @@ async fn try_play_queued(app: &Arc<Mutex<App>>, track: &TrackInfo) -> bool {
     QueueItemSource::Subsonic => play_queued_subsonic(app, track, &uri).await,
     #[cfg(feature = "youtube")]
     QueueItemSource::YouTube => play_queued_youtube(app, track, &uri).await,
-    QueueItemSource::Spotify => {
-      // Phase 3 plays queued Spotify tracks via native streaming; until then,
-      // skip them with a note rather than stalling the queue.
-      set_status(
-        app,
-        format!(
-          "Queued Spotify track \"{}\" needs native streaming (coming soon)",
-          track.name
-        ),
-      )
-      .await;
-      false
-    }
+    #[cfg(feature = "streaming")]
+    QueueItemSource::Spotify => play_queued_spotify(app, track, &uri).await,
     // Reached only when a source is `source_available` but its play arm is
     // cfg'd out — impossible (the check above *is* the cfg gate), but the match
     // must be exhaustive across builds.
@@ -271,6 +267,55 @@ async fn play_queued_youtube(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str
       false
     }
   }
+}
+
+/// Play a queued Spotify track through the native streaming player via a direct
+/// `player.load` (no Spirc context), publishing a Spotify queue slot. Requires a
+/// connected streaming player; otherwise the item is skipped like any other
+/// unplayable one. Any decoded audio is silenced first so librespot doesn't play
+/// over it.
+#[cfg(feature = "streaming")]
+async fn play_queued_spotify(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  let player = { app.lock().await.streaming_player.clone() };
+  let Some(player) = player.filter(|p| p.is_connected()) else {
+    set_status(
+      app,
+      format!(
+        "Native streaming isn't connected; skipped \"{}\"",
+        track.name
+      ),
+    )
+    .await;
+    return false;
+  };
+  // Silence any decoded audio so two players never share the sink. A decoded
+  // queue slot is stopped and dropped; a suspended decoded context (which keeps
+  // its player for resume) is paused — resume reloads its sink either way.
+  #[cfg(feature = "audio-decode")]
+  {
+    if let Some(p) = { app.lock().await.take_queue_now_decoded_player() } {
+      p.stop();
+    }
+    if let Some(p) = suspended_context_player(app).await {
+      p.pause();
+    }
+  }
+  player.activate();
+  if let Err(e) = player.play_uri(uri).await {
+    set_status(app, format!("Cannot play {}: {e}", track.name)).await;
+    return false;
+  }
+  {
+    use crate::infra::queue::QueueNowPlaying;
+    let mut guard = app.lock().await;
+    guard.queue_now = Some(QueueNowPlaying::Spotify {
+      track: track.clone(),
+    });
+    // Fresh slot: reset the Spirc self-advance retry budget.
+    guard.spotify_queue_guard_reloads = 0;
+    guard.set_status_message(format!("\u{266a} {} (queue)", track.name), 4);
+  }
+  true
 }
 
 /// Publish the decoded queue slot and announce the track. `tempfile` is the
@@ -444,8 +489,8 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
       context_uri,
       resume_track_uri,
     }) => {
-      // Phase 3 implements the actual Spotify context resume; the IoEvent is a
-      // no-op for now. Stop the decoded queue slot if one exists.
+      // The network handler re-loads the Spotify context (offset by the resume
+      // track) on the native device. Stop the decoded queue slot if one exists.
       #[cfg(feature = "audio-decode")]
       if let Some(player) = queue_player {
         player.stop();

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -239,9 +239,11 @@ async fn try_play_queued(app: &Arc<Mutex<App>>, track: &TrackInfo) -> bool {
 
 #[cfg(feature = "local-files")]
 async fn play_queued_local(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  release_librespot(app).await;
   let Some(player) = acquire_queue_player(app).await else {
     return false;
   };
+  let _ = publish_pending_decoded(app, &player, track).await;
   match crate::infra::local::dispatch::play_single_file(&player, uri).await {
     Ok(_info) => {
       apply_volume(app, &player).await;
@@ -257,46 +259,48 @@ async fn play_queued_local(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) 
 
 #[cfg(feature = "subsonic")]
 async fn play_queued_subsonic(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
-  let Some(player) = acquire_queue_player(app).await else {
-    return false;
-  };
+  release_librespot(app).await;
   let Some(source) = crate::infra::subsonic::dispatch::build_source(app).await else {
     return false; // build_source surfaced its own status
   };
-  match crate::infra::subsonic::dispatch::download_and_play(&source, &player, uri).await {
-    Ok(tmp) => {
-      apply_volume(app, &player).await;
-      publish_decoded(app, player, track.clone(), Some(tmp)).await;
-      true
-    }
-    Err(e) => {
-      set_status(app, format!("Cannot play {}: {e}", track.name)).await;
-      false
-    }
-  }
+  let Some(player) = acquire_queue_player(app).await else {
+    return false;
+  };
+  let fetch_id = publish_pending_decoded(app, &player, track).await;
+  // Fetch off the IoEvent pump: awaiting the download here would freeze every
+  // other event (skips included, for every source) for its whole duration.
+  let app = Arc::clone(app);
+  let uri = uri.to_string();
+  let name = track.name.clone();
+  tokio::spawn(async move {
+    let result = crate::infra::subsonic::dispatch::download_for_queue(&source, &uri).await;
+    finish_decoded_fetch(&app, fetch_id, result, &name).await;
+  });
+  true
 }
 
 #[cfg(feature = "youtube")]
 async fn play_queued_youtube(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  release_librespot(app).await;
   let Some(player) = acquire_queue_player(app).await else {
     return false;
   };
+  let fetch_id = publish_pending_decoded(app, &player, track).await;
   {
     let mut guard = app.lock().await;
     guard.set_status_message(format!("Fetching {}\u{2026}", track.name), 30);
   }
   let source = crate::infra::youtube::dispatch::build_source(app).await;
-  match crate::infra::youtube::dispatch::download_and_play(&source, &player, uri).await {
-    Ok(tmp) => {
-      apply_volume(app, &player).await;
-      publish_decoded(app, player, track.clone(), Some(tmp)).await;
-      true
-    }
-    Err(e) => {
-      set_status(app, format!("Cannot play {}: {e}", track.name)).await;
-      false
-    }
-  }
+  // Fetch off the IoEvent pump: awaiting yt-dlp here would freeze every other
+  // event (skips included, for every source) for its whole duration.
+  let app = Arc::clone(app);
+  let uri = uri.to_string();
+  let name = track.name.clone();
+  tokio::spawn(async move {
+    let result = crate::infra::youtube::dispatch::download_for_queue(&source, &uri).await;
+    finish_decoded_fetch(&app, fetch_id, result, &name).await;
+  });
+  true
 }
 
 /// Play a queued Spotify track through the native streaming player via a direct
@@ -330,11 +334,10 @@ async fn play_queued_spotify(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str
       p.pause();
     }
   }
-  player.activate();
-  if let Err(e) = player.play_uri(uri).await {
-    set_status(app, format!("Cannot play {}: {e}", track.name)).await;
-    return false;
-  }
+  // Publish the slot *before* the load, so librespot events arriving during it
+  // are classified correctly: the stray-playback guard sees a Spotify slot and
+  // lets this track start, and a Spirc self-advance racing the load is caught
+  // by the reload guard instead of slipping through an empty slot.
   {
     use crate::infra::queue::QueueNowPlaying;
     let mut guard = app.lock().await;
@@ -343,15 +346,131 @@ async fn play_queued_spotify(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str
     });
     // Fresh slot: reset the Spirc self-advance retry budget.
     guard.spotify_queue_guard_reloads = 0;
+  }
+  player.activate();
+  if let Err(e) = player.play_uri(uri).await {
+    // Unpublish so the failed slot can't shadow the next item (or the resume).
+    app.lock().await.queue_now = None;
+    set_status(app, format!("Cannot play {}: {e}", track.name)).await;
+    return false;
+  }
+  {
+    let mut guard = app.lock().await;
     guard.set_status_message(format!("\u{266a} {} (queue)", track.name), 4);
+    preload_next_queued_spotify(&guard);
   }
   true
 }
 
-/// Publish the decoded queue slot and announce the track. `tempfile` is the
-/// downloaded backing file (Subsonic / YouTube) or `None` (local files play
-/// straight from disk).
+/// Warm the *next* queued Spotify track's audio while the current queue slot
+/// plays. A queued Spotify track is a cold direct `player.load` (metadata +
+/// audio key + CDN handshake), which reads as a small skip delay that Spirc's
+/// own in-context skipping doesn't have — Spirc preloads. This levels that:
+/// called whenever a queue slot starts playing, under whatever `App` borrow the
+/// caller already holds.
+#[cfg(feature = "streaming")]
+fn preload_next_queued_spotify(app: &App) {
+  let Some(uri) = app.native_queue.first().and_then(|t| t.uri.clone()) else {
+    return;
+  };
+  if queue_item_source(&uri) != QueueItemSource::Spotify {
+    return;
+  }
+  if let Some(player) = app.streaming_player.as_ref().filter(|p| p.is_connected()) {
+    player.preload_uri(&uri);
+  }
+}
+
+/// Monotonic source for [`DecodedQueuePlayback::fetch_id`] stamps.
 #[cfg(feature = "audio-decode")]
+static QUEUE_FETCH_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(feature = "audio-decode")]
+fn next_fetch_id() -> u64 {
+  QUEUE_FETCH_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Publish the queue slot for `track` *before* its (possibly multi-second)
+/// download or decode, marked `advancing` so the runner tick doesn't read the
+/// still-empty sink as end-of-track. From this instant `queue_owns_playback()`
+/// is true, so the transport paths (skip, pause, playbar) see the queued track
+/// as current during the fetch. Without this, a skip in the silent download
+/// window fell through to the "context playing with items waiting" branch,
+/// which re-suspended the context and dispatched a second advance — dropping
+/// one queued item on the floor. Returns the slot's fetch stamp, which a
+/// background fetch passes back to [`finish_decoded_fetch`].
+#[cfg(feature = "audio-decode")]
+async fn publish_pending_decoded(
+  app: &Arc<Mutex<App>>,
+  player: &Arc<LocalPlayer>,
+  track: &TrackInfo,
+) -> u64 {
+  use crate::infra::queue::{DecodedQueuePlayback, QueueNowPlaying};
+  let fetch_id = next_fetch_id();
+  let mut guard = app.lock().await;
+  guard.queue_now = Some(QueueNowPlaying::Decoded(DecodedQueuePlayback {
+    player: Arc::clone(player),
+    track: track.clone(),
+    advancing: true,
+    fetch_id,
+    #[cfg(any(feature = "subsonic", feature = "youtube"))]
+    tempfile: None,
+  }));
+  fetch_id
+}
+
+/// Complete a background queue fetch: if the slot still carries `fetch_id`,
+/// play the downloaded file and finalize the slot; otherwise (skipped, torn
+/// down, or replaced meanwhile) drop the result silently. On a download or
+/// decode failure the queue advances past the item, exactly like the old
+/// inline path. Play + finalize happen under one `App` lock so a concurrent
+/// advance (which pops under the same lock) can never interleave.
+#[cfg(any(feature = "subsonic", feature = "youtube"))]
+async fn finish_decoded_fetch(
+  app: &Arc<Mutex<App>>,
+  fetch_id: u64,
+  result: anyhow::Result<tempfile::NamedTempFile>,
+  track_name: &str,
+) {
+  use crate::infra::queue::QueueNowPlaying;
+  let mut guard = app.lock().await;
+  let player = match guard.queue_now.as_ref() {
+    Some(QueueNowPlaying::Decoded(d)) if d.fetch_id == fetch_id => Arc::clone(&d.player),
+    _ => return, // superseded — the tempfile drops here
+  };
+  let tmp = match result {
+    Ok(tmp) => tmp,
+    Err(e) => {
+      guard.set_status_message(format!("Cannot play {track_name}: {e}"), 4);
+      guard.dispatch(IoEvent::AdvanceNativeQueue);
+      return;
+    }
+  };
+  let path = tmp.path().to_path_buf();
+  let decode_player = Arc::clone(&player);
+  let played = tokio::task::spawn_blocking(move || decode_player.play_file(&path))
+    .await
+    .map(|r| r.map_err(|e| e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+  if let Err(e) = played {
+    guard.set_status_message(format!("Cannot play {track_name}: {e}"), 4);
+    guard.dispatch(IoEvent::AdvanceNativeQueue);
+    return;
+  }
+  player.set_volume(guard.user_config.behavior.volume_percent as f32 / 100.0);
+  if let Some(QueueNowPlaying::Decoded(d)) = guard.queue_now.as_mut() {
+    d.tempfile = Some(tmp);
+    d.advancing = false;
+  }
+  guard.set_status_message(format!("\u{266a} {track_name} (queue)"), 4);
+  #[cfg(feature = "streaming")]
+  preload_next_queued_spotify(&guard);
+}
+
+/// Publish the decoded queue slot and announce the track. Only the local-file
+/// path finalizes synchronously through here (it plays straight from disk);
+/// downloaded sources finalize via [`finish_decoded_fetch`].
+#[cfg(feature = "local-files")]
 async fn publish_decoded(
   app: &Arc<Mutex<App>>,
   player: Arc<LocalPlayer>,
@@ -366,16 +485,24 @@ async fn publish_decoded(
     player,
     track,
     advancing: false,
+    fetch_id: next_fetch_id(),
     #[cfg(any(feature = "subsonic", feature = "youtube"))]
     tempfile,
   }));
   guard.set_status_message(format!("\u{266a} {name} (queue)"), 4);
+  #[cfg(feature = "streaming")]
+  preload_next_queued_spotify(&guard);
 }
 
 /// Acquire an output-device player for the queue slot, in priority order:
 /// 1. reuse the queue slot's own player (advancing within the queue);
 /// 2. reuse the suspended decoded context's player (device-handoff-free);
-/// 3. pause librespot and open a fresh device.
+/// 3. open a fresh device.
+///
+/// Callers must [`release_librespot`] *before* acquiring, not just on the
+/// fresh-device path: the outgoing queue slot can be a still-playing Spotify
+/// track (mid-track skip / Enter-jump), and on the reuse paths nothing else
+/// silences it — it would keep playing under the whole download window.
 #[cfg(feature = "audio-decode")]
 async fn acquire_queue_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>> {
   if let Some(p) = {
@@ -387,7 +514,6 @@ async fn acquire_queue_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>>
   if let Some(p) = suspended_context_player(app).await {
     return Some(p);
   }
-  release_librespot(app).await;
   match tokio::task::spawn_blocking(LocalPlayer::new).await {
     Ok(Ok(p)) => Some(Arc::new(p)),
     Ok(Err(e)) => {
@@ -423,8 +549,11 @@ async fn suspended_context_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlay
   None
 }
 
-/// Pause native Spotify so librespot releases the output device before the queue
-/// opens a fresh one.
+/// Pause native Spotify before a decoded queue item takes over: it both
+/// releases the output device (when a fresh one is opened) and silences a
+/// still-playing queued Spotify track that is being skipped mid-play. Called
+/// unconditionally at the top of every decoded queue-play path — a Spirc pause
+/// on an already-paused or idle librespot is a no-op.
 #[cfg(feature = "audio-decode")]
 async fn release_librespot(app: &Arc<Mutex<App>>) {
   #[cfg(feature = "streaming")]
@@ -440,7 +569,7 @@ async fn release_librespot(app: &Arc<Mutex<App>>) {
   }
 }
 
-#[cfg(feature = "audio-decode")]
+#[cfg(feature = "local-files")]
 async fn apply_volume(app: &Arc<Mutex<App>>, player: &Arc<LocalPlayer>) {
   let volume = app.lock().await.user_config.behavior.volume_percent;
   player.set_volume(volume as f32 / 100.0);
@@ -464,6 +593,24 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   use crate::core::queue::SuspendedContext;
 
   let suspended = { app.lock().await.queue_suspended.take() };
+
+  // The slot can still be a *playing* Spotify track when the drain came from a
+  // mid-play skip (only unplayable items were left); silence it before anything
+  // resumes over it. A naturally-ended slot was already cleared at EndOfTrack.
+  #[cfg(feature = "streaming")]
+  {
+    let player = {
+      let guard = app.lock().await;
+      if guard.queue_now_is_spotify() {
+        guard.streaming_player.clone()
+      } else {
+        None
+      }
+    };
+    if let Some(player) = player {
+      player.pause();
+    }
+  }
 
   // Take the queue slot's player so we can decide whether to stop it.
   #[cfg(feature = "audio-decode")]

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -51,9 +51,17 @@ pub async fn route_queue_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool {
     return handled;
   }
 
+  #[cfg(feature = "streaming")]
+  if let Some(handled) = route_spotify_queue_transport(app, event).await {
+    return handled;
+  }
+
   // An explicit new-playback start relinquishes the queue slot (keeping the
   // queued items) so the per-source teardowns/starts run against a clean state.
-  if matches!(event, IoEvent::StartPlayback(..)) {
+  if matches!(
+    event,
+    IoEvent::StartPlayback(Some(_), _, _) | IoEvent::StartPlayback(_, Some(_), _)
+  ) {
     clear_queue_playback(app).await;
   }
   false
@@ -96,6 +104,28 @@ async fn route_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -> Option
     // A forward-only queue has no "previous"; restart the current queued track.
     IoEvent::PreviousTrack | IoEvent::ForcePreviousTrack => {
       let _ = player.seek(Duration::from_millis(0));
+      Some(true)
+    }
+    _ => None,
+  }
+}
+
+/// Transport controls for a queued Spotify track playing through librespot.
+#[cfg(feature = "streaming")]
+async fn route_spotify_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -> Option<bool> {
+  let is_spotify_slot = { app.lock().await.queue_now_is_spotify() };
+  if !is_spotify_slot {
+    return None;
+  }
+  match event {
+    IoEvent::NextTrack => {
+      advance_native_queue(app).await;
+      Some(true)
+    }
+    IoEvent::PreviousTrack | IoEvent::ForcePreviousTrack => {
+      if let Some(player) = { app.lock().await.streaming_player.clone() } {
+        player.seek(0);
+      }
       Some(true)
     }
     _ => None,
@@ -446,7 +476,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   match suspended {
     None => {
       // Nothing was suspended: the queue was playing over an idle app (or a
-      // Spotify context Phase 2 doesn't resume). Stop the slot and note it.
+      // context finished before the queue started). Stop the slot and note it.
       #[cfg(feature = "audio-decode")]
       if let Some(player) = queue_player {
         player.stop();
@@ -604,7 +634,8 @@ async fn resume_subsonic(
       let decode_player = Arc::clone(&player);
       let ok = tokio::task::spawn_blocking(move || decode_player.play_file(&path))
         .await
-        .is_ok();
+        .map(|r| r.is_ok())
+        .unwrap_or(false);
       // Clear the latch either way: on failure the sink is empty, so leaving
       // `advancing = true` would wedge the runner tick's advance off forever.
       if let Some(s) = app.lock().await.subsonic_playback.as_mut() {
@@ -655,7 +686,8 @@ async fn resume_youtube(
       let decode_player = Arc::clone(&player);
       let ok = tokio::task::spawn_blocking(move || decode_player.play_file(&path))
         .await
-        .is_ok();
+        .map(|r| r.is_ok())
+        .unwrap_or(false);
       // Clear the latch either way: on failure the sink is empty, so leaving
       // `advancing = true` would wedge the runner tick's advance off forever.
       if let Some(s) = app.lock().await.youtube_playback.as_mut() {
@@ -742,6 +774,72 @@ mod tests {
     let app = test_app();
     assert!(route_queue_event(&app, &IoEvent::AdvanceNativeQueue).await);
     assert!(app.lock().await.native_queue.is_empty());
+  }
+
+  #[cfg(feature = "streaming")]
+  #[tokio::test]
+  async fn next_track_is_consumed_by_spotify_queue_slot() {
+    use crate::infra::queue::QueueNowPlaying;
+    let app = test_app();
+    app.lock().await.queue_now = Some(QueueNowPlaying::Spotify {
+      track: track("spotify:track:queued", "Queued"),
+    });
+
+    assert!(route_queue_event(&app, &IoEvent::NextTrack).await);
+  }
+
+  #[cfg(feature = "streaming")]
+  #[tokio::test]
+  async fn bare_resume_does_not_clear_spotify_queue_slot() {
+    use crate::core::queue::SuspendedContext;
+    use crate::infra::queue::QueueNowPlaying;
+    let app = test_app();
+    {
+      let mut guard = app.lock().await;
+      guard.queue_now = Some(QueueNowPlaying::Spotify {
+        track: track("spotify:track:queued", "Queued"),
+      });
+      guard.queue_suspended = Some(SuspendedContext::Spotify {
+        context_uri: Some("spotify:playlist:ctx".to_string()),
+        resume_track_uri: Some("spotify:track:resume".to_string()),
+      });
+    }
+
+    assert!(!route_queue_event(&app, &IoEvent::StartPlayback(None, None, None)).await);
+
+    let guard = app.lock().await;
+    assert!(guard.queue_now_is_spotify());
+    assert!(guard.queue_suspended.is_some());
+  }
+
+  #[cfg(feature = "streaming")]
+  #[tokio::test]
+  async fn new_playback_clears_spotify_queue_slot() {
+    use crate::core::queue::SuspendedContext;
+    use crate::infra::queue::QueueNowPlaying;
+    let app = test_app();
+    {
+      let mut guard = app.lock().await;
+      guard.queue_now = Some(QueueNowPlaying::Spotify {
+        track: track("spotify:track:queued", "Queued"),
+      });
+      guard.queue_suspended = Some(SuspendedContext::Spotify {
+        context_uri: Some("spotify:playlist:ctx".to_string()),
+        resume_track_uri: Some("spotify:track:resume".to_string()),
+      });
+    }
+
+    assert!(
+      !route_queue_event(
+        &app,
+        &IoEvent::StartPlayback(Some("spotify:playlist:new".to_string()), None, None)
+      )
+      .await
+    );
+
+    let guard = app.lock().await;
+    assert!(!guard.queue_owns_playback());
+    assert!(guard.queue_suspended.is_none());
   }
 
   /// A live end-to-end queue test: browse a Subsonic playlist, start it, queue a

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -1,0 +1,762 @@
+//! Native queue playback routing.
+//!
+//! [`route_queue_event`] is wired **first** in the runtime IoEvent pump (before
+//! the per-source dispatchers). It owns [`IoEvent::AdvanceNativeQueue`] and the
+//! transport controls for the queue slot's player, and it relinquishes the queue
+//! slot when the user starts an unrelated playback.
+//!
+//! Compiled unconditionally; the decoded-playback bodies are gated per source
+//! feature. In a slim build the engine reduces to "skip every item with a
+//! `not available in this build` status" — correct, and enough for the pump to
+//! stay one shape across builds.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::core::app::App;
+use crate::core::plugin_api::TrackInfo;
+use crate::core::queue::{queue_item_source, source_available, source_label, QueueItemSource};
+use crate::infra::network::IoEvent;
+
+#[cfg(feature = "audio-decode")]
+use crate::infra::audio::LocalPlayer;
+#[cfg(feature = "audio-decode")]
+use std::time::Duration;
+
+/// Intercept queue-owned events before the per-source dispatchers.
+///
+/// Returns `true` when the event was consumed and must **not** be forwarded,
+/// `false` to let the normal dispatch run. [`IoEvent::StartPlayback`] variants
+/// return `false` (the per-source teardowns/starts still run) but first clear
+/// the queue slot so a new play cleanly takes over.
+pub async fn route_queue_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool {
+  if let IoEvent::AdvanceNativeQueue = event {
+    advance_native_queue(app).await;
+    return true;
+  }
+
+  // Transport for the queue slot's own player (Pause / Seek / Volume / Next /
+  // bare-resume). Only meaningful when a decoded queued track owns the sink;
+  // compiles out entirely without `audio-decode`.
+  #[cfg(feature = "audio-decode")]
+  if let Some(handled) = route_queue_transport(app, event).await {
+    return handled;
+  }
+
+  // An explicit new-playback start relinquishes the queue slot (keeping the
+  // queued items) so the per-source teardowns/starts run against a clean state.
+  if matches!(event, IoEvent::StartPlayback(..)) {
+    clear_queue_playback(app).await;
+  }
+  false
+}
+
+/// Transport controls for the queue slot's player, when a decoded queued track
+/// owns the sink. Returns `Some(true)` when consumed, `None` when this event is
+/// not a queue-slot transport control (so the caller falls through).
+#[cfg(feature = "audio-decode")]
+async fn route_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -> Option<bool> {
+  let player = {
+    let guard = app.lock().await;
+    guard.queue_now_decoded_player().map(Arc::clone)
+  }?;
+  match event {
+    IoEvent::PausePlayback => {
+      player.pause();
+      Some(true)
+    }
+    // Bare "resume current" while the queue owns playback resumes the queue slot.
+    IoEvent::StartPlayback(None, None, None) => {
+      player.resume();
+      Some(true)
+    }
+    IoEvent::Seek(position_ms) => {
+      let _ = player.seek(Duration::from_millis(*position_ms as u64));
+      Some(true)
+    }
+    IoEvent::ChangeVolume(volume) => {
+      player.set_volume(*volume as f32 / 100.0);
+      app.lock().await.user_config.behavior.volume_percent = *volume;
+      Some(true)
+    }
+    // Skip the queued track: advance to the next queued item (or resume).
+    IoEvent::NextTrack => {
+      drop(player);
+      advance_native_queue(app).await;
+      Some(true)
+    }
+    // A forward-only queue has no "previous"; restart the current queued track.
+    IoEvent::PreviousTrack | IoEvent::ForcePreviousTrack => {
+      let _ = player.seek(Duration::from_millis(0));
+      Some(true)
+    }
+    _ => None,
+  }
+}
+
+/// Drop the queue slot (stopping its player) and forget any suspended context,
+/// but keep the queued items. Called when the user starts an unrelated playback.
+async fn clear_queue_playback(app: &Arc<Mutex<App>>) {
+  #[cfg(feature = "audio-decode")]
+  {
+    let player = {
+      let mut guard = app.lock().await;
+      guard.queue_suspended = None;
+      guard.take_queue_now_decoded_player()
+    };
+    if let Some(player) = player {
+      player.stop();
+    }
+  }
+  #[cfg(all(feature = "streaming", not(feature = "audio-decode")))]
+  {
+    let mut guard = app.lock().await;
+    guard.queue_suspended = None;
+    guard.queue_now = None;
+  }
+  #[cfg(not(any(feature = "streaming", feature = "audio-decode")))]
+  {
+    let _ = app;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Advance
+// ---------------------------------------------------------------------------
+
+/// Pop the head of the native queue and play it, skipping unplayable items with
+/// a status message (bounded by the queue length — never unbounded recursion).
+/// When the queue drains, resume the suspended context (or finish).
+async fn advance_native_queue(app: &Arc<Mutex<App>>) {
+  loop {
+    let track = {
+      let mut guard = app.lock().await;
+      if guard.native_queue.is_empty() {
+        None
+      } else {
+        Some(guard.native_queue.remove(0))
+      }
+    };
+    let Some(track) = track else {
+      resume_or_finish(app).await;
+      return;
+    };
+    if try_play_queued(app, &track).await {
+      return; // now playing this track
+    }
+    // Unplayable / skipped — loop to the next item.
+  }
+}
+
+/// Try to play one queued track. Returns `true` if it is now playing, `false`
+/// if it was skipped (feature off, no URI, download/decode error) — the caller
+/// then advances to the next item.
+async fn try_play_queued(app: &Arc<Mutex<App>>, track: &TrackInfo) -> bool {
+  let Some(uri) = track.uri.clone() else {
+    set_status(app, "Skipped a queued track with no URI".to_string()).await;
+    return false;
+  };
+  let source = queue_item_source(&uri);
+  if !source_available(source) {
+    set_status(
+      app,
+      format!(
+        "{} playback isn't available in this build",
+        source_label(source)
+      ),
+    )
+    .await;
+    return false;
+  }
+  match source {
+    #[cfg(feature = "local-files")]
+    QueueItemSource::LocalFile => play_queued_local(app, track, &uri).await,
+    #[cfg(feature = "subsonic")]
+    QueueItemSource::Subsonic => play_queued_subsonic(app, track, &uri).await,
+    #[cfg(feature = "youtube")]
+    QueueItemSource::YouTube => play_queued_youtube(app, track, &uri).await,
+    QueueItemSource::Spotify => {
+      // Phase 3 plays queued Spotify tracks via native streaming; until then,
+      // skip them with a note rather than stalling the queue.
+      set_status(
+        app,
+        format!(
+          "Queued Spotify track \"{}\" needs native streaming (coming soon)",
+          track.name
+        ),
+      )
+      .await;
+      false
+    }
+    // Reached only when a source is `source_available` but its play arm is
+    // cfg'd out — impossible (the check above *is* the cfg gate), but the match
+    // must be exhaustive across builds.
+    #[allow(unreachable_patterns)]
+    _ => {
+      set_status(
+        app,
+        format!(
+          "{} playback isn't available in this build",
+          source_label(source)
+        ),
+      )
+      .await;
+      false
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-source queue playback
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "local-files")]
+async fn play_queued_local(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  let Some(player) = acquire_queue_player(app).await else {
+    return false;
+  };
+  match crate::infra::local::dispatch::play_single_file(&player, uri).await {
+    Ok(_info) => {
+      apply_volume(app, &player).await;
+      publish_decoded(app, player, track.clone(), None).await;
+      true
+    }
+    Err(e) => {
+      set_status(app, format!("Cannot play {}: {e}", track.name)).await;
+      false
+    }
+  }
+}
+
+#[cfg(feature = "subsonic")]
+async fn play_queued_subsonic(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  let Some(player) = acquire_queue_player(app).await else {
+    return false;
+  };
+  let Some(source) = crate::infra::subsonic::dispatch::build_source(app).await else {
+    return false; // build_source surfaced its own status
+  };
+  match crate::infra::subsonic::dispatch::download_and_play(&source, &player, uri).await {
+    Ok(tmp) => {
+      apply_volume(app, &player).await;
+      publish_decoded(app, player, track.clone(), Some(tmp)).await;
+      true
+    }
+    Err(e) => {
+      set_status(app, format!("Cannot play {}: {e}", track.name)).await;
+      false
+    }
+  }
+}
+
+#[cfg(feature = "youtube")]
+async fn play_queued_youtube(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str) -> bool {
+  let Some(player) = acquire_queue_player(app).await else {
+    return false;
+  };
+  {
+    let mut guard = app.lock().await;
+    guard.set_status_message(format!("Fetching {}\u{2026}", track.name), 30);
+  }
+  let source = crate::infra::youtube::dispatch::build_source(app).await;
+  match crate::infra::youtube::dispatch::download_and_play(&source, &player, uri).await {
+    Ok(tmp) => {
+      apply_volume(app, &player).await;
+      publish_decoded(app, player, track.clone(), Some(tmp)).await;
+      true
+    }
+    Err(e) => {
+      set_status(app, format!("Cannot play {}: {e}", track.name)).await;
+      false
+    }
+  }
+}
+
+/// Publish the decoded queue slot and announce the track. `tempfile` is the
+/// downloaded backing file (Subsonic / YouTube) or `None` (local files play
+/// straight from disk).
+#[cfg(feature = "audio-decode")]
+async fn publish_decoded(
+  app: &Arc<Mutex<App>>,
+  player: Arc<LocalPlayer>,
+  track: TrackInfo,
+  #[cfg(any(feature = "subsonic", feature = "youtube"))] tempfile: Option<tempfile::NamedTempFile>,
+  #[cfg(not(any(feature = "subsonic", feature = "youtube")))] _tempfile: Option<()>,
+) {
+  use crate::infra::queue::{DecodedQueuePlayback, QueueNowPlaying};
+  let name = track.name.clone();
+  let mut guard = app.lock().await;
+  guard.queue_now = Some(QueueNowPlaying::Decoded(DecodedQueuePlayback {
+    player,
+    track,
+    advancing: false,
+    #[cfg(any(feature = "subsonic", feature = "youtube"))]
+    tempfile,
+  }));
+  guard.set_status_message(format!("\u{266a} {name} (queue)"), 4);
+}
+
+/// Acquire an output-device player for the queue slot, in priority order:
+/// 1. reuse the queue slot's own player (advancing within the queue);
+/// 2. reuse the suspended decoded context's player (device-handoff-free);
+/// 3. pause librespot and open a fresh device.
+#[cfg(feature = "audio-decode")]
+async fn acquire_queue_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>> {
+  if let Some(p) = {
+    let guard = app.lock().await;
+    guard.queue_now_decoded_player().map(Arc::clone)
+  } {
+    return Some(p);
+  }
+  if let Some(p) = suspended_context_player(app).await {
+    return Some(p);
+  }
+  release_librespot(app).await;
+  match tokio::task::spawn_blocking(LocalPlayer::new).await {
+    Ok(Ok(p)) => Some(Arc::new(p)),
+    Ok(Err(e)) => {
+      set_status(app, format!("No audio output for queue playback: {e}")).await;
+      None
+    }
+    Err(e) => {
+      set_status(app, format!("Audio output init failed: {e}")).await;
+      None
+    }
+  }
+}
+
+/// The player of whichever decoded context (local / Subsonic / YouTube) is
+/// currently suspended under the queue, so the queue slot can reuse its output
+/// device. Radio is excluded: it is torn down at suspension (a live stream can't
+/// share the sink), so the queue opens a fresh player and reconnects on resume.
+#[cfg(feature = "audio-decode")]
+async fn suspended_context_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>> {
+  let guard = app.lock().await;
+  #[cfg(feature = "local-files")]
+  if let Some(s) = guard.local_playback.as_ref() {
+    return Some(Arc::clone(&s.player));
+  }
+  #[cfg(feature = "subsonic")]
+  if let Some(s) = guard.subsonic_playback.as_ref() {
+    return Some(Arc::clone(&s.player));
+  }
+  #[cfg(feature = "youtube")]
+  if let Some(s) = guard.youtube_playback.as_ref() {
+    return Some(Arc::clone(&s.player));
+  }
+  None
+}
+
+/// Pause native Spotify so librespot releases the output device before the queue
+/// opens a fresh one.
+#[cfg(feature = "audio-decode")]
+async fn release_librespot(app: &Arc<Mutex<App>>) {
+  #[cfg(feature = "streaming")]
+  {
+    let streaming = app.lock().await.streaming_player.clone();
+    if let Some(player) = streaming {
+      player.pause();
+    }
+  }
+  #[cfg(not(feature = "streaming"))]
+  {
+    let _ = app;
+  }
+}
+
+#[cfg(feature = "audio-decode")]
+async fn apply_volume(app: &Arc<Mutex<App>>, player: &Arc<LocalPlayer>) {
+  let volume = app.lock().await.user_config.behavior.volume_percent;
+  player.set_volume(volume as f32 / 100.0);
+}
+
+// ---------------------------------------------------------------------------
+// Resume
+// ---------------------------------------------------------------------------
+
+/// Queue drained: resume the suspended context, or finish if nothing was
+/// suspended. The queue slot's player is stopped only when it is **not** shared
+/// with the context being resumed (`Arc::ptr_eq`).
+async fn resume_or_finish(app: &Arc<Mutex<App>>) {
+  #[cfg(any(
+    feature = "streaming",
+    feature = "local-files",
+    feature = "subsonic",
+    feature = "youtube",
+    feature = "internet-radio"
+  ))]
+  use crate::core::queue::SuspendedContext;
+
+  let suspended = { app.lock().await.queue_suspended.take() };
+
+  // Take the queue slot's player so we can decide whether to stop it.
+  #[cfg(feature = "audio-decode")]
+  let queue_player = { app.lock().await.take_queue_now_decoded_player() };
+  #[cfg(all(feature = "streaming", not(feature = "audio-decode")))]
+  {
+    app.lock().await.queue_now = None;
+  }
+
+  match suspended {
+    None => {
+      // Nothing was suspended: the queue was playing over an idle app (or a
+      // Spotify context Phase 2 doesn't resume). Stop the slot and note it.
+      #[cfg(feature = "audio-decode")]
+      if let Some(player) = queue_player {
+        player.stop();
+        app
+          .lock()
+          .await
+          .set_status_message("Queue finished".to_string(), 3);
+      }
+    }
+    #[cfg(feature = "local-files")]
+    Some(SuspendedContext::Local {
+      resume_index,
+      resume_position_ms,
+    }) => resume_local(app, resume_index, resume_position_ms, queue_player).await,
+    #[cfg(feature = "subsonic")]
+    Some(SuspendedContext::Subsonic {
+      resume_index,
+      resume_position_ms,
+    }) => resume_subsonic(app, resume_index, resume_position_ms, queue_player).await,
+    #[cfg(feature = "youtube")]
+    Some(SuspendedContext::YouTube {
+      resume_index,
+      resume_position_ms,
+    }) => resume_youtube(app, resume_index, resume_position_ms, queue_player).await,
+    #[cfg(feature = "internet-radio")]
+    Some(SuspendedContext::Radio { station }) => {
+      // Radio uses its own fresh player, so always stop the queue slot.
+      if let Some(player) = queue_player {
+        player.stop();
+      }
+      if let Some(uri) = station.uri.clone() {
+        let mut guard = app.lock().await;
+        // Seed the browse table so the radio start path resolves the station.
+        guard.track_table.tracks = vec![station];
+        guard.dispatch(IoEvent::StartPlayback(Some(uri), None, None));
+      }
+    }
+    #[cfg(feature = "streaming")]
+    Some(SuspendedContext::Spotify {
+      context_uri,
+      resume_track_uri,
+    }) => {
+      // Phase 3 implements the actual Spotify context resume; the IoEvent is a
+      // no-op for now. Stop the decoded queue slot if one exists.
+      #[cfg(feature = "audio-decode")]
+      if let Some(player) = queue_player {
+        player.stop();
+      }
+      app
+        .lock()
+        .await
+        .dispatch(IoEvent::ResumeSpotifyContext(context_uri, resume_track_uri));
+    }
+    // In slim builds `SuspendedContext` is uninhabited, so every arm above is
+    // cfg'd out and only `None` is reachable.
+    #[allow(unreachable_patterns)]
+    _ =>
+    {
+      #[cfg(feature = "audio-decode")]
+      if let Some(player) = queue_player {
+        player.stop();
+      }
+    }
+  }
+}
+
+#[cfg(feature = "local-files")]
+async fn resume_local(
+  app: &Arc<Mutex<App>>,
+  resume_index: Option<usize>,
+  resume_position_ms: u64,
+  queue_player: Option<Arc<LocalPlayer>>,
+) {
+  let Some(index) = resume_index else {
+    // Context exhausted: tear it down and stop the queue slot.
+    if let Some(local) = app.lock().await.local_playback.take() {
+      local.player.stop();
+    }
+    if let Some(player) = queue_player {
+      player.stop();
+    }
+    return;
+  };
+  // Point the context at the resume track and keep it latched until play_index
+  // commits. Stop the queue slot only if it is a different player.
+  let shared = {
+    let mut guard = app.lock().await;
+    match guard.local_playback.as_mut() {
+      Some(local) => {
+        let shared = queue_player
+          .as_ref()
+          .is_some_and(|qp| Arc::ptr_eq(qp, &local.player));
+        local.index = index;
+        local.advancing = true;
+        shared
+      }
+      None => false,
+    }
+  };
+  if !shared {
+    if let Some(player) = queue_player {
+      player.stop();
+    }
+  }
+  // Local has no retained tempfile; play_index re-reads from disk (restarting
+  // the track), then we seek to the saved position for a mid-track resume.
+  crate::infra::local::dispatch::play_index(app, index).await;
+  if resume_position_ms > 0 {
+    let guard = app.lock().await;
+    if let Some(local) = guard.local_playback.as_ref() {
+      let _ = local.player.seek(Duration::from_millis(resume_position_ms));
+    }
+  }
+}
+
+#[cfg(feature = "subsonic")]
+async fn resume_subsonic(
+  app: &Arc<Mutex<App>>,
+  resume_index: Option<usize>,
+  resume_position_ms: u64,
+  queue_player: Option<Arc<LocalPlayer>>,
+) {
+  let Some(index) = resume_index else {
+    if let Some(s) = app.lock().await.subsonic_playback.take() {
+      s.player.stop();
+    }
+    if let Some(player) = queue_player {
+      player.stop();
+    }
+    return;
+  };
+  // Same track and its tempfile is still loaded (mid-track Enter-jump): replay
+  // the retained tempfile and seek, avoiding a re-download. Otherwise re-download
+  // the target index through the existing play_index machinery.
+  let replay = {
+    let mut guard = app.lock().await;
+    match guard.subsonic_playback.as_mut() {
+      Some(s) if index == s.index => {
+        s.advancing = true;
+        Some((Arc::clone(&s.player), s.tempfile.path().to_path_buf()))
+      }
+      Some(s) => {
+        s.index = index;
+        s.advancing = true;
+        None
+      }
+      None => None,
+    }
+  };
+  // The queue slot shares the context player (reused at acquire time), so it is
+  // never stopped here — the same sink is reloaded on resume.
+  let _ = queue_player;
+  match replay {
+    Some((player, path)) => {
+      let decode_player = Arc::clone(&player);
+      let ok = tokio::task::spawn_blocking(move || decode_player.play_file(&path))
+        .await
+        .is_ok();
+      // Clear the latch either way: on failure the sink is empty, so leaving
+      // `advancing = true` would wedge the runner tick's advance off forever.
+      if let Some(s) = app.lock().await.subsonic_playback.as_mut() {
+        s.advancing = false;
+      }
+      if ok && resume_position_ms > 0 {
+        let _ = player.seek(Duration::from_millis(resume_position_ms));
+      }
+    }
+    None => crate::infra::subsonic::dispatch::play_index(app, index).await,
+  }
+}
+
+#[cfg(feature = "youtube")]
+async fn resume_youtube(
+  app: &Arc<Mutex<App>>,
+  resume_index: Option<usize>,
+  resume_position_ms: u64,
+  queue_player: Option<Arc<LocalPlayer>>,
+) {
+  let Some(index) = resume_index else {
+    if let Some(s) = app.lock().await.youtube_playback.take() {
+      s.player.stop();
+    }
+    if let Some(player) = queue_player {
+      player.stop();
+    }
+    return;
+  };
+  let replay = {
+    let mut guard = app.lock().await;
+    match guard.youtube_playback.as_mut() {
+      Some(s) if index == s.index => {
+        s.advancing = true;
+        Some((Arc::clone(&s.player), s.tempfile.path().to_path_buf()))
+      }
+      Some(s) => {
+        s.index = index;
+        s.advancing = true;
+        None
+      }
+      None => None,
+    }
+  };
+  let _ = queue_player;
+  match replay {
+    Some((player, path)) => {
+      let decode_player = Arc::clone(&player);
+      let ok = tokio::task::spawn_blocking(move || decode_player.play_file(&path))
+        .await
+        .is_ok();
+      // Clear the latch either way: on failure the sink is empty, so leaving
+      // `advancing = true` would wedge the runner tick's advance off forever.
+      if let Some(s) = app.lock().await.youtube_playback.as_mut() {
+        s.advancing = false;
+      }
+      if ok && resume_position_ms > 0 {
+        let _ = player.seek(Duration::from_millis(resume_position_ms));
+      }
+    }
+    None => crate::infra::youtube::dispatch::play_index(app, index).await,
+  }
+}
+
+async fn set_status(app: &Arc<Mutex<App>>, message: String) {
+  app.lock().await.set_status_message(message, 4);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::user_config::UserConfig;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn track(uri: &str, name: &str) -> TrackInfo {
+    TrackInfo {
+      uri: Some(uri.to_string()),
+      name: name.to_string(),
+      artists: vec!["Artist".to_string()],
+      album: "Album".to_string(),
+      duration_ms: 1000,
+      id: None,
+      album_id: None,
+      artist_refs: vec![],
+      is_playable: true,
+      is_local: false,
+      track_number: 0,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  fn test_app() -> Arc<Mutex<App>> {
+    let (tx, _rx) = channel();
+    Arc::new(Mutex::new(App::new(
+      tx,
+      UserConfig::new(),
+      Some(SystemTime::now()),
+    )))
+  }
+
+  /// A queued item whose source feature is off in this build must be skipped
+  /// with an actionable status message — never panic, never stall the queue.
+  /// In the slim CI build every alternative source is unavailable, so a
+  /// `subsonic:` item exercises exactly that path.
+  #[cfg(not(feature = "subsonic"))]
+  #[tokio::test]
+  async fn advance_skips_unavailable_source_without_panicking() {
+    let app = test_app();
+    app
+      .lock()
+      .await
+      .native_queue
+      .push(track("subsonic:track:1", "Unplayable"));
+
+    assert!(route_queue_event(&app, &IoEvent::AdvanceNativeQueue).await);
+
+    let guard = app.lock().await;
+    assert!(guard.native_queue.is_empty(), "the item is consumed");
+    assert!(
+      guard
+        .status_message
+        .as_deref()
+        .is_some_and(|m| m.contains("isn't available in this build")),
+      "expected an unavailable-source message, got {:?}",
+      guard.status_message
+    );
+  }
+
+  /// An empty queue with nothing suspended is a no-op advance: it must not
+  /// panic and must leave the queue empty.
+  #[tokio::test]
+  async fn advance_on_empty_queue_is_a_noop() {
+    let app = test_app();
+    assert!(route_queue_event(&app, &IoEvent::AdvanceNativeQueue).await);
+    assert!(app.lock().await.native_queue.is_empty());
+  }
+
+  /// A live end-to-end queue test: browse a Subsonic playlist, start it, queue a
+  /// track from mid-playlist, then advance the native queue. Asserts the
+  /// suspended context (index + tempfile) survives the queue playback so it can
+  /// resume. Ignored (needs the demo server AND an audio device); run:
+  /// `cargo test --features subsonic -- --ignored live_queue`
+  #[cfg(feature = "subsonic")]
+  #[tokio::test]
+  #[ignore = "hits the live demo server AND requires an audio output device"]
+  async fn live_queue_suspends_and_preserves_subsonic_context() {
+    use crate::infra::subsonic::dispatch::route_subsonic_event;
+
+    let app = {
+      let (tx, _rx) = channel();
+      let mut a = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+      a.user_config.behavior.subsonic_url = Some("https://demo.navidrome.org".to_string());
+      a.user_config.behavior.subsonic_username = Some("demo".to_string());
+      a.user_config.behavior.subsonic_password = Some("demo".to_string());
+      Arc::new(Mutex::new(a))
+    };
+
+    assert!(route_subsonic_event(&app, &IoEvent::GetSubsonicPlaylists).await);
+    let playlist_uri = app
+      .lock()
+      .await
+      .subsonic_playlists
+      .first()
+      .unwrap()
+      .uri
+      .clone();
+    assert!(route_subsonic_event(&app, &IoEvent::GetSubsonicTracks(playlist_uri)).await);
+    let tracks: Vec<TrackInfo> = app.lock().await.track_table.tracks.clone();
+    assert!(tracks.len() >= 3, "need a multi-track playlist");
+    let uris: Vec<String> = tracks.iter().filter_map(|t| t.uri.clone()).collect();
+
+    // Start the playlist at index 0.
+    assert!(route_subsonic_event(&app, &IoEvent::StartPlayback(None, Some(uris), Some(0))).await);
+
+    // Queue a track from later in the playlist, then advance the native queue
+    // (as an end-of-track suspension would).
+    {
+      let mut guard = app.lock().await;
+      guard.native_queue.push(tracks[2].clone());
+      guard.queue_suspended = Some(crate::core::queue::SuspendedContext::Subsonic {
+        resume_index: crate::infra::subsonic::next_index(0, tracks.len()),
+        resume_position_ms: 0,
+      });
+      if let Some(s) = guard.subsonic_playback.as_mut() {
+        s.advancing = true;
+      }
+    }
+    assert!(route_queue_event(&app, &IoEvent::AdvanceNativeQueue).await);
+
+    let guard = app.lock().await;
+    let s = guard.subsonic_playback.as_ref().expect("context preserved");
+    assert_eq!(s.index, 0, "the suspended context index is untouched");
+    assert!(
+      guard.queue_owns_playback(),
+      "the queue slot now owns playback"
+    );
+  }
+}

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -82,6 +82,12 @@ pub struct DecodedQueuePlayback {
   /// Guards the empty-sink window during a queue advance from being read as
   /// end-of-track by the runner tick (mirrors the per-source `advancing` guard).
   pub advancing: bool,
+  /// Generation stamp for the slot's background fetch. A Subsonic/YouTube
+  /// download runs off the IoEvent pump (so it never blocks other events); its
+  /// completion only plays and finalizes when the slot still carries the same
+  /// stamp — a skip or teardown in the meantime republished the slot with a new
+  /// one, and the stale result is silently discarded.
+  pub fetch_id: u64,
   /// The tempfile backing a downloaded track (Subsonic / YouTube). `None` for a
   /// local file, which is played straight from disk. Held purely to keep the
   /// file alive on disk for the duration of playback (dropped with the slot), so

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -102,9 +102,8 @@ pub enum QueueNowPlaying {
   #[cfg(feature = "audio-decode")]
   Decoded(DecodedQueuePlayback),
   /// A Spotify track playing via native streaming (`player.load`, no Spirc
-  /// context). Constructed in Phase 3; defined now so the enum is stable.
+  /// context).
   #[cfg(feature = "streaming")]
-  #[allow(dead_code)]
   Spotify {
     track: crate::core::plugin_api::TrackInfo,
   },

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -1,8 +1,8 @@
-//! Native cross-source queue playback engine (Phase 2).
+//! Native cross-source queue playback engine.
 //!
-//! Phase 1 built the queue *state* (`App::native_queue`, the Queue screen ops,
-//! [`SuspendedContext`](crate::core::queue::SuspendedContext), persistence).
-//! This module is the *engine* that consumes it: [`dispatch::route_queue_event`]
+//! [`App::native_queue`](crate::core::app::App::native_queue) holds the queue
+//! state, while this module is the engine that consumes it:
+//! [`dispatch::route_queue_event`]
 //! plays queued tracks through the shared decoded-audio sink, overlaying the
 //! per-source playback contexts without mutating them, and resumes the
 //! underlying context once the queue drains.

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -1,0 +1,146 @@
+//! Native cross-source queue playback engine (Phase 2).
+//!
+//! Phase 1 built the queue *state* (`App::native_queue`, the Queue screen ops,
+//! [`SuspendedContext`](crate::core::queue::SuspendedContext), persistence).
+//! This module is the *engine* that consumes it: [`dispatch::route_queue_event`]
+//! plays queued tracks through the shared decoded-audio sink, overlaying the
+//! per-source playback contexts without mutating them, and resumes the
+//! underlying context once the queue drains.
+//!
+//! ## Playback slot vs. suspended context
+//!
+//! [`QueueNowPlaying`] is what the queue slot is *currently* playing. It never
+//! touches the per-source `*_playback` structs — those are the context to
+//! resume, recorded in `App::queue_suspended`. When the suspended context is a
+//! decoded source, the queue slot **reuses that context's `Arc<LocalPlayer>`**
+//! (the sink is reloaded with the queued track); only when Spotify or nothing is
+//! suspended does it open a fresh player. This keeps the "never two live players
+//! on one output device" invariant.
+
+pub mod dispatch;
+
+/// The runner-tick decision at a decoded source's auto-advance point, once the
+/// native queue is in the picture.
+///
+/// Pure data so the full decision table is unit-testable without an audio
+/// device. `#[allow(dead_code)]` because a slim build (no source features) never
+/// calls it — clippy's slim run does not compile the tests that do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum Decision {
+  /// Nothing to do (still playing, or a track change is already in flight).
+  None,
+  /// Advance within the source's own context (the existing `NextTrack` path).
+  AdvanceContext,
+  /// Suspend the context and hand the sink to the native queue.
+  SuspendToQueue,
+  /// Context exhausted and the queue is empty: tear the session down.
+  Teardown,
+}
+
+/// Decide what a decoded source should do when its current track ends.
+///
+/// - `finished` / `advancing`: the source's live end-of-track + in-flight guard.
+/// - `has_next`: whether the source's own context has a following track.
+/// - `queue_len`: the number of items waiting in the native queue.
+///
+/// The native queue takes priority: whenever it is non-empty and a track just
+/// ended, the context is suspended (regardless of whether it has a next track;
+/// `resume_index` is computed separately and is `None` when the context is
+/// exhausted). Only with an empty queue does the source's own advance / teardown
+/// behavior apply.
+#[allow(dead_code)]
+pub fn advance_decision(
+  finished: bool,
+  advancing: bool,
+  has_next: bool,
+  queue_len: usize,
+) -> Decision {
+  if !finished || advancing {
+    return Decision::None;
+  }
+  if queue_len > 0 {
+    return Decision::SuspendToQueue;
+  }
+  if has_next {
+    Decision::AdvanceContext
+  } else {
+    Decision::Teardown
+  }
+}
+
+/// A queued *decoded* track playing through the shared [`LocalPlayer`] sink
+/// (local file, Subsonic, or YouTube). Kept separate from the per-source
+/// `*_playback` structs so the underlying context is preserved for resume.
+#[cfg(feature = "audio-decode")]
+pub struct DecodedQueuePlayback {
+  /// The output-device sink. Shared (`Arc::ptr_eq`) with the suspended context's
+  /// player when there is one, so no second device is opened.
+  pub player: std::sync::Arc<crate::infra::audio::LocalPlayer>,
+  /// The queued track's metadata (drives the playbar / MPRIS / cover art).
+  pub track: crate::core::plugin_api::TrackInfo,
+  /// Guards the empty-sink window during a queue advance from being read as
+  /// end-of-track by the runner tick (mirrors the per-source `advancing` guard).
+  pub advancing: bool,
+  /// The tempfile backing a downloaded track (Subsonic / YouTube). `None` for a
+  /// local file, which is played straight from disk. Held purely to keep the
+  /// file alive on disk for the duration of playback (dropped with the slot), so
+  /// it is never read back.
+  #[cfg(any(feature = "subsonic", feature = "youtube"))]
+  #[allow(dead_code)]
+  pub tempfile: Option<tempfile::NamedTempFile>,
+}
+
+/// What the native queue's playback slot is currently playing.
+///
+/// A slim build (neither native streaming nor a decoded source) cannot play a
+/// queued track at all, so this type is gated to builds that can; the
+/// `App::queue_now` field shares that gate, and every call site goes through the
+/// unconditional `App::queue_owns_playback()` accessor.
+#[cfg(any(feature = "streaming", feature = "audio-decode"))]
+pub enum QueueNowPlaying {
+  #[cfg(feature = "audio-decode")]
+  Decoded(DecodedQueuePlayback),
+  /// A Spotify track playing via native streaming (`player.load`, no Spirc
+  /// context). Constructed in Phase 3; defined now so the enum is stable.
+  #[cfg(feature = "streaming")]
+  #[allow(dead_code)]
+  Spotify {
+    track: crate::core::plugin_api::TrackInfo,
+  },
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn advance_decision_full_table() {
+    // Not finished, or a change already in flight: never act.
+    assert_eq!(advance_decision(false, false, true, 3), Decision::None);
+    assert_eq!(advance_decision(false, true, false, 0), Decision::None);
+    assert_eq!(advance_decision(true, true, true, 3), Decision::None);
+
+    // Finished with a non-empty queue: always suspend to the queue, whether or
+    // not the context has a next track.
+    assert_eq!(
+      advance_decision(true, false, true, 1),
+      Decision::SuspendToQueue
+    );
+    assert_eq!(
+      advance_decision(true, false, false, 1),
+      Decision::SuspendToQueue
+    );
+    assert_eq!(
+      advance_decision(true, false, true, 5),
+      Decision::SuspendToQueue
+    );
+
+    // Finished with an empty queue: fall back to the source's own behavior.
+    assert_eq!(
+      advance_decision(true, false, true, 0),
+      Decision::AdvanceContext
+    );
+    assert_eq!(advance_decision(true, false, false, 0), Decision::Teardown);
+  }
+}

--- a/src/infra/subsonic/dispatch.rs
+++ b/src/infra/subsonic/dispatch.rs
@@ -344,21 +344,15 @@ async fn download_track(source: &SubsonicSource, track_id: &str) -> Result<Named
   Ok(tmp)
 }
 
-/// Download the track at `uri` and play it on `player`, returning the tempfile
-/// (which the caller must keep alive for the duration of playback). Extracted so
-/// the native queue engine can play a one-off Subsonic track on a borrowed
-/// player without touching `subsonic_playback`.
-pub(crate) async fn download_and_play(
+/// Download the track at `uri` into a tempfile, for the native queue engine's
+/// off-pump fetch (playing is the queue's job — it re-checks that the queue
+/// slot is still current before touching the shared player).
+pub(crate) async fn download_for_queue(
   source: &SubsonicSource,
-  player: &Arc<LocalPlayer>,
   uri: &str,
 ) -> Result<NamedTempFile> {
   let track_id = track_id_from_uri(uri)?.to_string();
-  let tmp = download_track(source, &track_id).await?;
-  let path = tmp.path().to_path_buf();
-  let decode_player = Arc::clone(player);
-  tokio::task::spawn_blocking(move || decode_player.play_file(&path)).await??;
-  Ok(tmp)
+  download_track(source, &track_id).await
 }
 
 /// Begin playing a queue of subsonic tracks, taking over the session and

--- a/src/infra/subsonic/dispatch.rs
+++ b/src/infra/subsonic/dispatch.rs
@@ -137,7 +137,7 @@ pub async fn route_subsonic_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> boo
 /// Build a [`SubsonicSource`] from the saved server config, with the password
 /// taken from the `SPOTATUI_SUBSONIC_PASSWORD` env var when set. Returns `None`
 /// (after surfacing a status message) when no server URL is configured.
-async fn build_source(app: &Arc<Mutex<App>>) -> Option<SubsonicSource> {
+pub(crate) async fn build_source(app: &Arc<Mutex<App>>) -> Option<SubsonicSource> {
   let (url, username, config_password) = {
     let guard = app.lock().await;
     let behavior = &guard.user_config.behavior;
@@ -344,6 +344,23 @@ async fn download_track(source: &SubsonicSource, track_id: &str) -> Result<Named
   Ok(tmp)
 }
 
+/// Download the track at `uri` and play it on `player`, returning the tempfile
+/// (which the caller must keep alive for the duration of playback). Extracted so
+/// the native queue engine can play a one-off Subsonic track on a borrowed
+/// player without touching `subsonic_playback`.
+pub(crate) async fn download_and_play(
+  source: &SubsonicSource,
+  player: &Arc<LocalPlayer>,
+  uri: &str,
+) -> Result<NamedTempFile> {
+  let track_id = track_id_from_uri(uri)?.to_string();
+  let tmp = download_track(source, &track_id).await?;
+  let path = tmp.path().to_path_buf();
+  let decode_player = Arc::clone(player);
+  tokio::task::spawn_blocking(move || decode_player.play_file(&path)).await??;
+  Ok(tmp)
+}
+
 /// Begin playing a queue of subsonic tracks, taking over the session and
 /// starting at `start_idx` (clamped into range).
 async fn start_subsonic_queue(app: &Arc<Mutex<App>>, uris: &[String], start_idx: usize) {
@@ -461,7 +478,7 @@ enum Plan {
 /// A download failure tears the session down (deliberate divergence from the
 /// local source's skip-past): on a network outage, walking the whole queue at
 /// tick speed would spray error toasts, so one failure ends playback instead.
-async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
+pub(crate) async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
   let plan = {
     let guard = app.lock().await;
     match guard.subsonic_playback.as_ref() {

--- a/src/infra/youtube/dispatch.rs
+++ b/src/infra/youtube/dispatch.rs
@@ -492,21 +492,12 @@ async fn download_audio(source: &YouTubeSource, video_id: &str) -> Result<NamedT
   Ok(tmp)
 }
 
-/// Download the audio for `uri` and play it on `player`, returning the tempfile
-/// (which the caller must keep alive for the duration of playback). Extracted so
-/// the native queue engine can play a one-off YouTube track on a borrowed player
-/// without touching `youtube_playback`.
-pub(crate) async fn download_and_play(
-  source: &YouTubeSource,
-  player: &Arc<LocalPlayer>,
-  uri: &str,
-) -> Result<NamedTempFile> {
+/// Download the audio for `uri` into a tempfile, for the native queue engine's
+/// off-pump fetch (playing is the queue's job — it re-checks that the queue
+/// slot is still current before touching the shared player).
+pub(crate) async fn download_for_queue(source: &YouTubeSource, uri: &str) -> Result<NamedTempFile> {
   let video_id = video_id_from_uri(uri)?.to_string();
-  let tmp = download_audio(source, &video_id).await?;
-  let path = tmp.path().to_path_buf();
-  let decode_player = Arc::clone(player);
-  tokio::task::spawn_blocking(move || decode_player.play_file(&path)).await??;
-  Ok(tmp)
+  download_audio(source, &video_id).await
 }
 
 /// Decode-failure hint: without ffmpeg on `$PATH`, yt-dlp leaves the download

--- a/src/infra/youtube/dispatch.rs
+++ b/src/infra/youtube/dispatch.rs
@@ -142,7 +142,7 @@ pub async fn route_youtube_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool
 /// override, else `yt-dlp` on `$PATH`). Unlike Subsonic there is nothing that
 /// can be "unconfigured" — a missing binary surfaces as an actionable error
 /// from the first search instead.
-async fn build_source(app: &Arc<Mutex<App>>) -> YouTubeSource {
+pub(crate) async fn build_source(app: &Arc<Mutex<App>>) -> YouTubeSource {
   let ytdlp_path = app.lock().await.user_config.behavior.ytdlp_path.clone();
   YouTubeSource::new(ytdlp_path)
 }
@@ -492,6 +492,23 @@ async fn download_audio(source: &YouTubeSource, video_id: &str) -> Result<NamedT
   Ok(tmp)
 }
 
+/// Download the audio for `uri` and play it on `player`, returning the tempfile
+/// (which the caller must keep alive for the duration of playback). Extracted so
+/// the native queue engine can play a one-off YouTube track on a borrowed player
+/// without touching `youtube_playback`.
+pub(crate) async fn download_and_play(
+  source: &YouTubeSource,
+  player: &Arc<LocalPlayer>,
+  uri: &str,
+) -> Result<NamedTempFile> {
+  let video_id = video_id_from_uri(uri)?.to_string();
+  let tmp = download_audio(source, &video_id).await?;
+  let path = tmp.path().to_path_buf();
+  let decode_player = Arc::clone(player);
+  tokio::task::spawn_blocking(move || decode_player.play_file(&path)).await??;
+  Ok(tmp)
+}
+
 /// Decode-failure hint: without ffmpeg on `$PATH`, yt-dlp leaves the download
 /// as a fragmented DASH container some decoders reject.
 fn decode_hint(e: impl std::fmt::Display) -> String {
@@ -631,7 +648,7 @@ enum Plan {
 /// A download failure tears the session down (same rationale as Subsonic): on
 /// a network outage or a broken extractor, walking the whole queue at tick
 /// speed would spray error toasts, so one failure ends playback instead.
-async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
+pub(crate) async fn play_index(app: &Arc<Mutex<App>>, target: usize) {
   let plan = {
     let guard = app.lock().await;
     match guard.youtube_playback.as_ref() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -742,7 +742,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   // the browse source was later switched to Spotify while the song kept playing
   // (browse-source and playback-source are deliberately decoupled). A session
   // whose source feature isn't compiled into this build is a no-op on restore.
-  let restore_session: Option<crate::core::persisted_playback::PersistedPlayback> =
+  let restore_session: Option<crate::core::persisted_playback::PersistedSession> =
     match crate::core::persisted_playback::default_session_path()
       .and_then(|path| crate::core::persisted_playback::load(&path))
     {
@@ -752,6 +752,16 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
         None
       }
     };
+  // Split the session: the playback (if any) drives the source resume, while the
+  // native queue is restored into app state regardless of whether a source is
+  // resumed (a queue-only session must not suppress Spotify's device transfer).
+  let (restore_playback, restore_queue): (
+    Option<crate::core::persisted_playback::PersistedPlayback>,
+    Vec<crate::core::plugin_api::TrackInfo>,
+  ) = match restore_session {
+    Some(s) => (s.playback, s.queue),
+    None => (None, Vec::new()),
+  };
 
   if let Some(tick_rate) = matches
     .get_one::<String>("tick-rate")
@@ -1370,7 +1380,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
         // to a device on startup — that would fight the restored source for the
         // audio output. Treat the device decision as passive (Continue); the
         // device list is still fetched above for the UI.
-        let device_startup_behavior = if restore_session.is_some() {
+        let device_startup_behavior = if restore_playback.is_some() {
           StartupBehavior::Continue
         } else {
           initial_startup_behavior
@@ -1396,7 +1406,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
       // startup behavior for its own play/pause decision. Otherwise fall back to
       // the Spotify startup play behavior. Continue is passive and must not
       // transfer devices, change shuffle, or otherwise activate Spotatui.
-      if let Some(session) = restore_session {
+      // Restore the persisted native queue into app state before the runner
+      // starts, independent of whether a source playback is resumed.
+      if !restore_queue.is_empty() {
+        network.app.lock().await.native_queue = restore_queue;
+      }
+      if let Some(session) = restore_playback {
         // Resume off the event pump: a slow source (yt-dlp download, remote
         // fetch) must not stall the Spotify startup events the UI's first render
         // queues (user, playlists, current playback). The restore drives the

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1767,9 +1767,8 @@ async fn handle_mpris_events(
       MprisEvent::Next => {
         #[cfg(feature = "streaming")]
         if let Some(ref player) = streaming_player {
-          player.activate();
-          player.next();
-          player.play();
+          let _ = player;
+          app.lock().await.next_track();
           continue;
         }
         let mut app_lock = app.lock().await;
@@ -1778,9 +1777,8 @@ async fn handle_mpris_events(
       MprisEvent::Previous => {
         #[cfg(feature = "streaming")]
         if let Some(ref player) = streaming_player {
-          player.activate();
-          player.prev();
-          player.play();
+          let _ = player;
+          app.lock().await.previous_track();
           continue;
         }
         let mut app_lock = app.lock().await;
@@ -2038,16 +2036,12 @@ async fn handle_macos_media_events(
         player.pause();
       }
       MacMediaEvent::Next => {
-        player.activate();
-        player.next();
-        // Keep Connect + audio state in sync.
-        player.play();
+        let _ = player;
+        app.lock().await.next_track();
       }
       MacMediaEvent::Previous => {
-        player.activate();
-        player.prev();
-        // Keep Connect + audio state in sync.
-        player.play();
+        let _ = player;
+        app.lock().await.previous_track();
       }
       MacMediaEvent::Stop => {
         player.stop();
@@ -2169,18 +2163,16 @@ async fn handle_windows_media_events(
       }
       WindowsMediaEvent::Next => {
         if let Some(player) = &player_opt {
-          player.activate();
-          player.next();
-          player.play();
+          let _ = player;
+          app.lock().await.next_track();
         } else {
           app.lock().await.dispatch(IoEvent::NextTrack);
         }
       }
       WindowsMediaEvent::Previous => {
         if let Some(player) = &player_opt {
-          player.activate();
-          player.prev();
-          player.play();
+          let _ = player;
+          app.lock().await.previous_track();
         } else {
           app.lock().await.dispatch(IoEvent::PreviousTrack);
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1610,9 +1610,15 @@ async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Ne
   loop {
     match io_rx.try_recv() {
       Ok(io_event) => {
+        // The native queue router runs first: it owns `AdvanceNativeQueue` and
+        // the queue slot's transport controls, and relinquishes the slot on an
+        // unrelated `StartPlayback` (returning false so the per-source
+        // teardowns/starts still run). Compiled unconditionally.
+        let handled_queue =
+          crate::infra::queue::dispatch::route_queue_event(&network.app, &io_event).await;
         // Local-file playback is intercepted before the Spotify network so the
         // network stays Spotify-only (see infra::local::dispatch).
-        let handled_locally = {
+        let handled_locally = !handled_queue && {
           #[cfg(feature = "local-files")]
           {
             crate::infra::local::dispatch::route_local_event(&network.app, &io_event).await
@@ -1627,7 +1633,8 @@ async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Ne
         // false) and is caught here (see infra::subsonic::dispatch). Skipped when
         // local already consumed the event.
         #[cfg(feature = "subsonic")]
-        let handled_subsonic = !handled_locally
+        let handled_subsonic = !handled_queue
+          && !handled_locally
           && crate::infra::subsonic::dispatch::route_subsonic_event(&network.app, &io_event).await;
         #[cfg(not(feature = "subsonic"))]
         let handled_subsonic = false;
@@ -1635,7 +1642,8 @@ async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Ne
         // `radio:` URI falls through both earlier dispatches and is caught here
         // (see infra::radio::dispatch). Skipped when already consumed.
         #[cfg(feature = "internet-radio")]
-        let handled_radio = !handled_locally
+        let handled_radio = !handled_queue
+          && !handled_locally
           && !handled_subsonic
           && crate::infra::radio::dispatch::route_radio_event(&network.app, &io_event).await;
         #[cfg(not(feature = "internet-radio"))]
@@ -1644,13 +1652,19 @@ async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Ne
         // URI falls through the three earlier dispatches and is caught here
         // (see infra::youtube::dispatch). Skipped when already consumed.
         #[cfg(feature = "youtube")]
-        let handled_youtube = !handled_locally
+        let handled_youtube = !handled_queue
+          && !handled_locally
           && !handled_subsonic
           && !handled_radio
           && crate::infra::youtube::dispatch::route_youtube_event(&network.app, &io_event).await;
         #[cfg(not(feature = "youtube"))]
         let handled_youtube = false;
-        if !handled_locally && !handled_subsonic && !handled_radio && !handled_youtube {
+        if !handled_queue
+          && !handled_locally
+          && !handled_subsonic
+          && !handled_radio
+          && !handled_youtube
+        {
           network.handle_network_event(io_event).await;
         } else {
           // A source router consumed the event and returned without touching

--- a/src/tui/handlers/album_tracks.rs
+++ b/src/tui/handlers/album_tracks.rs
@@ -77,34 +77,21 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Char('r') => {
       handle_recommended_tracks(app);
     }
-    _ if key == app.user_config.keys.add_item_to_queue => match app.album_table_context {
-      AlbumTableContext::Full => {
-        if let Some(selected_album) = app.selected_album_full.clone() {
-          if let Some(track) = selected_album
-            .album
-            .tracks
-            .get(app.saved_album_tracks_index)
-          {
-            if let Some(track_id_str) = &track.id {
-              app.dispatch(IoEvent::AddItemToQueue(track_id_str.clone()));
-            }
-          }
-        };
+    _ if key == app.user_config.keys.add_item_to_queue => {
+      let track = match app.album_table_context {
+        AlbumTableContext::Full => app
+          .selected_album_full
+          .as_ref()
+          .and_then(|a| a.album.tracks.get(app.saved_album_tracks_index).cloned()),
+        AlbumTableContext::Simplified => app
+          .selected_album_simplified
+          .as_ref()
+          .and_then(|a| a.tracks.items.get(a.selected_index).cloned()),
+      };
+      if let Some(track) = track {
+        app.add_track_to_native_queue(track);
       }
-      AlbumTableContext::Simplified => {
-        if let Some(selected_album_simplified) = &app.selected_album_simplified.clone() {
-          if let Some(track) = selected_album_simplified
-            .tracks
-            .items
-            .get(selected_album_simplified.selected_index)
-          {
-            if let Some(track_id_str) = &track.id {
-              app.dispatch(IoEvent::AddItemToQueue(track_id_str.clone()));
-            }
-          }
-        };
-      }
-    },
+    }
     _ => {}
   };
 }

--- a/src/tui/handlers/artist.rs
+++ b/src/tui/handlers/artist.rs
@@ -318,14 +318,18 @@ pub fn handler(key: Key, app: &mut App) {
         _ => (),
       },
       _ if key == app.user_config.keys.add_item_to_queue => {
-        if let Some(artist) = &app.artist {
+        let track = app.artist.as_ref().and_then(|artist| {
           if let ArtistBlock::TopTracks = artist.artist_selected_block {
-            if let Some(track) = artist.top_tracks.get(artist.selected_top_track_index) {
-              if let Some(id_str) = &track.id {
-                app.dispatch(IoEvent::AddItemToQueue(id_str.clone()));
-              }
-            };
+            artist
+              .top_tracks
+              .get(artist.selected_top_track_index)
+              .cloned()
+          } else {
+            None
           }
+        });
+        if let Some(track) = track {
+          app.add_track_to_native_queue(track);
         }
       }
       _ => {}

--- a/src/tui/handlers/discover.rs
+++ b/src/tui/handlers/discover.rs
@@ -76,16 +76,14 @@ pub fn handler(key: Key, app: &mut App) {
       }
     }
     _ if key == app.user_config.keys.add_item_to_queue => {
-      // Add selected track from top tracks to queue if available
-      let tracks = match app.discover_selected_index {
-        0 => &app.discover_artists_mix,
-        1 => &app.discover_top_tracks,
-        _ => return,
+      // Add the first track from the selected discover list to the queue.
+      let track = match app.discover_selected_index {
+        0 => app.discover_artists_mix.first().cloned(),
+        1 => app.discover_top_tracks.first().cloned(),
+        _ => None,
       };
-      if let Some(track) = tracks.first() {
-        if let Some(uri) = track.uri.clone() {
-          app.dispatch(IoEvent::AddItemToQueue(uri));
-        }
+      if let Some(track) = track {
+        app.add_track_to_native_queue(track);
       }
     }
     _ => {}

--- a/src/tui/handlers/queue_menu.rs
+++ b/src/tui/handlers/queue_menu.rs
@@ -2,31 +2,200 @@ use super::common_key_events;
 use crate::core::app::App;
 use crate::tui::event::Key;
 
+/// The Queue screen is a header row ("Now playing", index 0, non-actionable)
+/// followed by one selectable row per native-queue item. Selection index `k`
+/// (k >= 1) maps to `native_queue[k - 1]`.
 pub fn handler(key: Key, app: &mut App) {
   match key {
-    k if common_key_events::down_event(k, &app.user_config.keys) => {
-      move_selection(1, app);
-    }
-    k if common_key_events::up_event(k, &app.user_config.keys) => {
-      move_selection(-1, app);
+    k if common_key_events::down_event(k, &app.user_config.keys) => move_selection(1, app),
+    k if common_key_events::up_event(k, &app.user_config.keys) => move_selection(-1, app),
+    // Shift+J / Shift+K reorder the selected item (hardcoded per design, not
+    // rebindable). J moves it down, K moves it up.
+    Key::Char('J') => reorder(1, app),
+    Key::Char('K') => reorder(-1, app),
+    k if k == app.user_config.keys.remove_from_queue => remove_selected(app),
+    Key::Enter => {
+      // Play-from-queue is wired in Phase 2 (queue playback engine).
+      app.set_status_message("Play-from-queue lands with queue playback", 3);
     }
     _ => {}
   }
 }
 
+/// Total selectable rows: the now-playing header plus every queue item.
+fn row_count(app: &App) -> usize {
+  1 + app.native_queue.len()
+}
+
 fn move_selection(delta: i32, app: &mut App) {
-  let len = app.queue.as_ref().map_or(0, |q| {
-    let now = if q.currently_playing.is_some() { 1 } else { 0 };
-    now + q.queue.len()
-  });
-  if len == 0 {
-    return;
-  }
-  let max_index = len.saturating_sub(1);
+  let max_index = row_count(app).saturating_sub(1);
   let current = app.queue_selected_index;
-  let next = match delta {
+  app.queue_selected_index = match delta {
     -1 => current.saturating_sub(1),
     _ => (current + 1).min(max_index),
   };
-  app.queue_selected_index = next;
+}
+
+/// Remove the selected queue item and clamp the selection to the shortened list.
+/// Row 0 (now playing) is non-actionable.
+fn remove_selected(app: &mut App) {
+  let selected = app.queue_selected_index;
+  if selected == 0 {
+    return;
+  }
+  let idx = selected - 1;
+  if idx < app.native_queue.len() {
+    app.native_queue.remove(idx);
+    let max_index = row_count(app).saturating_sub(1);
+    if app.queue_selected_index > max_index {
+      app.queue_selected_index = max_index;
+    }
+  }
+}
+
+/// Swap the selected item with its neighbor and move the selection with it, so
+/// the highlighted row keeps following the same item. No wrap at the ends.
+fn reorder(delta: i32, app: &mut App) {
+  let selected = app.queue_selected_index;
+  if selected == 0 {
+    return;
+  }
+  let idx = selected - 1;
+  let len = app.native_queue.len();
+  if idx >= len {
+    return;
+  }
+  match delta {
+    1 if idx + 1 < len => {
+      app.native_queue.swap(idx, idx + 1);
+      app.queue_selected_index = selected + 1;
+    }
+    -1 if idx > 0 => {
+      app.native_queue.swap(idx, idx - 1);
+      app.queue_selected_index = selected - 1;
+    }
+    _ => {}
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::plugin_api::TrackInfo;
+  use crate::core::user_config::UserConfig;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn track(uri: &str, name: &str) -> TrackInfo {
+    TrackInfo {
+      uri: Some(uri.to_string()),
+      name: name.to_string(),
+      artists: vec!["Artist".to_string()],
+      album: "Album".to_string(),
+      duration_ms: 1000,
+      id: None,
+      album_id: None,
+      artist_refs: vec![],
+      is_playable: true,
+      is_local: false,
+      track_number: 0,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  fn app_with_queue(names: &[&str]) -> App {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.native_queue = names.iter().map(|n| track("spotify:track:x", n)).collect();
+    app
+  }
+
+  #[test]
+  fn move_selection_clamps_to_rows() {
+    let mut app = app_with_queue(&["A", "B"]);
+    // Rows: [now playing, A, B] => max index 2.
+    app.queue_selected_index = 0;
+    move_selection(-1, &mut app);
+    assert_eq!(app.queue_selected_index, 0);
+    move_selection(1, &mut app);
+    move_selection(1, &mut app);
+    move_selection(1, &mut app);
+    move_selection(1, &mut app);
+    assert_eq!(app.queue_selected_index, 2);
+  }
+
+  #[test]
+  fn remove_ignores_now_playing_row() {
+    let mut app = app_with_queue(&["A", "B"]);
+    app.queue_selected_index = 0;
+    remove_selected(&mut app);
+    assert_eq!(app.native_queue.len(), 2);
+  }
+
+  #[test]
+  fn remove_deletes_selected_and_clamps() {
+    let mut app = app_with_queue(&["A", "B"]);
+    // Select last item (row 2 => native_queue[1] == "B").
+    app.queue_selected_index = 2;
+    remove_selected(&mut app);
+    assert_eq!(app.native_queue.len(), 1);
+    assert_eq!(app.native_queue[0].name, "A");
+    // Selection clamped from 2 to the new max (row 1).
+    assert_eq!(app.queue_selected_index, 1);
+  }
+
+  #[test]
+  fn reorder_down_swaps_and_follows_item() {
+    let mut app = app_with_queue(&["A", "B", "C"]);
+    // Select A (row 1).
+    app.queue_selected_index = 1;
+    reorder(1, &mut app);
+    assert_eq!(
+      app
+        .native_queue
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect::<Vec<_>>(),
+      vec!["B", "A", "C"]
+    );
+    // Selection followed A down to row 2.
+    assert_eq!(app.queue_selected_index, 2);
+  }
+
+  #[test]
+  fn reorder_up_swaps_and_follows_item() {
+    let mut app = app_with_queue(&["A", "B", "C"]);
+    // Select C (row 3).
+    app.queue_selected_index = 3;
+    reorder(-1, &mut app);
+    assert_eq!(
+      app
+        .native_queue
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect::<Vec<_>>(),
+      vec!["A", "C", "B"]
+    );
+    assert_eq!(app.queue_selected_index, 2);
+  }
+
+  #[test]
+  fn reorder_at_bounds_is_noop() {
+    let mut app = app_with_queue(&["A", "B"]);
+    // First item can't move up.
+    app.queue_selected_index = 1;
+    reorder(-1, &mut app);
+    assert_eq!(app.native_queue[0].name, "A");
+    assert_eq!(app.queue_selected_index, 1);
+    // Last item can't move down.
+    app.queue_selected_index = 2;
+    reorder(1, &mut app);
+    assert_eq!(app.native_queue[1].name, "B");
+    assert_eq!(app.queue_selected_index, 2);
+    // Now-playing row is non-actionable.
+    app.queue_selected_index = 0;
+    reorder(1, &mut app);
+    assert_eq!(app.queue_selected_index, 0);
+  }
 }

--- a/src/tui/handlers/queue_menu.rs
+++ b/src/tui/handlers/queue_menu.rs
@@ -20,9 +20,10 @@ pub fn handler(key: Key, app: &mut App) {
 }
 
 /// Jump to the selected queue row: drop every item before it, then start the
-/// native queue there. If a decoded context is playing and the queue does not
-/// already own playback, suspend it mid-track first (so it resumes at the same
-/// track + position when the queue drains). Row 0 (now playing) is non-actionable.
+/// native queue there. If a context is playing and the queue does not already
+/// own playback, suspend it mid-track first (a decoded source resumes at the
+/// same track + position; a native-Spotify context resumes at the same track).
+/// Row 0 (now playing) is non-actionable.
 fn play_selected(app: &mut App) {
   let selected = app.queue_selected_index;
   if selected == 0 {
@@ -37,6 +38,12 @@ fn play_selected(app: &mut App) {
   app.queue_selected_index = 1;
   if !app.queue_owns_playback() {
     app.suspend_active_decoded_context_mid_track();
+    // No decoded context recorded a suspension: a native-Spotify context may be
+    // playing instead — suspend it so the queue hands back to it on drain.
+    #[cfg(feature = "streaming")]
+    if app.queue_suspended.is_none() {
+      app.suspend_native_spotify_context_mid_track();
+    }
   }
   app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
 }

--- a/src/tui/handlers/queue_menu.rs
+++ b/src/tui/handlers/queue_menu.rs
@@ -14,12 +14,31 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Char('J') => reorder(1, app),
     Key::Char('K') => reorder(-1, app),
     k if k == app.user_config.keys.remove_from_queue => remove_selected(app),
-    Key::Enter => {
-      // Play-from-queue is wired in Phase 2 (queue playback engine).
-      app.set_status_message("Play-from-queue lands with queue playback", 3);
-    }
+    Key::Enter => play_selected(app),
     _ => {}
   }
+}
+
+/// Jump to the selected queue row: drop every item before it, then start the
+/// native queue there. If a decoded context is playing and the queue does not
+/// already own playback, suspend it mid-track first (so it resumes at the same
+/// track + position when the queue drains). Row 0 (now playing) is non-actionable.
+fn play_selected(app: &mut App) {
+  let selected = app.queue_selected_index;
+  if selected == 0 {
+    return;
+  }
+  let skip = selected - 1;
+  if skip >= app.native_queue.len() {
+    return;
+  }
+  // Drop the items before the selected one so it becomes the queue head.
+  app.native_queue.drain(..skip);
+  app.queue_selected_index = 1;
+  if !app.queue_owns_playback() {
+    app.suspend_active_decoded_context_mid_track();
+  }
+  app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
 }
 
 /// Total selectable rows: the now-playing header plus every queue item.

--- a/src/tui/handlers/recently_played.rs
+++ b/src/tui/handlers/recently_played.rs
@@ -99,13 +99,14 @@ pub fn handler(key: Key, app: &mut App) {
       };
     }
     _ if key == app.user_config.keys.add_item_to_queue => {
-      if let Some(recently_played_result) = &app.recently_played.result.clone() {
-        if let Some(selected_track) = recently_played_result.items.get(app.recently_played.index) {
-          if let Some(ref id_str) = selected_track.id {
-            app.dispatch(IoEvent::AddItemToQueue(id_str.clone()));
-          };
-        };
-      };
+      let track = app
+        .recently_played
+        .result
+        .as_ref()
+        .and_then(|r| r.items.get(app.recently_played.index).cloned());
+      if let Some(track) = track {
+        app.add_track_to_native_queue(track);
+      }
     }
     _ => {}
   };

--- a/src/tui/handlers/search_results.rs
+++ b/src/tui/handlers/search_results.rs
@@ -265,25 +265,18 @@ fn handle_low_press_on_selected_block(app: &mut App) {
 }
 
 fn handle_add_item_to_queue(app: &mut App) {
-  match &app.search_results.selected_block {
-    SearchResultBlock::SongSearch => {
-      if let (Some(index), Some(tracks)) = (
-        app.search_results.selected_tracks_index,
-        &app.search_results.tracks,
-      ) {
-        if let Some(track) = tracks.items.get(index) {
-          if let Some(uri) = track.uri.clone() {
-            app.dispatch(IoEvent::AddItemToQueue(uri));
-          }
-        }
-      }
+  if let SearchResultBlock::SongSearch = app.search_results.selected_block {
+    let track = app.search_results.selected_tracks_index.and_then(|index| {
+      app
+        .search_results
+        .tracks
+        .as_ref()
+        .and_then(|tracks| tracks.items.get(index).cloned())
+    });
+    if let Some(track) = track {
+      app.add_track_to_native_queue(track);
     }
-    SearchResultBlock::ArtistSearch => {}
-    SearchResultBlock::PlaylistSearch => {}
-    SearchResultBlock::AlbumSearch => {}
-    SearchResultBlock::ShowSearch => {}
-    SearchResultBlock::Empty => {}
-  };
+  }
 }
 
 fn handle_enter_event_on_selected_block(app: &mut App) {

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -477,71 +477,23 @@ fn on_enter(app: &mut App) {
 }
 
 fn on_queue(app: &mut App) {
-  let TrackTable {
-    context,
-    selected_index,
-    tracks,
-  } = &app.track_table;
-  if let Some(context) = &context {
-    match context {
-      TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
-        if let Some(track) = tracks.get(*selected_index) {
-          if let Some(playable_id) = track.uri.clone() {
-            app.dispatch(IoEvent::AddItemToQueue(playable_id));
-          }
-        };
-      }
-      TrackTableContext::RecommendedTracks => {
-        if let Some(track) = tracks.get(*selected_index) {
-          if let Some(playable_id) = track.uri.clone() {
-            app.dispatch(IoEvent::AddItemToQueue(playable_id));
-          }
-        }
-      }
-      TrackTableContext::SavedTracks => {
-        if let Some(track) = tracks.get(*selected_index) {
-          if let Some(playable_id) = track.uri.clone() {
-            app.dispatch(IoEvent::AddItemToQueue(playable_id));
-          }
-        }
-      }
-      TrackTableContext::AlbumSearch => {}
-      TrackTableContext::DiscoverPlaylist => {
-        if let Some(track) = tracks.get(*selected_index) {
-          if let Some(playable_id) = track.uri.clone() {
-            app.dispatch(IoEvent::AddItemToQueue(playable_id));
-          }
-        }
-      }
-      // Append the selected file to the live local queue. This is pure in-memory
-      // state (no async player work), so it mutates `App` directly rather than
-      // dispatching. Without an active local session there is no queue to append
-      // to; tell the user to start playback first.
-      TrackTableContext::LocalPlaylist => {
-        #[cfg(feature = "local-files")]
-        if let Some(uri) = tracks.get(*selected_index).and_then(|t| t.uri.clone()) {
-          let name = tracks
-            .get(*selected_index)
-            .map(|t| t.name.clone())
-            .unwrap_or_default();
-          match app.local_playback.as_mut() {
-            Some(local) => {
-              local.queue.push(uri);
-              app.set_status_message(format!("Added to queue: {name}"), 3);
-            }
-            None => {
-              app.set_status_message("Play a local track first to start a queue", 3);
-            }
-          }
-        }
-      }
-      // Subsonic queue-append needs an active subsonic session (wired in M3).
-      TrackTableContext::SubsonicPlaylist => {}
-      // YouTube queue-append would need to splice the live download queue;
-      // start playback from the row instead (Enter). Tracked follow-up.
-      TrackTableContext::YouTubePlaylist => {}
-    }
-  };
+  // Every context except AlbumSearch holds full `TrackInfo` rows, so the queue
+  // action collapses to one path: clone the selected row and hand it to the
+  // native cross-source queue, which routes by URI scheme (Spotify tracks on an
+  // external device still fall back to the Web-API queue). AlbumSearch rows lack
+  // full track info, so it stays a no-op.
+  match app.track_table.context {
+    Some(TrackTableContext::AlbumSearch) | None => return,
+    Some(_) => {}
+  }
+  if let Some(track) = app
+    .track_table
+    .tracks
+    .get(app.track_table.selected_index)
+    .cloned()
+  {
+    app.add_track_to_native_queue(track);
+  }
 }
 
 fn jump_to_start(app: &mut App) {
@@ -623,6 +575,36 @@ mod tests {
     SavedTrack {
       added_at: Utc::now(),
       track: full_track(id, name),
+    }
+  }
+
+  /// A Spotify playback context on some non-native device. In a slim (no
+  /// streaming) build, any Spotify context reads as an external device.
+  #[allow(deprecated)]
+  fn external_spotify_context() -> rspotify::model::context::CurrentPlaybackContext {
+    use rspotify::model::{
+      context::{Actions, CurrentPlaybackContext},
+      CurrentlyPlayingType, Device, DeviceType, RepeatState,
+    };
+    CurrentPlaybackContext {
+      device: Device {
+        id: Some("external-device".to_string()),
+        is_active: true,
+        is_private_session: false,
+        is_restricted: false,
+        name: "Phone".to_string(),
+        _type: DeviceType::Smartphone,
+        volume_percent: Some(50),
+      },
+      repeat_state: RepeatState::Off,
+      shuffle_state: false,
+      context: None,
+      timestamp: Utc::now(),
+      progress: None,
+      is_playing: true,
+      item: None,
+      currently_playing_type: CurrentlyPlayingType::Track,
+      actions: Actions::default(),
     }
   }
 
@@ -728,7 +710,7 @@ mod tests {
   }
 
   #[test]
-  fn saved_tracks_queue_uses_continuous_row_selection() {
+  fn saved_tracks_queue_pushes_selected_row_to_native_queue() {
     let (mut app, rx) = app_with_saved_tracks();
     let first_page = saved_tracks_page(
       0,
@@ -759,12 +741,42 @@ mod tests {
 
     on_queue(&mut app);
 
+    // With no external Spotify device active, the track lands in the native
+    // queue and no Web-API AddItemToQueue is dispatched.
+    assert_eq!(app.native_queue.len(), 1);
+    assert_eq!(
+      app.native_queue[0].uri.as_deref(),
+      Some("spotify:track:0000000000000000000004")
+    );
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn saved_tracks_queue_on_external_device_dispatches_web_api_add() {
+    let (mut app, rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      false,
+    );
+    app.library.saved_tracks.upsert_page_by_offset(page.clone());
+    app.library.saved_tracks.index = 0;
+    app.track_table.selected_index = 1;
+    app.track_table.tracks = page.items.to_vec();
+    // Simulate controlling an external Spotify Connect device: any Spotify
+    // context with no native streaming device counts as external in the slim
+    // build, so `z` keeps today's Web-API queue behavior.
+    app.current_playback_context = Some(external_spotify_context());
+
+    on_queue(&mut app);
+
     match rx.recv().unwrap() {
-      IoEvent::AddItemToQueue(playable_id) => {
-        assert_eq!(playable_id, "spotify:track:0000000000000000000004");
+      IoEvent::AddItemToQueue(uri) => {
+        assert_eq!(uri, "spotify:track:0000000000000000000002");
       }
       other => panic!("unexpected event: {:?}", event_name(&other)),
     }
+    assert!(app.native_queue.is_empty());
   }
 
   #[test]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -1054,29 +1054,39 @@ pub async fn start_ui(
           source_owns_playback = true;
           app.song_progress_ms = d.player.position().as_millis();
         }
+        #[allow(unused_variables)]
+        let spotify_queue_slot = app.queue_now_is_spotify();
         #[cfg(feature = "local-files")]
-        if let Some(local) = app.local_playback.as_ref() {
-          source_owns_playback = true;
-          let position_ms = local.player.position().as_millis();
-          app.song_progress_ms = position_ms;
+        if !spotify_queue_slot {
+          if let Some(local) = app.local_playback.as_ref() {
+            source_owns_playback = true;
+            let position_ms = local.player.position().as_millis();
+            app.song_progress_ms = position_ms;
+          }
         }
         #[cfg(feature = "subsonic")]
-        if let Some(subsonic) = app.subsonic_playback.as_ref() {
-          source_owns_playback = true;
-          let position_ms = subsonic.player.position().as_millis();
-          app.song_progress_ms = position_ms;
+        if !spotify_queue_slot {
+          if let Some(subsonic) = app.subsonic_playback.as_ref() {
+            source_owns_playback = true;
+            let position_ms = subsonic.player.position().as_millis();
+            app.song_progress_ms = position_ms;
+          }
         }
         #[cfg(feature = "internet-radio")]
-        if let Some(radio) = app.radio_playback.as_ref() {
-          source_owns_playback = true;
-          let position_ms = radio.player.position().as_millis();
-          app.song_progress_ms = position_ms;
+        if !spotify_queue_slot {
+          if let Some(radio) = app.radio_playback.as_ref() {
+            source_owns_playback = true;
+            let position_ms = radio.player.position().as_millis();
+            app.song_progress_ms = position_ms;
+          }
         }
         #[cfg(feature = "youtube")]
-        if let Some(youtube) = app.youtube_playback.as_ref() {
-          source_owns_playback = true;
-          let position_ms = youtube.player.position().as_millis();
-          app.song_progress_ms = position_ms;
+        if !spotify_queue_slot {
+          if let Some(youtube) = app.youtube_playback.as_ref() {
+            source_owns_playback = true;
+            let position_ms = youtube.player.position().as_millis();
+            app.song_progress_ms = position_ms;
+          }
         }
 
         // Persist the active non-Spotify session so it resumes on next launch.

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -1036,7 +1036,7 @@ pub async fn start_ui(
         // Persist the active non-Spotify session so it resumes on next launch.
         // Throttled to avoid churning the file every tick; a Some -> None
         // transition (queue ended, or switched to Spotify) clears it instead.
-        match app.current_persisted_playback() {
+        match app.current_persisted_session() {
           Some(session) => {
             let due = last_session_save
               .map(|t| t.elapsed() >= SESSION_SAVE_INTERVAL)
@@ -1170,7 +1170,7 @@ pub async fn start_ui(
   // quit (the throttled in-loop save is up to a few seconds stale). Done
   // synchronously before teardown so the player is still alive to read from.
   {
-    let session = app.lock().await.current_persisted_playback();
+    let session = app.lock().await.current_persisted_session();
     if let Some(session) = session {
       if let Ok(path) = crate::core::persisted_playback::default_session_path() {
         if let Err(e) = crate::core::persisted_playback::save(&path, &session) {

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -909,27 +909,52 @@ pub async fn start_ui(
         // The `advancing` guard also protects the brief empty-sink window during
         // a track change's decode — the same class of guard as the
         // "don't treat the pre-playback empty sink as end-of-track" invariant.
-        #[cfg(feature = "local-files")]
+        // Native queue slot: when the queued track finishes, advance the queue
+        // (play the next queued item, or resume the suspended context). Runs
+        // before the per-source blocks so it takes precedence over them.
+        #[cfg(feature = "audio-decode")]
         {
-          // Decide under one borrow whether to advance (true), tear down
-          // (false), or do nothing (None) — then act after the borrow ends so
-          // the teardown's `app.local_playback = None` doesn't overlap it.
-          let advance = app.local_playback.as_mut().and_then(|local| {
-            if local.player.is_finished() && !local.advancing {
-              if crate::infra::local::next_index(local.index, local.queue.len()).is_some() {
-                local.advancing = true; // atomic check-and-set: one dispatch only
-                Some(true)
-              } else {
-                Some(false)
-              }
-            } else {
-              None
+          use crate::infra::queue::QueueNowPlaying;
+          let advance = match app.queue_now.as_mut() {
+            Some(QueueNowPlaying::Decoded(d)) if d.player.is_finished() && !d.advancing => {
+              d.advancing = true; // atomic check-and-set: one dispatch only
+              true
             }
+            _ => false,
+          };
+          if advance {
+            app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
+          }
+        }
+
+        #[cfg(feature = "local-files")]
+        if !app.queue_owns_playback() {
+          // Decide under one borrow, then act after the borrow ends. With items
+          // in the native queue a finished track suspends the context and hands
+          // the sink to the queue instead of advancing/tearing down.
+          use crate::infra::queue::{advance_decision, Decision};
+          let queue_len = app.native_queue.len();
+          let decision = app.local_playback.as_ref().map(|local| {
+            advance_decision(
+              local.player.is_finished(),
+              local.advancing,
+              crate::infra::local::next_index(local.index, local.queue.len()).is_some(),
+              queue_len,
+            )
           });
-          match advance {
-            Some(true) => app.dispatch(crate::infra::network::IoEvent::NextTrack),
-            Some(false) => app.local_playback = None,
-            None => {}
+          match decision {
+            Some(Decision::AdvanceContext) => {
+              if let Some(local) = app.local_playback.as_mut() {
+                local.advancing = true; // atomic check-and-set: one dispatch only
+              }
+              app.dispatch(crate::infra::network::IoEvent::NextTrack);
+            }
+            Some(Decision::SuspendToQueue) => {
+              app.suspend_active_decoded_context_for_skip();
+              app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
+            }
+            Some(Decision::Teardown) => app.local_playback = None,
+            Some(Decision::None) | None => {}
           }
         }
 
@@ -938,24 +963,30 @@ pub async fn start_ui(
         // empty for the whole multi-second download window; without it the next
         // tick would re-dispatch and skip several tracks per advance.
         #[cfg(feature = "subsonic")]
-        {
-          let advance = app.subsonic_playback.as_mut().and_then(|subsonic| {
-            if subsonic.player.is_finished() && !subsonic.advancing {
-              if crate::infra::subsonic::next_index(subsonic.index, subsonic.tracks.len()).is_some()
-              {
-                subsonic.advancing = true; // atomic check-and-set: one dispatch only
-                Some(true)
-              } else {
-                Some(false)
-              }
-            } else {
-              None
-            }
+        if !app.queue_owns_playback() {
+          use crate::infra::queue::{advance_decision, Decision};
+          let queue_len = app.native_queue.len();
+          let decision = app.subsonic_playback.as_ref().map(|subsonic| {
+            advance_decision(
+              subsonic.player.is_finished(),
+              subsonic.advancing,
+              crate::infra::subsonic::next_index(subsonic.index, subsonic.tracks.len()).is_some(),
+              queue_len,
+            )
           });
-          match advance {
-            Some(true) => app.dispatch(crate::infra::network::IoEvent::NextTrack),
-            Some(false) => app.subsonic_playback = None,
-            None => {}
+          match decision {
+            Some(Decision::AdvanceContext) => {
+              if let Some(subsonic) = app.subsonic_playback.as_mut() {
+                subsonic.advancing = true; // atomic check-and-set: one dispatch only
+              }
+              app.dispatch(crate::infra::network::IoEvent::NextTrack);
+            }
+            Some(Decision::SuspendToQueue) => {
+              app.suspend_active_decoded_context_for_skip();
+              app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
+            }
+            Some(Decision::Teardown) => app.subsonic_playback = None,
+            Some(Decision::None) | None => {}
           }
         }
 
@@ -963,23 +994,30 @@ pub async fn start_ui(
         // download window is even longer, so the `advancing` guard matters
         // just as much here.
         #[cfg(feature = "youtube")]
-        {
-          let advance = app.youtube_playback.as_mut().and_then(|youtube| {
-            if youtube.player.is_finished() && !youtube.advancing {
-              if crate::infra::youtube::next_index(youtube.index, youtube.tracks.len()).is_some() {
-                youtube.advancing = true; // atomic check-and-set: one dispatch only
-                Some(true)
-              } else {
-                Some(false)
-              }
-            } else {
-              None
-            }
+        if !app.queue_owns_playback() {
+          use crate::infra::queue::{advance_decision, Decision};
+          let queue_len = app.native_queue.len();
+          let decision = app.youtube_playback.as_ref().map(|youtube| {
+            advance_decision(
+              youtube.player.is_finished(),
+              youtube.advancing,
+              crate::infra::youtube::next_index(youtube.index, youtube.tracks.len()).is_some(),
+              queue_len,
+            )
           });
-          match advance {
-            Some(true) => app.dispatch(crate::infra::network::IoEvent::NextTrack),
-            Some(false) => app.youtube_playback = None,
-            None => {}
+          match decision {
+            Some(Decision::AdvanceContext) => {
+              if let Some(youtube) = app.youtube_playback.as_mut() {
+                youtube.advancing = true; // atomic check-and-set: one dispatch only
+              }
+              app.dispatch(crate::infra::network::IoEvent::NextTrack);
+            }
+            Some(Decision::SuspendToQueue) => {
+              app.suspend_active_decoded_context_for_skip();
+              app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
+            }
+            Some(Decision::Teardown) => app.youtube_playback = None,
+            Some(Decision::None) | None => {}
           }
         }
 
@@ -1008,6 +1046,14 @@ pub async fn start_ui(
         // the (paused) librespot position below clobber it.
         #[allow(unused_mut)]
         let mut source_owns_playback = false;
+        // The native queue slot owns the sink when playing a decoded track; read
+        // progress from its player first (it may share the suspended context's
+        // player, in which case a per-source block below reads the same value).
+        #[cfg(feature = "audio-decode")]
+        if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
+          source_owns_playback = true;
+          app.song_progress_ms = d.player.position().as_millis();
+        }
         #[cfg(feature = "local-files")]
         if let Some(local) = app.local_playback.as_ref() {
           source_owns_playback = true;

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -370,6 +370,11 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("Queue"),
     ],
     vec![
+      String::from("Play selected queue item (skip ahead to it)"),
+      String::from("<Enter>"),
+      String::from("Queue"),
+    ],
+    vec![
       String::from("Toggle saved state for currently playing track/episode"),
       key_bindings.like_track.to_string(),
       String::from("General"),

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -360,6 +360,16 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("General"),
     ],
     vec![
+      String::from("Remove selected track from queue"),
+      key_bindings.remove_from_queue.to_string(),
+      String::from("Queue"),
+    ],
+    vec![
+      String::from("Move selected queue item down / up"),
+      String::from("J / K"),
+      String::from("Queue"),
+    ],
+    vec![
       String::from("Toggle saved state for currently playing track/episode"),
       key_bindings.like_track.to_string(),
       String::from("General"),

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -802,15 +802,20 @@ fn draw_lyrics(f: &mut Frame<'_>, app: &App, area: Rect) {
   }
 }
 
-/// Display snapshot for an engine playbar (local files, Subsonic or radio).
+/// Display snapshot for an engine playbar (local files, Subsonic, radio, or the
+/// native queue slot).
 ///
 /// Extracted from the live player so [`render_local_playbar`] is a pure function
 /// of plain values and can be unit-tested with `TestBackend` (no audio device).
+/// Gated to every build that can render one: the decoded sources plus the
+/// native queue slot (`streaming` covers a queued Spotify track).
 #[cfg(any(
   feature = "local-files",
   feature = "subsonic",
   feature = "internet-radio",
-  feature = "youtube"
+  feature = "youtube",
+  feature = "streaming",
+  feature = "audio-decode"
 ))]
 struct LocalPlaybarView {
   /// Source name shown in the playbar title, e.g. `"Local"` or `"Subsonic"`.
@@ -935,7 +940,9 @@ fn draw_radio_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   feature = "local-files",
   feature = "subsonic",
   feature = "internet-radio",
-  feature = "youtube"
+  feature = "youtube",
+  feature = "streaming",
+  feature = "audio-decode"
 ))]
 fn render_local_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect, view: &LocalPlaybarView) {
   let playbar_areas = playbar_layout_areas(app, layout_chunk);
@@ -1053,6 +1060,59 @@ fn render_local_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect, view: 
 }
 
 pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
+  // The native queue slot owns playback: render the queued track, not the
+  // suspended context (whose `*_playback` is still `Some`) and not the stale
+  // Spotify context (still cached when a Spotify context was suspended).
+  // Checked first so the playbar always shows what is actually audible.
+  #[cfg(feature = "audio-decode")]
+  if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
+    let source_label = d
+      .track
+      .uri
+      .as_deref()
+      .map(crate::core::queue::queue_item_source)
+      .map(crate::core::queue::source_label)
+      .unwrap_or("Queue");
+    // `advancing` spans the download/decode window (the slot is published
+    // before the fetch), so surface it instead of a silent frozen bar.
+    let name = if d.advancing {
+      format!("{} (loading\u{2026})", d.track.name)
+    } else {
+      d.track.name.clone()
+    };
+    let view = LocalPlaybarView {
+      source_label,
+      name,
+      artists: d.track.artists.join(", "),
+      is_playing: !d.player.is_paused(),
+      position_ms: d.player.position().as_millis(),
+      duration_ms: d.track.duration_ms,
+      volume_percent: app.user_config.behavior.volume_percent,
+      queue_position: None,
+      live: false,
+    };
+    render_local_playbar(f, app, layout_chunk, &view);
+    return;
+  }
+  // A queued Spotify track plays through librespot: progress and play-state
+  // come from the native event stream, metadata from the queue slot.
+  #[cfg(feature = "streaming")]
+  if let Some(crate::infra::queue::QueueNowPlaying::Spotify { track }) = app.queue_now.as_ref() {
+    let view = LocalPlaybarView {
+      source_label: "Spotify",
+      name: track.name.clone(),
+      artists: track.artists.join(", "),
+      is_playing: app.native_is_playing.unwrap_or(true),
+      position_ms: app.song_progress_ms,
+      duration_ms: track.duration_ms,
+      volume_percent: app.user_config.behavior.volume_percent,
+      queue_position: None,
+      live: false,
+    };
+    render_local_playbar(f, app, layout_chunk, &view);
+    return;
+  }
+
   // Local-file playback owns the session and has no Spotify context to render
   // from, so it takes a dedicated path.
   #[cfg(feature = "local-files")]

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -87,6 +87,123 @@ fn queue_item_line(item: &PlayableInfo) -> String {
   }
 }
 
+/// Build the dimmed "up next from context" preview rows shown under the native
+/// queue: what resumes once the queue drains. Returns an empty vector when
+/// nothing is suspended and no queued items are pending, so `draw_queue` omits
+/// the section entirely.
+///
+/// The source of truth is [`App::queue_suspended`](crate::core::app::App) when
+/// the queue is draining over a suspended context; otherwise (queued items
+/// pending over a still-playing context) it is that context's own upcoming
+/// tracks. Rows read from the still-alive per-source `*_playback` state.
+fn context_preview_lines(app: &App, max: usize) -> Vec<String> {
+  // Format the upcoming rows of a Subsonic/YouTube `TrackInfo` context list.
+  #[cfg(any(feature = "subsonic", feature = "youtube"))]
+  fn track_rows(
+    tracks: &[crate::core::plugin_api::TrackInfo],
+    start: usize,
+    max: usize,
+  ) -> Vec<String> {
+    tracks
+      .iter()
+      .skip(start)
+      .take(max)
+      .map(|t| format!("{} - {}", t.name, t.artists.join(", ")))
+      .collect()
+  }
+
+  // Local queues are `file://` URIs only (no API metadata), so display the
+  // file name stem for each upcoming track.
+  #[cfg(feature = "local-files")]
+  fn local_rows(uris: &[String], start: usize, max: usize) -> Vec<String> {
+    uris
+      .iter()
+      .skip(start)
+      .take(max)
+      .map(|u| {
+        let trimmed = u.trim_start_matches("file://");
+        std::path::Path::new(trimmed)
+          .file_stem()
+          .and_then(|s| s.to_str())
+          .map(|s| s.to_string())
+          .unwrap_or_else(|| u.clone())
+      })
+      .collect()
+  }
+
+  // The Spotify Web-API mirror's upcoming list (native or external context).
+  let spotify_mirror = |max: usize| -> Vec<String> {
+    app
+      .queue
+      .as_ref()
+      .map(|q| q.queue.iter().take(max).map(queue_item_line).collect())
+      .unwrap_or_default()
+  };
+
+  // 1. A suspended context is authoritative: the queue is draining over it.
+  #[cfg(any(
+    feature = "streaming",
+    feature = "local-files",
+    feature = "subsonic",
+    feature = "youtube",
+    feature = "internet-radio"
+  ))]
+  if let Some(ctx) = app.queue_suspended.as_ref() {
+    use crate::core::queue::SuspendedContext;
+    return match ctx {
+      #[cfg(feature = "streaming")]
+      SuspendedContext::Spotify { .. } => spotify_mirror(max),
+      #[cfg(feature = "local-files")]
+      SuspendedContext::Local { resume_index, .. } => {
+        match (resume_index, app.local_playback.as_ref()) {
+          (Some(i), Some(s)) => local_rows(&s.queue, *i, max),
+          _ => Vec::new(),
+        }
+      }
+      #[cfg(feature = "subsonic")]
+      SuspendedContext::Subsonic { resume_index, .. } => {
+        match (resume_index, app.subsonic_playback.as_ref()) {
+          (Some(i), Some(s)) => track_rows(&s.tracks, *i, max),
+          _ => Vec::new(),
+        }
+      }
+      #[cfg(feature = "youtube")]
+      SuspendedContext::YouTube { resume_index, .. } => {
+        match (resume_index, app.youtube_playback.as_ref()) {
+          (Some(i), Some(s)) => track_rows(&s.tracks, *i, max),
+          _ => Vec::new(),
+        }
+      }
+      #[cfg(feature = "internet-radio")]
+      SuspendedContext::Radio { station } => vec![format!("Resumes: {}", station.name)],
+    };
+  }
+
+  // 2. Queued items pending over a still-playing context: preview what resumes
+  //    after them (the context's upcoming tracks, from the next index on).
+  if !app.native_queue.is_empty() {
+    #[cfg(feature = "local-files")]
+    if let Some(s) = app.local_playback.as_ref() {
+      return local_rows(&s.queue, s.index + 1, max);
+    }
+    #[cfg(feature = "subsonic")]
+    if let Some(s) = app.subsonic_playback.as_ref() {
+      return track_rows(&s.tracks, s.index + 1, max);
+    }
+    #[cfg(feature = "youtube")]
+    if let Some(s) = app.youtube_playback.as_ref() {
+      return track_rows(&s.tracks, s.index + 1, max);
+    }
+    #[cfg(feature = "internet-radio")]
+    if let Some(s) = app.radio_playback.as_ref() {
+      return vec![format!("Resumes: {}", s.station.name)];
+    }
+    return spotify_mirror(max);
+  }
+
+  Vec::new()
+}
+
 pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
   let [area] = f
     .area()
@@ -126,7 +243,9 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
           items.push(ListItem::new(queue_item_line(item)).style(style));
         }
       }
-    } else {
+    } else if !app.queue_owns_playback() {
+      // While the queue owns playback the last queued track is the "Now playing"
+      // row above, so an "empty" hint would contradict it — omit it there.
       items.push(
         ListItem::new(Span::raw("Queue is empty — press z on a track to add it")).style(style),
       );
@@ -138,6 +257,22 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
       ));
       let line = format!("{} - {}  [{}]", track.name, track.artists.join(", "), label);
       items.push(ListItem::new(line).style(style));
+    }
+  }
+
+  // Dimmed, non-selectable preview of what resumes once the queue drains. It is
+  // appended after the selectable native-queue rows; selection stays confined to
+  // those rows (queue_menu.rs counts only `1 + native_queue.len()` rows), so
+  // these extra rows never receive the highlight.
+  let preview = context_preview_lines(app, 5);
+  if !preview.is_empty() {
+    let header_style = Style::default().fg(app.user_config.theme.hint);
+    let row_style = Style::default()
+      .fg(app.user_config.theme.inactive)
+      .add_modifier(Modifier::DIM);
+    items.push(ListItem::new(Span::styled("Up next from context:", header_style)).style(style));
+    for line in preview {
+      items.push(ListItem::new(Span::styled(line, row_style)).style(style));
     }
   }
 
@@ -155,7 +290,10 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
         .borders(Borders::ALL)
         .style(style)
         .title(Span::styled(
-          "Queue  (x remove · J/K move · Enter play · Esc back)",
+          format!(
+            "Queue  ({} remove · J/K move · Enter play · Esc back)",
+            app.user_config.keys.remove_from_queue
+          ),
           style,
         ))
         .border_style(style),

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -93,28 +93,48 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
     .layout(&Layout::vertical([Constraint::Percentage(100)]).margin(2));
 
   let style = app.user_config.theme.base_style();
-  let items: Vec<ListItem> = match &app.queue {
-    None => vec![ListItem::new(Span::raw("Loading...")).style(style)],
-    Some(q) => {
-      let mut rows = Vec::new();
-      if let Some(ref now) = q.currently_playing {
-        rows.push(
-          ListItem::new(Line::from(vec![
-            Span::styled("Now playing: ", style.add_modifier(Modifier::BOLD)),
-            Span::raw(queue_item_line(now)),
-          ]))
-          .style(style),
-        );
+  let mut items: Vec<ListItem> = Vec::new();
+
+  // Row 0: "Now playing" header. Still sourced from the Spotify Web-API mirror
+  // for now; Phase 2 rewires it to the native queue slot's current track.
+  let now = app
+    .queue
+    .as_ref()
+    .and_then(|q| q.currently_playing.as_ref());
+  let now_text = now.map(queue_item_line).unwrap_or_else(|| "—".to_string());
+  items.push(
+    ListItem::new(Line::from(vec![
+      Span::styled("Now playing: ", style.add_modifier(Modifier::BOLD)),
+      Span::raw(now_text),
+    ]))
+    .style(style),
+  );
+
+  // The native queue is the selectable list.
+  if app.native_queue.is_empty() {
+    // With an empty native queue, fall back to displaying the legacy Spotify
+    // mirror only when controlling an external Connect device (the queue there
+    // lives Spotify-side). Otherwise show a hint.
+    if app.spotify_external_device_active() {
+      if let Some(q) = app.queue.as_ref() {
+        for item in &q.queue {
+          items.push(ListItem::new(queue_item_line(item)).style(style));
+        }
       }
-      for item in &q.queue {
-        rows.push(ListItem::new(queue_item_line(item)).style(style));
-      }
-      if rows.is_empty() {
-        rows.push(ListItem::new(Span::raw("No queue (no active device?)")).style(style));
-      }
-      rows
+    } else {
+      items.push(
+        ListItem::new(Span::raw("Queue is empty — press z on a track to add it")).style(style),
+      );
     }
-  };
+  } else {
+    for track in &app.native_queue {
+      let label = crate::core::queue::source_label(crate::core::queue::queue_item_source(
+        track.uri.as_deref().unwrap_or(""),
+      ));
+      let line = format!("{} - {}  [{}]", track.name, track.artists.join(", "), label);
+      items.push(ListItem::new(line).style(style));
+    }
+  }
 
   let mut state = ListState::default();
   let len = items.len();
@@ -129,7 +149,10 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
       Block::default()
         .borders(Borders::ALL)
         .style(style)
-        .title(Span::styled("Queue (press Esc to go back)", style))
+        .title(Span::styled(
+          "Queue  (x remove · J/K move · Enter play · Esc back)",
+          style,
+        ))
         .border_style(style),
     )
     .style(style)

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -95,13 +95,18 @@ pub fn draw_queue(f: &mut Frame<'_>, app: &App) {
   let style = app.user_config.theme.base_style();
   let mut items: Vec<ListItem> = Vec::new();
 
-  // Row 0: "Now playing" header. Still sourced from the Spotify Web-API mirror
-  // for now; Phase 2 rewires it to the native queue slot's current track.
-  let now = app
-    .queue
-    .as_ref()
-    .and_then(|q| q.currently_playing.as_ref());
-  let now_text = now.map(queue_item_line).unwrap_or_else(|| "—".to_string());
+  // Row 0: "Now playing" header. Prefer the native queue slot's current track;
+  // fall back to the Spotify Web-API mirror (external Connect device) otherwise.
+  let now_text = app
+    .queue_now_display()
+    .or_else(|| {
+      app
+        .queue
+        .as_ref()
+        .and_then(|q| q.currently_playing.as_ref())
+        .map(queue_item_line)
+    })
+    .unwrap_or_else(|| "—".to_string());
   items.push(
     ListItem::new(Line::from(vec![
       Span::styled("Now playing: ", style.add_modifier(Modifier::BOLD)),


### PR DESCRIPTION
## Summary

Adds a native play queue that works across every source (Spotify, Local Files, Subsonic, YouTube) in one FIFO, plus the reliability and responsiveness work that came out of live-testing the Spotify-to-YouTube handoff.

### Feature

- Press `z` on any track to queue it natively; queued tracks play before the underlying playlist/album context, then the context resumes where it left off.
- Queue screen (`Shift+Q`): remove (`x`, rebindable), reorder (`J`/`K`), jump ahead (`Enter`), plus an up-next preview of what resumes after the queue drains.
- Queued Spotify tracks play through native (librespot) streaming via a direct load with context suspend/resume; on an external Spotify Connect device, `z` keeps the Web API queue behavior.
- The queue survives restarts (persisted in `last_session.yml`).

### Handoff reliability and responsiveness

- End-of-track handling no longer uses `try_lock`, so the queue handoff can never be silently dropped by a lock race with the render loop.
- The queue slot is published before a download starts (with a loading indicator in the playbar), so skip/pause/playbar treat the queued track as current during the fetch, and a skip can no longer fire a second advance that dropped a queued item.
- The playbar renders the queue slot for every source instead of showing the stale paused Spotify context.
- A finished queued Spotify track clears its slot immediately, so the Spirc reload guard cannot resurrect it during the next item's download; librespot is also silenced on every decoded queue start and on queue drain, covering mid-play skips on device-reuse paths.
- Queue downloads (YouTube/Subsonic) run off the IoEvent pump with a generation stamp; superseded fetches are discarded. Previously a fetch froze all event handling, delaying every skip for any source.
- The next queued Spotify track is preloaded while the current slot plays, so back-to-back queued Spotify skips start near-instantly instead of paying a cold load each time.

Notable non-obvious finding: Spirc ignores player events from direct `player.load` calls (play_request_id mismatch), so it never self-advances off a queued track; the ghost-audio bugs were all missing pause/release calls in the queue engine.

## Testing

- `cargo clippy -D warnings` clean on slim (`--no-default-features --features telemetry`), default, and `--features all-sources`.
- `cargo test`: 349 passing on slim, 568 with all sources, including regression tests for slot clearing and queue routing.
- Live-verified: Spotify context to queued Spotify to queued YouTube handoff, mid-play skips, rapid consecutive skips, playbar loading states.

Closes #206
