### PR TITLE
Keep audio device open across pause for instant play/pause

### DIFF
--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -33,6 +33,7 @@ use tokio::time::{timeout, Duration};
 struct RecoveringSink {
   inner: Option<Box<dyn audio_backend::Sink>>,
   make_sink: Box<dyn Fn() -> Box<dyn audio_backend::Sink>>,
+  started: bool,
 }
 
 impl RecoveringSink {
@@ -43,6 +44,7 @@ impl RecoveringSink {
     Self {
       inner: None,
       make_sink: Box::new(make_sink),
+      started: false,
     }
   }
 
@@ -100,12 +102,14 @@ impl RecoveringSink {
       Ok(Err(err)) => {
         warn!("Audio backend {context} error: {err}");
         self.inner = None;
+        self.started = false;
         Err(err)
       }
       Err(payload) => {
         let err = Self::panic_to_sink_error(context, payload);
         error!("{err}");
         self.inner = None;
+        self.started = false;
         Err(err)
       }
     }
@@ -114,17 +118,24 @@ impl RecoveringSink {
 
 impl audio_backend::Sink for RecoveringSink {
   fn start(&mut self) -> audio_backend::SinkResult<()> {
-    self.with_inner("start", |sink| sink.start())
+    // The stream is already open and running (kept alive across pause): resuming
+    // is a no-op, avoiding librespot's ~600ms PortAudio reopen on every resume.
+    if self.started && self.inner.is_some() {
+      return Ok(());
+    }
+    let result = self.with_inner("start", |sink| sink.start());
+    if result.is_ok() {
+      self.started = true;
+    }
+    result
   }
 
   fn stop(&mut self) -> audio_backend::SinkResult<()> {
-    if self.inner.is_none() {
-      return Ok(());
-    }
-
-    // Avoid process exits in librespot when sink.stop() errors.
-    let _ = self.with_inner("stop", |sink| sink.stop());
-    self.inner = None;
+    // Keep the underlying device open across pause. librespot pauses by ceasing
+    // to feed packets (blocking writes simply stop), which is what silences
+    // output; tearing the PortAudio stream down here would force a slow reopen
+    // on the next resume. The stream is closed when the sink is dropped (player
+    // shutdown/replacement) or reset via the error-recovery path in with_inner.
     Ok(())
   }
 


### PR DESCRIPTION
## Problem
On macOS, native play/pause was noticeably (~500ms) slower than the Spotify desktop app. Instrumenting the transport pipeline showed the entire cost is librespot's PortAudio sink being torn down on pause and reopened on resume:

- keypress → `play` dispatch: ~20µs
- librespot `Playing` event: ~50µs
- **audio sink `start()` (PortAudio open + start): ~621ms**
- keypress → `Paused` (PortAudio stop/close): ~887ms

CoreAudio stream open/start/stop on macOS is inherently slow; the native app keeps its output device open permanently.

## Fix
`RecoveringSink` now keeps the underlying device open across pause:
- `stop()` no longer tears down the stream — librespot silences output by ceasing to feed packets, so the reopen was pure overhead.
- `start()` is a no-op when the stream is already running.
- The stream still closes on player shutdown/replacement (sink drop) and resets via the existing error-recovery path (`with_inner` clears the `started` flag when it drops the sink).

Only the first play after launch (or a post-error recovery) pays the ~600ms device-open cost.

## Results (measured, same session)
| Action | Before | After |
| --- | --- | --- |
| Resume (keypress → Playing) | ~621 ms | ~0.11 ms |
| Pause (keypress → Paused) | ~887 ms | ~7–9 ms |

## Testing
- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --all` clean (default features).
- Manually verified on macOS with the full `cargo run` build: pause silences audio, resume is instant, no glitches.

Worth an extra check on Bluetooth (AirPods) and when switching to a decoded source (local/YouTube) while librespot is paused, since the device now stays open across pause.