### PR TITLE
Pin vergen below 9.1 so cargo install builds again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Native idle recovery no longer repeats forever**: When Spotify reports no active playback after a stale native session, spotatui still tries to restore the local device automatically. It now stops after two recovery attempts for the same idle session instead of sending `transfer(None)` and `activate()` every few seconds ([#311](https://github.com/LargeModGames/spotatui/issues/311)).
 - **Album tracklists no longer cut off at 50 songs**: Opening an album now pages through the full Spotify tracklist instead of stopping at the API's 50-track page limit, whether the album is opened from search results, an artist's discography, a track's context, or the saved-albums library ([#324](https://github.com/LargeModGames/spotatui/issues/324)).
+- **`cargo install spotatui` builds again**: A fresh dependency resolve pulled in `vergen 9.1.0`, which breaks librespot's build script (two incompatible `vergen-lib` versions in the graph, error E0277). A constraint-only pin keeps `vergen` below 9.1 until librespot ships a fix; the README now also recommends `cargo install --locked` ([#350](https://github.com/LargeModGames/spotatui/issues/350)).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5925,6 +5925,7 @@ dependencies = [
  "tui-equalizer",
  "unicode-width",
  "url",
+ "vergen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,12 @@ youtube = ["audio-decode", "dep:tempfile"]
 [dev-dependencies]
 tempfile = "3"
 
+# Constraint-only pin (spotatui has no build script): vergen 9.1.0 breaks
+# librespot-core 0.8.0's build script on a fresh resolve (#350). Remove once
+# librespot ships a fix.
+[build-dependencies]
+vergen = { version = ">=9.0.6, <9.1", default-features = false }
+
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl-sys = { version = "0.9", features = ["vendored"] }
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ brew install spotatui
 winget install spotatui
 
 # Cargo
-cargo install spotatui
+cargo install --locked spotatui
 
 # Arch Linux (AUR) - pre-built binary (faster)
 yay -S spotatui-bin
@@ -173,7 +173,7 @@ spotatui is a general music player, not just a Spotify client. Press `d` to open
 **Availability:** included in the Linux and Windows release binaries. Not yet on macOS (the shared audio output path is disabled there pending a fix; contributions welcome). When building from source, enable them with cargo features:
 
 ```bash
-cargo install spotatui --features local-files,subsonic,internet-radio,youtube
+cargo install --locked spotatui --features local-files,subsonic,internet-radio,youtube
 ```
 
 Each source has a few config keys; the essentials are below, and the full reference lives in the [Configuration Wiki](https://github.com/LargeModGames/spotatui/wiki/Configuration).


### PR DESCRIPTION
Fixes #350

A fresh dependency resolve now pulls in vergen 9.1.0, which breaks librespot-core 0.8.0's build script: vergen-gitcl ^1.0 allows vergen ^9.0.6 but requires vergen-lib ^0.1.6, while vergen 9.1.0 moved to vergen-lib ^9.1.0. The resolver ends up with two incompatible vergen-lib versions in the graph and the build fails with the E0277 reported in the issue. `cargo install` resolves fresh unless `--locked` is passed, which is why installs of 0.40.1 started failing without any change on our side.

Changes:
- Add a constraint-only `[build-dependencies]` pin keeping vergen on 9.0.x. spotatui has no build script, so the pin is never compiled for spotatui itself; it only steers resolution for librespot-core's build script. Verified by regenerating the lockfile from scratch: before the pin a fresh resolve picks vergen 9.1.0 + both vergen-lib 0.1.6 and 9.1.0 (reproducing the error); with the pin it picks vergen 9.0.6 + a single vergen-lib 0.1.6.
- Recommend `cargo install --locked` in the README. This also works today as a user-side workaround, since the published lockfile has the good versions.
- Changelog entry.

The pin can be removed once librespot publishes a release whose vergen build-deps resolve cleanly (nothing published upstream yet as of today).