### PR TITLE
Make 's' save the highlighted track in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Native idle recovery no longer repeats forever**: When Spotify reports no active playback after a stale native session, spotatui still tries to restore the local device automatically. It now stops after two recovery attempts for the same idle session instead of sending `transfer(None)` and `activate()` every few seconds ([#311](https://github.com/LargeModGames/spotatui/issues/311)).
 - **Album tracklists no longer cut off at 50 songs**: Opening an album now pages through the full Spotify tracklist instead of stopping at the API's 50-track page limit, whether the album is opened from search results, an artist's discography, a track's context, or the saved-albums library ([#324](https://github.com/LargeModGames/spotatui/issues/324)).
+- **`s` saves tracks in search results**: Pressing `s` on a highlighted track in the Songs search block now toggles its saved/liked state, matching the track-table binding shown in the help menu. Search results also fetch the liked state of listed tracks, so already-liked songs show the liked marker and toggle correctly ([#348](https://github.com/LargeModGames/spotatui/issues/348)).
 
 ### Added
 

--- a/src/infra/network/search.rs
+++ b/src/infra/network/search.rs
@@ -105,6 +105,17 @@ impl SearchNetwork for Network {
     let mut app = self.app.lock().await;
 
     // Extract ids for follow/saved checks from raw rspotify pages before conversion.
+    if let Some(ref track_results) = track_result {
+      let track_ids = track_results
+        .items
+        .iter()
+        .filter_map(|track| track.id.as_ref().map(|id| id.id().to_string()))
+        .collect();
+
+      // Check if these tracks are liked
+      app.dispatch(IoEvent::CurrentUserSavedTracksContains(track_ids));
+    }
+
     if let Some(ref album_results) = album_result {
       let artist_ids = album_results
         .items

--- a/src/tui/handlers/search_results.rs
+++ b/src/tui/handlers/search_results.rs
@@ -691,8 +691,24 @@ pub fn handler(key: Key, app: &mut App) {
     },
     Key::Char('r') => handle_recommended_tracks(app),
     _ if key == app.user_config.keys.add_item_to_queue => handle_add_item_to_queue(app),
-    // Add `s` to "see more" on each option
+    Key::Char('s') => handle_save_track_event(app),
     _ => {}
+  }
+}
+
+fn handle_save_track_event(app: &mut App) {
+  if let SearchResultBlock::SongSearch = app.search_results.selected_block {
+    let uri = app.search_results.selected_tracks_index.and_then(|index| {
+      app
+        .search_results
+        .tracks
+        .as_ref()
+        .and_then(|tracks| tracks.items.get(index))
+        .and_then(|track| track.uri.clone())
+    });
+    if let Some(uri) = uri {
+      app.dispatch(IoEvent::ToggleSaveTrack(uri));
+    }
   }
 }
 
@@ -863,6 +879,38 @@ mod tests {
       app.get_current_route().active_block,
       ActiveBlock::Dialog(DialogContext::AddTrackToPlaylistPicker)
     );
+  }
+
+  /// Issue #348 regression: `s` on a highlighted search-result track must
+  /// toggle its saved/liked state, matching the track-table binding shown in
+  /// the help menu ("Save track in list or table").
+  #[test]
+  fn pressing_s_on_search_song_toggles_saved_track() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.search_results.tracks = Some(Paged {
+      items: vec![TrackInfo::from(&full_track(
+        "0000000000000000000001",
+        "Search Track",
+      ))],
+      offset: 0,
+      limit: 1,
+      total: 1,
+      next: None,
+      previous: None,
+    });
+    app.search_results.selected_block = SearchResultBlock::SongSearch;
+    app.search_results.selected_tracks_index = Some(0);
+    app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
+
+    handler(Key::Char('s'), &mut app);
+
+    match rx.try_recv().unwrap() {
+      IoEvent::ToggleSaveTrack(uri) => {
+        assert_eq!(uri, "spotify:track:0000000000000000000001");
+      }
+      _ => panic!("expected a ToggleSaveTrack for the selected search track"),
+    }
   }
 
   /// panic-1 regression: a stale `selected_playlists_index` left over from a


### PR DESCRIPTION
Fixes #348

Two gaps caused this:
- The search results key handler had no save arm at all; the only trace was a stale `// Add 's' to "see more"` comment inherited from spotify-tui. Pressing `s` on a highlighted song fell through to the catch-all. Added an arm that dispatches `IoEvent::ToggleSaveTrack` for the selected track in the Songs block, matching the hardcoded `s` binding used by the track table ("Save track in list or table" in the help menu).
- `get_search_results` fetched saved/followed state for albums, artists, and shows, but never for tracks. Without that, already-liked tracks showed no liked marker in search results and the toggle would start from the wrong state (an already-liked track could not be unliked). It now dispatches `CurrentUserSavedTracksContains` for track results; the search UI already renders the liked icon from `liked_song_ids_set`, so the visual feedback works with no UI changes.

Includes a regression test that presses `s` on a selected search track and asserts the `ToggleSaveTrack` dispatch.