### PR TITLE
fix(albums): page through full tracklist instead of capping at 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Album tracklists no longer cut off at 50 songs**: Opening an album now pages through the full Spotify tracklist instead of stopping at the API's 50-track page limit, whether the album is opened from search results, an artist's discography, a track's context, or the saved-albums library ([#324](https://github.com/LargeModGames/spotatui/issues/324)).
+
 ### Added
 
 - **Native cross-source play queue**: Press `z` on any track to add it to a native queue that plays across sources (Spotify, Local Files, Subsonic, and YouTube in one FIFO; internet radio is excluded since a live stream is not a finite track). Queued tracks play before the underlying playlist/album context, then that context resumes where it left off. Open the queue with `Shift+Q`: remove the selected item with `x` (rebindable via `remove_from_queue`, default `x`), reorder it with `J`/`K`, or press `Enter` to skip ahead and play it now. The Queue screen also previews what resumes from the underlying context once the queue drains. The queue survives restarts (persisted in `last_session.yml`). Spotify tracks queue through native (librespot) streaming; when you are controlling an external Spotify Connect device instead, `z` keeps the previous Web-API "add to Spotify's queue" behavior ([#206](https://github.com/LargeModGames/spotatui/issues/206)).

--- a/src/infra/network/metadata.rs
+++ b/src/infra/network/metadata.rs
@@ -13,7 +13,7 @@ use rspotify::model::{
   enums::Country,
   idtypes::{AlbumId, ArtistId, ShowId, TrackId},
   page::{CursorBasedPage, Page},
-  track::FullTrack,
+  track::{FullTrack, SimplifiedTrack},
 };
 use rspotify::prelude::*;
 use serde::Deserialize;
@@ -36,6 +36,34 @@ struct FollowedArtistsResponse {
 fn country_code(country: Country) -> String {
   let code: &'static str = country.into();
   code.to_string()
+}
+
+/// Fetch an album's tracklist from `offset` onward, following pagination until
+/// the API reports no further page. Spotify caps each response at 50 tracks,
+/// so albums longer than that need this loop to come back complete.
+async fn fetch_album_tracks_from(
+  network: &Network,
+  album_id: &str,
+  mut offset: u32,
+) -> anyhow::Result<Vec<SimplifiedTrack>> {
+  let path = format!("albums/{}/tracks", album_id);
+  let limit = 50u32;
+  let mut items = Vec::new();
+  loop {
+    let page = network
+      .spotify_get_typed::<Page<SimplifiedTrack>>(
+        &path,
+        &[("limit", limit.to_string()), ("offset", offset.to_string())],
+      )
+      .await?;
+    let has_next = page.next.is_some();
+    items.extend(page.items);
+    if !has_next {
+      break;
+    }
+    offset += limit;
+  }
+  Ok(items)
 }
 
 pub trait MetadataNetwork {
@@ -155,17 +183,19 @@ impl MetadataNetwork for Network {
   async fn get_album_tracks(&mut self, album: Box<SimplifiedAlbum>) {
     let album_id = album.id.clone();
     if let Some(id) = album_id {
-      let path = format!("albums/{}/tracks", id.id());
-      // TODO: Handle pagination for albums with > 50 tracks
-      match self
-        .spotify_get_typed::<Page<rspotify::model::track::SimplifiedTrack>>(
-          &path,
-          &[("limit", "50".to_string()), ("offset", "0".to_string())],
-        )
-        .await
-      {
-        Ok(tracks) => {
+      match fetch_album_tracks_from(self, id.id(), 0).await {
+        Ok(track_items) => {
           let album_info = crate::core::plugin_api::AlbumInfo::from(album.as_ref());
+          let total = track_items.len() as u32;
+          let tracks = Page {
+            items: track_items,
+            href: String::new(),
+            limit: total,
+            next: None,
+            offset: 0,
+            previous: None,
+            total,
+          };
           let tracks_domain = map_page(&tracks, |t| crate::core::plugin_api::TrackInfo::from(t));
           let mut app = self.app.lock().await;
           app.selected_album_simplified = Some(crate::core::app::SelectedAlbum {
@@ -186,7 +216,19 @@ impl MetadataNetwork for Network {
       .spotify_get_typed::<FullAlbum>(&format!("albums/{}", album_id.id()), &[])
       .await
     {
-      Ok(album) => {
+      Ok(mut album) => {
+        // A full album embeds only the first page of its tracklist (50 tracks
+        // max); fetch the rest so longer albums render completely.
+        if album.tracks.next.is_some() {
+          let offset = album.tracks.items.len() as u32;
+          match fetch_album_tracks_from(self, album_id.id(), offset).await {
+            Ok(rest) => album.tracks.items.extend(rest),
+            Err(e) => {
+              self.handle_error(anyhow!(e)).await;
+              return;
+            }
+          }
+        }
         let album_info = crate::core::plugin_api::AlbumInfo::from(&album);
         let mut app = self.app.lock().await;
         app.selected_album_full = Some(crate::core::app::SelectedFullAlbum {

--- a/src/tui/handlers/album_list.rs
+++ b/src/tui/handlers/album_list.rs
@@ -1,6 +1,7 @@
 use super::common_key_events;
 use crate::{
   core::app::{ActiveBlock, AlbumTableContext, App, RouteId, SelectedFullAlbum},
+  infra::network::IoEvent,
   tui::event::Key,
 };
 
@@ -44,8 +45,21 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Enter => {
       if let Some(albums) = app.library.saved_albums.get_results(None) {
         if let Some(selected_album) = albums.items.get(app.album_list_index) {
+          let album = selected_album.album.clone();
+          // The library cache embeds only the first page of each album's
+          // tracklist (50 tracks max); refetch longer albums in full.
+          let cached_is_complete = album
+            .total_tracks
+            .is_none_or(|total| album.tracks.len() as u32 >= total);
+          if !cached_is_complete {
+            if let Some(id) = album.id.clone() {
+              // GetAlbum sets the Full context and pushes AlbumTracks itself.
+              app.dispatch(IoEvent::GetAlbum(id));
+              return;
+            }
+          }
           app.selected_album_full = Some(SelectedFullAlbum {
-            album: selected_album.album.clone(),
+            album,
             selected_index: 0,
           });
           app.album_table_context = AlbumTableContext::Full;
@@ -67,6 +81,92 @@ pub fn handler(key: Key, app: &mut App) {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::core::pagination::Paged;
+  use crate::core::plugin_api::{AlbumInfo, SavedAlbumInfo, TrackInfo};
+  use crate::core::user_config::UserConfig;
+  use std::sync::mpsc::channel;
+  use std::time::SystemTime;
+
+  fn track(name: &str) -> TrackInfo {
+    TrackInfo {
+      uri: None,
+      name: name.to_string(),
+      artists: vec!["Artist".to_string()],
+      album: "Album".to_string(),
+      duration_ms: 1000,
+      id: None,
+      album_id: None,
+      artist_refs: vec![],
+      is_playable: true,
+      is_local: false,
+      track_number: 0,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  fn app_with_saved_album(
+    cached_tracks: usize,
+    total_tracks: u32,
+  ) -> (App, std::sync::mpsc::Receiver<IoEvent>) {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    let album = AlbumInfo {
+      id: Some("longalbum".to_string()),
+      uri: Some("spotify:album:longalbum".to_string()),
+      name: "One Wayne G".to_string(),
+      total_tracks: Some(total_tracks),
+      tracks: (0..cached_tracks)
+        .map(|i| track(&format!("t{}", i)))
+        .collect(),
+      ..AlbumInfo::default()
+    };
+    app.library.saved_albums.add_pages(Paged {
+      items: vec![SavedAlbumInfo {
+        album,
+        added_at: String::new(),
+      }],
+      offset: 0,
+      limit: 1,
+      total: 1,
+      next: None,
+      previous: None,
+    });
+    (app, rx)
+  }
+
+  #[test]
+  fn enter_on_saved_album_with_complete_tracklist_uses_cache() {
+    let (mut app, rx) = app_with_saved_album(2, 2);
+
+    handler(Key::Enter, &mut app);
+
+    assert!(app.selected_album_full.is_some());
+    assert_eq!(
+      app.get_current_route().active_block,
+      ActiveBlock::AlbumTracks
+    );
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn enter_on_saved_album_with_truncated_tracklist_refetches_full_album() {
+    let (mut app, rx) = app_with_saved_album(50, 199);
+
+    handler(Key::Enter, &mut app);
+
+    // The cached 50-track page must not be rendered; GetAlbum fetches the
+    // complete tracklist and pushes the AlbumTracks route itself.
+    assert!(app.selected_album_full.is_none());
+    assert_ne!(
+      app.get_current_route().active_block,
+      ActiveBlock::AlbumTracks
+    );
+    match rx.recv().unwrap() {
+      IoEvent::GetAlbum(id) => assert_eq!(id, "longalbum"),
+      _ => panic!("expected GetAlbum"),
+    }
+  }
 
   #[test]
   fn on_left_press() {


### PR DESCRIPTION
# Summary
Albums with more than 50 tracks were cut off because every path into the AlbumTracks screen only used the first page Spotify returns:

- `get_album_tracks` (search results, artist discography, go-to-album from a track) fetched a single page of 50 with a literal `TODO: Handle pagination` comment
- `get_album` trusted the tracklist embedded in `FullAlbum`, which is silently just the first page
- Opening a saved album from the library rendered the same capped cache from `me/albums`

This adds a `fetch_album_tracks_from` helper that follows `next` until the tracklist is complete (mirroring the existing artist-albums pagination loop), extends `FullAlbum`'s embedded page before mapping to the domain type, and makes the saved-albums Enter handler refetch via `GetAlbum` when the cached tracklist is shorter than `total_tracks`. Complete albums still open instantly from cache.

Closes #324

# Testing
- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
- `cargo test --no-default-features --features telemetry` (351 passed, includes 2 new regression tests for the cache-vs-refetch decision)
- `cargo check` (full features)