### PR TITLE
Performance overhaul: instant startup, viewport rendering, concurrent event pump; login fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Startup login no longer hangs**: On a fresh install or with a stale token, the auth wizard's "Waiting for authorization callback" step ran a blocking callback server on the async runtime, which could park a worker thread and hang startup before the browser redirect was ever served. The wizard now uses the same async callback server as the in-TUI login ([#364](https://github.com/LargeModGames/spotatui/issues/364)).
+- **First-run double login completes without a restart**: On a fresh first run, both OAuth consents (the Web API login and the native-streaming "Spotify for Desktop" login) use callback port 8989 back-to-back, and the second could fail because the first server hadn't fully released the port — forcing a quit-and-relaunch to finish the streaming login. The streaming flow now waits for the port to be free before opening its consent, so both logins succeed in one run.
+- **Playback keys pressed during streaming recovery are no longer lost**: If native streaming is mid-recovery when you hit play, the request is stashed and replayed once the session is back (with a 30s recency gate), instead of being silently swallowed. Transfer/activate errors are surfaced, and pressing play with no usable backend shows a status message instead of the Error screen.
+- **Home banner animates again**: The banner gradient's animation tick was gated on the Home block having keyboard focus, which was almost never the case; it now runs whenever the Home screen is displayed.
+- **Playlist sidebar robustness**: Refreshing playlists no longer clobbers the folder you have open or your selection, and a playlist list that fails to paginate fully keeps the previous complete list instead of silently publishing a truncated one. Playlist folders also reconcile correctly after deferred streaming startup.
+- **Stale cover art and lyrics races**: Cover-art and lyrics results are now dropped unless they match the currently playing track, so a slow fetch can no longer overwrite the display with data for a previous song.
+
+### Performance
+
+- **Instant startup**: The TUI now appears immediately; the update check, token validation, and librespot session init run as background tasks, startup reuses one `/me` response instead of three round trips, and the first page of playlists is shown right away with the rest (and rootlist folders) fetched in the background.
+- **Concurrent event pump**: Non-Spotify work (lyrics, cover art, Subsonic/radio/local sources, telemetry) runs on a concurrent service lane, so a slow Spotify API call no longer head-of-line-blocks everything behind it. Playlists open on `Enter` immediately with a loading state.
+- **Track tables render only visible rows**: Tables format just the rows that fit on screen instead of the entire backing collection every frame (10k-track frame draw: 58ms → 2.5ms in debug builds), and the track table keeps its scroll position anchored while the cursor moves within the visible rows.
+- **Home screen frame cost**: The changelog pane and banner gradient are cached instead of being rebuilt (and deep-cloned) every frame, changelog lines are pre-wrapped, and scrolling no longer re-composes every line above the offset — frame cost no longer grows with scroll depth.
+- **Less redundant work per input**: A keypress no longer triggers a second full redraw, API pacing allows bursts of 5 so fan-outs (search, artist pages) start immediately, config saves from volume/resize/shuffle keys are debounced instead of hitting disk per key repeat, and album/artist metadata is cached with HTTP clients reused across requests.
+
 ## [v0.40.2] 2026-07-10
 
 ### Fixed

--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "spotatui",
-  "description": "A Spotify terminal client (TUI) in Rust with native streaming, audio visualization, listening parties, Lua scripting, and alternative music sources (Local/Subsonic/Radio/YouTube).",
+  "description": "A fast, standalone terminal music player in Rust: native Spotify streaming plus local, Subsonic, radio, and YouTube sources.",
   "folders": [
     "docs",
     "examples"

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "spotatui",
+  "description": "A Spotify terminal client (TUI) in Rust with native streaming, audio visualization, listening parties, Lua scripting, and alternative music sources (Local/Subsonic/Radio/YouTube).",
+  "folders": [
+    "docs",
+    "examples"
+  ],
+  "excludeFolders": [
+    "src",
+    "target",
+    "worker-relay",
+    "snap",
+    "graphify-out",
+    "spotatui.wiki",
+    ".github"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "how_to_release.md"
+  ],
+  "rules": [
+    "spotatui is a terminal application, not a library. A plain `cargo run` builds the Spotify-only default; use `cargo run --features all-sources` to enable the Local, Subsonic, Radio, and YouTube sources.",
+    "Native streaming (librespot) and audio visualization are part of the default features; the slim CI build uses `--no-default-features --features telemetry`.",
+    "Keybindings and most behavior are user-configurable via the YAML config; see docs/configuration.md and examples/config.example.yml.",
+    "The Lua scripting/plugin API is documented in docs/scripting.md with runnable examples under examples/plugins/."
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# spotatui Documentation
+
+Detailed documentation for [spotatui](https://github.com/LargeModGames/spotatui), a Spotify client for the terminal written in Rust.
+
+## Getting Started
+
+1. **[Installation](installation.md)** - Install spotatui on your platform
+2. **[Configuration](configuration.md)** - Customize behavior and settings
+3. **[Keybindings](keybindings.md)** - Learn the keyboard controls
+
+## Features
+
+- **[Themes](themes.md)** - Built-in presets and custom color schemes
+- **[Native Streaming](native-streaming.md)** - Play music directly without the Spotify app
+- **[Scripting](scripting.md)** - Lua plugin API for extending spotatui
+
+## Development
+
+- **[Roadmap](roadmap.md)** - Planned features and API coverage
+- **[CONTRIBUTING.md](https://github.com/LargeModGames/spotatui/blob/main/CONTRIBUTING.md)** - How to contribute
+
+## Getting Help
+
+- **[Report a bug](https://github.com/LargeModGames/spotatui/issues/new)** - Found an issue?
+- **[Discussions](https://github.com/LargeModGames/spotatui/discussions)** - Questions and ideas

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ Simple values (numbers, toggles, icons, positions) can also be changed live in t
 
 A typo in `config.yml` never prevents the app from starting. Structural mistakes — an unknown sort field, a bad template placeholder, an invalid column id, an icon that is too wide — are logged as warnings and the affected value falls back to its built-in default. Warnings go to the log file whose path is printed at startup (`/tmp/spotatui_logs/spotatuilog<pid>`).
 
-Only two kinds of errors are fatal: YAML syntax errors (the file cannot be parsed at all) and out-of-range numeric values that predate this policy (`volume_increment` outside 0–100, a zero tick rate, an unparseable `auto_update_delay`).
+Only two kinds of errors are fatal: YAML syntax errors (the file cannot be parsed at all) and a handful of out-of-range numeric values that bypass the warn-and-fallback policy: `volume_increment` outside 0–100, a tick rate (or animation tick rate) outside 1–999ms, an unparseable `auto_update_delay`, `playback_poll_seconds` below 1, and `like_animation_frames` below 1.
 
 ## Behavior
 
@@ -23,16 +23,19 @@ Only two kinds of errors are fatal: YAML syntax errors (the file cannot be parse
 behavior:
   # Timing
   seek_milliseconds: 5000          # seek step for < / >
-  tick_rate_milliseconds: 250      # UI event-loop cadence
-  playback_poll_seconds: 5         # how often playback state is polled (min 1;
+  tick_rate_milliseconds: 250      # UI event-loop cadence (1..=999, fatal if outside)
+  animation_tick_rate_milliseconds: 16
+                                   # animation-only cadence, e.g. the like-heart burst
+                                   #   (1..=999, fatal if outside)
+  playback_poll_seconds: 5         # how often playback state is polled (min 1, fatal if 0;
                                    #   near track end the app polls faster regardless)
   status_message_ttl_percent: 100  # scales how long status messages stay visible
                                    #   (10..=1000; 200 = twice as long)
-  like_animation_frames: 10        # length of the heart burst when liking a track (min 1)
+  like_animation_frames: 10        # length of the heart burst when liking a track (min 1, fatal if 0)
 
   # Volume
-  volume_increment: 1              # step for + / - (0..=100, fatal if outside)
-  volume_percent: 70               # startup volume
+  volume_increment: 10             # step for + / - (0..=100, fatal if outside)
+  volume_percent: 100              # startup volume
 
   # Scrolling
   table_scroll_padding: 5          # rows kept visible below the selection before
@@ -52,6 +55,7 @@ behavior:
 | `discover` | Discover | |
 | `artists` | Followed Artists | `library` |
 | `album_list` | Saved Albums | `albums` |
+| `stats` | Stats | |
 
 Unknown values fall back to `home` with a warning.
 
@@ -219,4 +223,4 @@ The ▶ now-playing marker attaches to the `title` column, or to the first colum
 
 ## Keybindings, theme, and plugins
 
-The `keybindings:` section rebinds ~40 named actions (`back: q`, `next_track: n`, modifier syntax like `ctrl-s` / `alt-,`), and `theme:` sets a preset plus 18 individual color slots (`"R, G, B"` or named colors) — both are easiest to edit from the in-app Settings screen, which writes them back to this file. `plugin_commands:` maps extra keys to Lua plugin commands. See [`examples/config.example.yml`](../examples/config.example.yml) and the [scripting docs](scripting.md).
+The `keybindings:` section rebinds ~40 named actions (`back: q`, `next_track: n`, modifier syntax like `ctrl-s` / `alt-,`), and `theme:` sets a preset plus 16 individual color slots (`"R, G, B"` or named colors) — both are easiest to edit from the in-app Settings screen, which writes them back to this file. `plugin_commands:` maps extra keys to Lua plugin commands. See [`examples/config.example.yml`](../examples/config.example.yml) and the [scripting docs](scripting.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,159 @@
+# Installation
+
+## Quick Install
+
+### Cargo (Recommended)
+
+If you have Rust installed:
+
+```bash
+cargo install --locked spotatui
+```
+
+### Windows (winget)
+
+```bash
+winget install spotatui
+```
+
+### macOS (Homebrew)
+
+```bash
+brew tap LargeModGames/spotatui
+brew install spotatui
+```
+
+### Pre-built Binaries
+
+Download from [GitHub Releases](https://github.com/LargeModGames/spotatui/releases/latest):
+
+| Platform | File |
+| --- | --- |
+| Windows 10/11 (64-bit) | `spotatui-windows-x86_64.zip` |
+| Linux (Ubuntu, Arch, Fedora, etc.) | `spotatui-linux-x86_64.tar.gz` |
+| macOS (Intel) | `spotatui-macos-x86_64.tar.gz` |
+| macOS (Apple Silicon M1/M2/M3) | `spotatui-macos-aarch64.tar.gz` |
+
+Checksums (`.sha256`) are provided if you want to verify the download.
+
+### Arch Linux (AUR)
+
+```bash
+# Pre-built binary (faster)
+yay -S spotatui-bin
+# or
+paru -S spotatui-bin
+
+# Build from source
+yay -S spotatui
+# or
+paru -S spotatui
+```
+
+---
+
+## Platform-Specific Requirements
+
+### Linux
+
+The pre-built Linux binary (and the `spotatui-bin` AUR package) is compiled with the PipeWire audio-visualization backend, so you need PipeWire installed for the visualizer:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install libpipewire-0.3-0
+
+# Arch Linux (already included with pipewire)
+sudo pacman -S pipewire
+
+# Fedora (already included with pipewire)
+sudo dnf install pipewire
+```
+
+> **Note:** Most modern Linux distributions already have PipeWire installed by default. If you build from source instead (`cargo install`), the default build uses the `cpal`-based visualizer backend and does not require PipeWire.
+
+### macOS
+
+spotatui uses the `portaudio` backend for better stability and bluetooth device support (AirPods, etc.):
+
+```bash
+brew install portaudio
+```
+
+---
+
+## Building from Source
+
+Ensure you have [Rust](https://www.rust-lang.org/tools/install) installed.
+
+### Prerequisites
+
+**macOS:**
+```bash
+brew install portaudio
+```
+
+**Linux (Debian/Ubuntu):**
+```bash
+sudo apt-get install libssl-dev libasound2-dev libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev pkg-config
+```
+
+**Linux (Arch):**
+```bash
+sudo pacman -S openssl alsa-lib pkg-config
+```
+
+**Linux (Fedora):**
+```bash
+sudo dnf install openssl-devel alsa-lib-devel pkg-config
+```
+
+### Build
+
+```bash
+git clone https://github.com/LargeModGames/spotatui.git
+cd spotatui
+```
+
+**macOS:**
+```bash
+cargo install --path . --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,portaudio-backend,audio-viz-cpal,macos-media
+```
+
+**Linux/Windows:**
+```bash
+cargo install --path .
+```
+
+**Nix:**
+```bash
+nix-build
+```
+
+---
+
+## Updating
+
+When a new version is available, you'll see a popup notification on startup. To update:
+
+1. Close spotatui
+2. Run:
+   ```bash
+   spotatui update --install
+   ```
+
+If you installed via a package manager (AUR, cargo, etc.), update through there instead.
+
+---
+
+## Connecting to Spotify
+
+spotatui needs to connect to Spotify's API. Instructions are shown when you first run the app.
+
+1. Go to the [Spotify Dashboard](https://developer.spotify.com/dashboard/applications)
+2. Click **Create an app**
+3. Note your `Client ID` and `Client Secret`
+4. Click **Edit Settings**
+5. Add these Redirect URIs:
+   - `http://127.0.0.1:8888/callback` (API authentication)
+   - `http://127.0.0.1:8989/login` (native streaming)
+6. Save and run `spotatui`

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,63 @@
+# Keybindings
+
+Press `?` in spotatui to see the help menu with all keybindings.
+
+## Default Keybindings
+
+| Key         | Action                    |
+| ----------- | ------------------------- |
+| `Space`     | Toggle play/pause         |
+| `n`         | Next track                |
+| `p`         | Previous track            |
+| `+` / `-`   | Volume up/down            |
+| `<` / `>`   | Seek backward/forward     |
+| `/`         | Search                    |
+| `h`/`j`/`k`/`l` | Navigate (vim-style: left/down/up/right) |
+| `Enter`     | Select / confirm          |
+| `a`         | Jump to album             |
+| `A`         | Jump to artist's albums   |
+| `o`         | Jump to context           |
+| `d`         | Manage devices            |
+| `c`         | Copy song URL             |
+| `C`         | Copy album URL            |
+| `Ctrl-r`    | Toggle repeat mode        |
+| `Ctrl-s`    | Toggle shuffle            |
+| `v`         | Audio visualization       |
+| `z`         | Add to queue              |
+| `Q`         | Show queue                |
+| `F`         | Like / save track         |
+| `B`         | Lyrics view               |
+| `T`         | Toggle miniplayer view    |
+| `R`         | Generate recap            |
+| `Ctrl-p`    | Listening party           |
+| `,`         | Open sort menu            |
+| `Alt-,`     | Open settings (`Ctrl-,` on macOS) |
+| `?`         | Show help                 |
+| `q`         | Go back / Quit            |
+
+## Customizing Keybindings
+
+Edit `~/.config/spotatui/config.yml`:
+
+```yaml
+keybindings:
+  back: "q"
+  jump_to_album: "a"
+  toggle_playback: " "
+  # ... etc
+```
+
+The `keybindings:` section rebinds around 40 named actions in total; see
+[`examples/config.example.yml`](../examples/config.example.yml) and
+[`docs/configuration.md`](configuration.md) for the full picture of how the
+config file is structured.
+
+### Key Format
+
+- Single keys: `"a"`, `"/"`, `" "` (space)
+- With Ctrl: `"ctrl-q"`, `"ctrl-s"`
+- With Alt: `"alt-,"`, `"alt-s"`
+- With Shift: Use capital letter `"A"`, `"C"`
+- Special keys: `"enter"`, `"esc"`, `"tab"`
+
+> **Note:** Three-key combinations like `ctrl-alt-q` are not supported.

--- a/docs/native-streaming.md
+++ b/docs/native-streaming.md
@@ -1,0 +1,75 @@
+# Native Streaming
+
+spotatui includes **native Spotify Connect** support, allowing it to play audio directly on your computer without needing an external player like spotifyd.
+
+## Setup
+
+The native streaming feature uses a separate authentication flow. On first run:
+
+1. Your browser will open to Spotify's authorization page
+2. **Important:** The redirect URI will be `http://127.0.0.1:8989/login` - this is different from the main app's callback URL
+3. After authorizing, "spotatui" will appear in your Spotify Connect device list
+4. Credentials are cached so you only need to do this once
+
+## How It Works
+
+- When streaming is enabled, "spotatui" registers as a Spotify Connect device
+- You can control playback from the TUI, your phone, or any other Spotify client
+- Audio plays directly on the computer running spotatui
+
+## Notes
+
+- Native streaming is **enabled by default** when built with the `streaming` feature
+- Premium account is required for playback
+- The streaming authentication uses a different client than the main app's API controls
+
+---
+
+## MPRIS D-Bus Integration (Linux)
+
+When using native streaming on Linux, spotatui automatically registers with the [MPRIS D-Bus interface](https://specifications.freedesktop.org/mpris-spec/latest/), enabling:
+
+- **Media key support** - Play/pause, next, previous via keyboard media keys
+- **Desktop integration** - Track info appears in GNOME/KDE media widgets
+- **playerctl compatibility** - Control spotatui from the command line:
+
+```bash
+# Check available players
+playerctl -l
+# Should show: spotatui
+
+# Control playback
+playerctl -p spotatui play-pause
+playerctl -p spotatui next
+playerctl -p spotatui previous
+
+# View current track metadata
+playerctl -p spotatui metadata
+```
+
+MPRIS is enabled by default on Linux builds with native streaming.
+
+---
+
+## macOS Now Playing Integration
+
+When using native streaming on macOS, spotatui registers with the system's [Now Playing](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter) interface, enabling:
+
+- **Media key support** - Play/pause, next, previous via keyboard media keys
+- **Control Center integration** - Control playback from macOS Control Center
+- **Touch Bar support** - Media controls on MacBook Pro Touch Bar
+- **AirPods / Headphone controls** - Play/pause and skip via Bluetooth headphone buttons
+
+This feature uses Apple's `MPRemoteCommandCenter` API and is enabled by default on macOS builds with native streaming.
+
+---
+
+## Windows System Media Transport Controls (SMTC)
+
+When using native streaming on Windows, spotatui registers with the [System Media Transport Controls](https://learn.microsoft.com/en-us/uwp/api/windows.media.systemmediatransportcontrols) (SMTC), enabling:
+
+- **Media key support** - Play/pause, next, previous via keyboard media keys
+- **Media overlay integration** - Track title, artist, album, and cover art appear in the Windows volume flyout / media overlay
+- **Transport controls** - Play, pause, next, previous, stop, and seek requests from the OS are routed back into spotatui
+
+This feature uses the `smtc-tokio` crate and is enabled by default on Windows builds with native streaming.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,78 @@
+# Roadmap
+
+The goal is to eventually implement almost every Spotify feature.
+
+## High Priority
+
+Both items previously listed here (adding songs to a playlist, and scrolling
+through result pages) are now implemented.
+
+## Spotify API Coverage
+
+This table shows what is possible with the Spotify API, what is implemented, and whether it's essential.
+
+| API Method | Implemented | Description | Essential |
+| --- | :---: | --- | :---: |
+| **Tracks** |
+| track | ✅ | Get a single track by ID | No |
+| tracks | ✅ | Get multiple tracks by IDs | No |
+| **Artists** |
+| artist | ❌ | Get a single artist by ID | Yes |
+| artists | ❌ | Get multiple artists by IDs | No |
+| artist_albums | ✅ | Get an artist's albums | Yes |
+| artist_top_tracks | ✅ | Get an artist's top 10 tracks | Yes |
+| artist_related_artists | ✅ | Get similar artists | Yes |
+| **Albums** |
+| album | ✅ | Get a single album by ID | Yes |
+| albums | ❌ | Get multiple albums by IDs | No |
+| album_track | ✅ | Get an album's tracks | Yes |
+| **Search** |
+| search_album | ✅ | Search albums | Yes |
+| search_artist | ✅ | Search artists | Yes |
+| search_track | ✅ | Search tracks | Yes |
+| search_playlist | ✅ | Search playlists | Yes |
+| **Playlists** |
+| playlist | ✅ | Get playlist details | Yes |
+| current_user_playlists | ✅ | Get user's playlists | Yes |
+| user_playlists | ❌ | Get another user's playlists | No |
+| user_playlist_tracks | ✅ | Get playlist tracks | Yes |
+| user_playlist_create | ✅ | Create a playlist | Yes |
+| user_playlist_change_detail | ❌ | Change playlist name/visibility | Yes |
+| user_playlist_unfollow | ✅ | Unfollow (delete) playlist | Yes |
+| user_playlist_add_track | ✅ | Add tracks to playlist | Yes |
+| user_playlist_follow_playlist | ✅ | Follow a playlist | Yes |
+| **Library** |
+| current_user_saved_albums | ✅ | Get saved albums | Yes |
+| current_user_saved_tracks | ✅ | Get liked songs | Yes |
+| current_user_followed_artists | ✅ | Get followed artists | Yes |
+| current_user_saved_tracks_add | ✅ | Like a track | Yes |
+| current_user_saved_tracks_delete | ✅ | Unlike a track | Yes |
+| current_user_saved_albums_add | ✅ | Save an album | Yes |
+| current_user_saved_albums_delete | ✅ | Remove saved album | Yes |
+| user_follow_artists | ✅ | Follow artists | Yes |
+| user_unfollow_artists | ✅ | Unfollow artists | Yes |
+| current_user_recently_played | ✅ | Get recently played | Yes |
+| current_user_top_artists | ✅ | Get top artists | Yes |
+| current_user_top_tracks | ✅ | Get top tracks | Yes |
+| **Playback** |
+| device | ✅ | Get available devices | Yes |
+| current_playback | ✅ | Get current playback state | Yes |
+| transfer_playback | ✅ | Transfer to another device | Yes |
+| start_playback | ✅ | Start/resume playback | Yes |
+| pause_playback | ✅ | Pause playback | Yes |
+| next_track | ✅ | Skip to next | Yes |
+| previous_track | ✅ | Skip to previous | Yes |
+| seek_track | ✅ | Seek position | Yes |
+| repeat | ✅ | Set repeat mode | Yes |
+| volume | ✅ | Set volume | Yes |
+| shuffle | ✅ | Toggle shuffle | Yes |
+| **Other** |
+| recommendations | ✅ | Get recommendations | Yes |
+| audio_analysis | ❌ | Get audio analysis (visualization now uses local FFT, not this endpoint) | Yes |
+| featured_playlists | ❌ | Get featured playlists | Yes |
+| new_releases | ❌ | Get new releases | Yes |
+| categories | ❌ | Get categories | Yes |
+
+## Want to Help?
+
+Pick an unimplemented feature and [contribute](https://github.com/LargeModGames/spotatui/blob/main/CONTRIBUTING.md)!

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -152,7 +152,13 @@ The playback table has these fields:
 
 ```
 {
-  track = { uri, name, artists = { ... }, album, duration_ms } or nil,
+  track = {
+    uri, name, artists = { ... }, album, duration_ms,
+    id, album_id,
+    artist_refs = { { id, name }, ... },
+    is_playable, is_local, track_number, explicit,
+    image_url,
+  } or nil,
   is_playing = bool,
   progress_ms = number,
   shuffle = bool,
@@ -164,6 +170,14 @@ The playback table has these fields:
 
 `repeat` is a Lua reserved word, so index it with `pb["repeat"]`, not `pb.repeat`. (The matching
 action is named `set_repeat` for the same reason.)
+
+The track's additional fields: `id` is the Spotify base62 track id (`nil` for local/unknown
+tracks); `album_id` is the album's base62 id, when known; `artist_refs` is an array of
+`{ id, name }` navigable artist references, populated when the source provides per-artist data
+and empty when only the combined `artists` display list is available (e.g. native-playback
+snapshots); `is_playable` and `is_local` default to `true`/`false`; `track_number` defaults to
+`0` and `explicit` to `false` when unknown; `image_url` is a directly-fetchable cover-art URL
+when the source provides one (e.g. Subsonic, YouTube), otherwise `nil`.
 
 The cached reads for playlists, queue and search results refresh when the underlying data
 changes; they are cheap to call but can be empty until the app has actually fetched that data.
@@ -268,7 +282,8 @@ tick. If the app stalls past several interval periods, the interval fires once a
   `artist`, `artists`, `recently_played`, `devices`, `queue`, `settings`, `help`, `lyrics`,
   `cover_art`, `miniplayer`, `analysis`, `discover`, `podcasts`, `podcast_episodes`,
   `recommendations`, `party`, `friends`, `local_browser`, `create_playlist`, `dialog`,
-  `announcement`, `exit_prompt`, `error`, and `plugin:<name>` for plugin screens.
+  `announcement`, `recap_prompt`, `exit_prompt`, `error`, `stats`, and `plugin:<name>` for
+  plugin screens.
 
 ### Persistent storage
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,58 @@
+# Themes
+
+spotatui comes with several built-in theme presets. Access them via `Alt-,` > Theme.
+
+## Built-in Presets
+
+| Preset           | Description                                 |
+| ---------------- | -------------------------------------------- |
+| Default (Cyan)   | Original spotatui theme                     |
+| Terminal (ANSI)  | Uses your terminal's ANSI colors            |
+| Pookie Pink      | Bright pink theme                           |
+| Spotify          | Official Spotify green (#1DB954)            |
+| Vesper           | Minimal dark theme with warm orange accents |
+| Dracula          | Popular dark purple/pink theme              |
+| Nord             | Arctic, bluish color palette                |
+| Solarized Dark   | Classic dark theme                          |
+| Monokai          | Vibrant colors on dark background           |
+| Gruvbox          | Warm retro groove colors                    |
+| Gruvbox Light    | Light variant with warm colors              |
+| Catppuccin Mocha | Popular pastel dark theme                   |
+
+## Custom Themes
+
+You can create custom themes in `~/.config/spotatui/config.yml`:
+
+```yaml
+theme:
+  active: "137, 180, 250"      # Current playing song
+  banner: "180, 190, 254"      # The "spotatui" banner
+  error_border: "243, 139, 168"
+  error_text: "243, 139, 168"
+  hint: "249, 226, 175"
+  hovered: "203, 166, 247"
+  inactive: "108, 112, 134"
+  playbar_background: "30, 30, 46"
+  playbar_progress: "166, 227, 161"
+  playbar_progress_text: "166, 227, 161"
+  playbar_text: "205, 214, 244"
+  selected: "137, 180, 250"
+  text: "205, 214, 244"
+  header: "255, 255, 255"
+  background: "30, 30, 46"
+  highlighted_lyrics: "166, 227, 161"
+```
+
+### Color Values
+
+**Always use RGB strings** for consistent colors across different terminals:
+
+```yaml
+text: "205, 214, 244"    # RGB format: "red, green, blue" (0-255)
+```
+
+> **Note:** Terminal color names like `Red`, `Cyan`, etc. are also supported but render differently depending on your terminal's color scheme. For consistent themes, use RGB values.
+
+## Contributing Themes
+
+Want to add a new theme preset? See [CONTRIBUTING.md](https://github.com/LargeModGames/spotatui/blob/main/CONTRIBUTING.md) and check out `src/core/user_config.rs` for examples.

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1272,6 +1272,13 @@ pub struct App {
   /// When true, we hold off on sending another one — rapid key presses
   /// just update `pending_volume` and the latest value wins.
   pub is_volume_change_in_flight: bool,
+  /// Deadline for a debounced config save scheduled by an auto-repeating key
+  /// (volume, panel resize, shuffle). Those keys used to call `save_config()`
+  /// synchronously per repeat, paying a full read, YAML parse, rebuild,
+  /// serialize, and write on the UI thread, dozens of times per second while
+  /// held. The tick handler flushes this once the debounce window passes;
+  /// shutdown flushes it unconditionally.
+  pub config_save_due: Option<Instant>,
   /// Reference to the native streaming player for direct control (bypasses event channel)
   #[cfg(feature = "streaming")]
   pub streaming_player: Option<Arc<crate::infra::player::StreamingPlayer>>,
@@ -1564,6 +1571,7 @@ impl Default for App {
       playlist_tracks_prefetch_generation: 0,
       playlist_tracks_prefetch_in_flight: HashSet::new(),
       is_volume_change_in_flight: false,
+      config_save_due: None,
       pending_volume: None,
       last_dispatched_volume: None,
       #[cfg(feature = "streaming")]
@@ -2752,6 +2760,29 @@ impl App {
   ///
   /// We intentionally don't clear `pending_volume` here — it sticks around until
   /// `get_current_playback` sees the matching value come back from the API.
+  /// Schedule a debounced config save. Hot paths (volume, panel resize,
+  /// shuffle) call this instead of `save_config()` so a held key doesn't pay
+  /// disk + YAML work on every auto-repeat; the save lands once, shortly
+  /// after the last change.
+  pub fn schedule_config_save(&mut self) {
+    const CONFIG_SAVE_DEBOUNCE_MS: u64 = 500;
+    self.config_save_due = Some(Instant::now() + Duration::from_millis(CONFIG_SAVE_DEBOUNCE_MS));
+  }
+
+  /// Flush a scheduled config save once its debounce window has passed, or
+  /// immediately when `force` is set (shutdown).
+  pub fn flush_config_save(&mut self, force: bool) {
+    let Some(due) = self.config_save_due else {
+      return;
+    };
+    if force || Instant::now() >= due {
+      self.config_save_due = None;
+      if let Err(e) = self.user_config.save_config() {
+        self.handle_error(anyhow!("Failed to save config: {}", e));
+      }
+    }
+  }
+
   pub fn flush_pending_volume(&mut self) {
     if self.is_volume_change_in_flight {
       return; // previous request still processing
@@ -2822,7 +2853,7 @@ impl App {
       if self.active_decoded_source() {
         self.dispatch(IoEvent::ChangeVolume(next_volume));
         self.user_config.behavior.volume_percent = next_volume;
-        let _ = self.user_config.save_config();
+        self.schedule_config_save();
         self.pending_volume = Some(next_volume);
         return;
       }
@@ -2837,7 +2868,7 @@ impl App {
             ctx.device.volume_percent = Some(next_volume.into());
           }
           self.user_config.behavior.volume_percent = next_volume;
-          let _ = self.user_config.save_config();
+          self.schedule_config_save();
           self.pending_volume = Some(next_volume);
 
           // Notify MPRIS clients of the change (VolumeChanged is never emitted by
@@ -2878,7 +2909,7 @@ impl App {
       if self.active_decoded_source() {
         self.dispatch(IoEvent::ChangeVolume(next_volume));
         self.user_config.behavior.volume_percent = next_volume;
-        let _ = self.user_config.save_config();
+        self.schedule_config_save();
         self.pending_volume = Some(next_volume);
         return;
       }
@@ -2893,7 +2924,7 @@ impl App {
             ctx.device.volume_percent = Some(next_volume.into());
           }
           self.user_config.behavior.volume_percent = next_volume;
-          let _ = self.user_config.save_config();
+          self.schedule_config_save();
           self.pending_volume = Some(next_volume);
 
           // Notify MPRIS clients of the change (VolumeChanged is never emitted by
@@ -2939,7 +2970,7 @@ impl App {
       if self.active_decoded_source() {
         self.dispatch(IoEvent::ChangeVolume(next_volume_u8));
         self.user_config.behavior.volume_percent = next_volume_u8;
-        let _ = self.user_config.save_config();
+        self.schedule_config_save();
         self.pending_volume = Some(next_volume_u8);
         return;
       }
@@ -2954,7 +2985,7 @@ impl App {
             ctx.device.volume_percent = Some(next_volume_u8.into());
           }
           self.user_config.behavior.volume_percent = next_volume_u8;
-          let _ = self.user_config.save_config();
+          self.schedule_config_save();
           self.pending_volume = Some(next_volume_u8);
 
           // Notify MPRIS clients of the change (VolumeChanged is never emitted by
@@ -4417,7 +4448,7 @@ impl App {
             ctx.shuffle_state = new_shuffle_state;
           }
           self.user_config.behavior.shuffle_enabled = new_shuffle_state;
-          let _ = self.user_config.save_config();
+          self.schedule_config_save();
 
           // Notify MPRIS clients of the change
           #[cfg(all(feature = "mpris", target_os = "linux"))]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -567,6 +567,10 @@ pub struct TrackTable {
   pub tracks: Vec<TrackInfo>,
   pub selected_index: usize,
   pub context: Option<TrackTableContext>,
+  /// First row shown in the table. Persisted across frames so the cursor can
+  /// move within the visible window without dragging the view (the view only
+  /// scrolls when the cursor reaches an edge). Updated during draw, hence Cell.
+  pub scroll_offset: std::cell::Cell<usize>,
 }
 
 fn sort_playlist_track_matches(matches: &mut [(FullTrack, usize)], sort_state: SortState) {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -982,11 +982,15 @@ pub struct QueueState {
   pub queue: Vec<PlayableInfo>,
 }
 
-/// The string payload of `IoEvent::StartPlayback`: (context uri, playable
-/// uris, offset). Parked on `App::pending_start_playback` while the native
-/// backend is recovering, then replayed.
 #[cfg(feature = "streaming")]
-pub type PendingStartPlayback = (Option<String>, Option<Vec<String>>, Option<usize>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingStartPlayback {
+  pub context_uri: Option<String>,
+  pub uris: Option<Vec<String>>,
+  pub offset: Option<usize>,
+  pub parked_at: Instant,
+  pub recovery_attempts: u8,
+}
 
 pub struct App {
   /// What the user actually wants the volume to be. We keep this around until
@@ -1042,6 +1046,10 @@ pub struct App {
   /// Status of the current track's cover art, driving the placeholder message.
   #[cfg(feature = "cover-art")]
   pub cover_art_status: CoverArtStatus,
+  /// Image key currently desired by the UI. Detached decode results for older
+  /// keys are discarded.
+  #[cfg(feature = "cover-art")]
+  pub desired_cover_art_key: Option<String>,
   // Inputs:
   // input is the string for input;
   // input_idx is the index of the cursor in terms of character;
@@ -1165,6 +1173,9 @@ pub struct App {
   pub pending_announcements: Vec<Announcement>,
   pub lyrics: Option<Vec<(u128, String)>>,
   pub lyrics_status: LyricsStatus,
+  /// Title/artist pair whose lyrics response is currently desired. Detached
+  /// service responses must match this before mutating visible state.
+  pub desired_lyrics_identity: Option<(String, String)>,
   pub global_song_count: Option<u64>,
   pub global_song_count_failed: bool,
   // Settings screen state
@@ -1285,6 +1296,9 @@ pub struct App {
   /// Incremented every time the playlist track table is reloaded to guard stale prefetch tasks
   pub playlist_tracks_prefetch_generation: u64,
   pub playlist_tracks_prefetch_in_flight: HashSet<u32>,
+  /// Playlist ids whose full track list is being fetched for sorting. Further
+  /// sort changes reuse the active fetch and apply the newest sort at completion.
+  pub playlist_sort_fetch_in_flight: HashSet<String>,
   /// Playlist id whose page-1 open fetch is in flight, so spamming Enter on a
   /// playlist doesn't queue duplicate full fetches. Cleared when the response
   /// (or its error) lands.
@@ -1555,6 +1569,7 @@ impl Default for App {
       pending_announcements: Vec::new(),
       lyrics: None,
       lyrics_status: LyricsStatus::default(),
+      desired_lyrics_identity: None,
       global_song_count: None,
       global_song_count_failed: false,
       // Settings defaults
@@ -1610,6 +1625,7 @@ impl Default for App {
       playlist_tracks_prefetch_generation: 0,
       pending_playlist_open: None,
       playlist_tracks_prefetch_in_flight: HashSet::new(),
+      playlist_sort_fetch_in_flight: HashSet::new(),
       is_volume_change_in_flight: false,
       config_save_due: None,
       pending_volume: None,
@@ -1638,6 +1654,8 @@ impl Default for App {
       cover_art: crate::tui::cover_art::CoverArt::new(),
       #[cfg(feature = "cover-art")]
       cover_art_status: CoverArtStatus::default(),
+      #[cfg(feature = "cover-art")]
+      desired_cover_art_key: None,
       friends: Vec::new(),
       friends_loading: false,
       friend_code: None,
@@ -1823,6 +1841,9 @@ impl App {
   pub fn current_persisted_playback(
     &self,
   ) -> Option<crate::core::persisted_playback::PersistedPlayback> {
+    if !self.has_persistable_playback() {
+      return None;
+    }
     #[cfg(any(
       feature = "youtube",
       feature = "subsonic",
@@ -2217,15 +2238,19 @@ impl App {
     self.seek_ms = None;
     self.native_load_watchdog = None;
     // Playback requests park for replay until recovery resolves (see
-    // `replay_pending_start_playback`).
-    self.native_backend_pending = true;
+    // `replay_pending_start_playback`). Only enter the pending state when the
+    // recovery request was actually accepted.
     if reselect_device {
       self.current_playback_context = None;
     }
 
     self.set_status_message("Native streaming disconnected; attempting recovery.", 8);
     if let Some(tx) = &self.streaming_recovery_tx {
-      let _ = tx.send(crate::infra::player::StreamingRecoveryRequest { reselect_device });
+      self.native_backend_pending = tx
+        .send(crate::infra::player::StreamingRecoveryRequest { reselect_device })
+        .is_ok();
+    } else {
+      self.native_backend_pending = false;
     }
     self.dispatch(IoEvent::GetCurrentPlayback);
   }
@@ -2240,17 +2265,39 @@ impl App {
     uris: Option<Vec<String>>,
     offset: Option<usize>,
   ) {
-    self.pending_start_playback = Some((context_uri, uris, offset));
+    let same_request = self.pending_start_playback.as_ref().is_some_and(|pending| {
+      pending.context_uri == context_uri && pending.uris == uris && pending.offset == offset
+    });
+    if !same_request {
+      self.pending_start_playback = Some(PendingStartPlayback {
+        context_uri,
+        uris,
+        offset,
+        parked_at: Instant::now(),
+        recovery_attempts: 0,
+      });
+    }
   }
 
   /// Replay a parked StartPlayback through the normal dispatch path. No-op
   /// when nothing is parked.
   #[cfg(feature = "streaming")]
   pub fn replay_pending_start_playback(&mut self) {
-    if let Some((context_uri, uris, offset)) = self.pending_start_playback.take() {
-      self.set_status_message("Resuming playback request…", 4);
-      self.dispatch(IoEvent::StartPlayback(context_uri, uris, offset));
+    const MAX_PARKED_AGE: Duration = Duration::from_secs(30);
+    let Some(pending) = self.pending_start_playback.clone() else {
+      return;
+    };
+    if pending.parked_at.elapsed() > MAX_PARKED_AGE {
+      self.pending_start_playback = None;
+      self.set_status_message("Playback request expired during native recovery.", 6);
+      return;
     }
+    self.set_status_message("Resuming playback request…", 4);
+    self.dispatch(IoEvent::StartPlayback(
+      pending.context_uri,
+      pending.uris,
+      pending.offset,
+    ));
   }
 
   pub fn playlist_is_editable(&self, playlist: &PlaylistInfo) -> bool {
@@ -2546,16 +2593,37 @@ impl App {
     #[cfg(feature = "streaming")]
     {
       const NATIVE_LOAD_WATCHDOG: Duration = Duration::from_secs(5);
+      let watchdog_window = NATIVE_LOAD_WATCHDOG.saturating_mul(
+        u32::from(
+          self
+            .pending_start_playback
+            .as_ref()
+            .map_or(0, |pending| pending.recovery_attempts),
+        ) + 1,
+      );
       if self
         .native_load_watchdog
-        .is_some_and(|armed| armed.elapsed() >= NATIVE_LOAD_WATCHDOG)
+        .is_some_and(|armed| armed.elapsed() >= watchdog_window)
       {
         self.native_load_watchdog = None;
-        log::warn!(
-          "no player event within {}s of native load; forcing session recovery",
-          NATIVE_LOAD_WATCHDOG.as_secs()
-        );
-        self.force_native_streaming_recovery(true);
+        const MAX_RECOVERY_ATTEMPTS: u8 = 2;
+        if let Some(pending) = self.pending_start_playback.as_mut() {
+          if pending.recovery_attempts >= MAX_RECOVERY_ATTEMPTS {
+            self.pending_start_playback = None;
+            self.set_status_message(
+              "Native playback did not respond after recovery; request dropped.",
+              8,
+            );
+          } else {
+            pending.recovery_attempts += 1;
+            log::warn!(
+              "no player event within {}s of native load; forcing recovery attempt {}",
+              NATIVE_LOAD_WATCHDOG.as_secs(),
+              pending.recovery_attempts
+            );
+            self.force_native_streaming_recovery(true);
+          }
+        }
       }
     }
 
@@ -3894,6 +3962,8 @@ impl App {
           if is_playing { "paused" } else { "playing" }
         );
         if is_playing {
+          self.pending_start_playback = None;
+          self.native_load_watchdog = None;
           player.pause();
           // Update UI state immediately
           if let Some(ctx) = &mut self.current_playback_context {
@@ -3936,6 +4006,11 @@ impl App {
 
   pub fn previous_track(&mut self) {
     info!("playing previous track or restarting current track");
+    #[cfg(feature = "streaming")]
+    {
+      self.pending_start_playback = None;
+      self.native_load_watchdog = None;
+    }
     // The native queue owns playback: a forward-only queue has no "previous",
     // so restart the current queued track. The queue router intercepts the
     // dispatched event for both decoded and Spotify queue slots.
@@ -3998,6 +4073,11 @@ impl App {
 
   pub fn force_previous_track(&mut self) {
     info!("force skipping to previous track");
+    #[cfg(feature = "streaming")]
+    {
+      self.pending_start_playback = None;
+      self.native_load_watchdog = None;
+    }
     // The native queue owns playback: restart the current queued track (the
     // queue router intercepts the event for both slot kinds).
     if self.queue_owns_playback() {
@@ -4039,6 +4119,11 @@ impl App {
 
   pub fn next_track(&mut self) {
     info!("skipping to next track");
+    #[cfg(feature = "streaming")]
+    {
+      self.pending_start_playback = None;
+      self.native_load_watchdog = None;
+    }
     // The native queue owns playback: skip to the next queued item (or resume
     // the suspended context when the queue drains).
     if self.queue_owns_playback() {
@@ -6512,6 +6597,47 @@ mod tests {
   use rspotify::prelude::Id;
   use std::collections::HashMap;
   use std::sync::mpsc::channel;
+
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn parked_playback_retries_are_keyed_to_the_request() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.park_start_playback(
+      Some("spotify:playlist:first".to_string()),
+      Some(vec!["spotify:track:first".to_string()]),
+      Some(1),
+    );
+    app
+      .pending_start_playback
+      .as_mut()
+      .unwrap()
+      .recovery_attempts = 2;
+
+    app.park_start_playback(
+      Some("spotify:playlist:first".to_string()),
+      Some(vec!["spotify:track:first".to_string()]),
+      Some(1),
+    );
+    assert_eq!(
+      app
+        .pending_start_playback
+        .as_ref()
+        .unwrap()
+        .recovery_attempts,
+      2
+    );
+
+    app.park_start_playback(Some("spotify:playlist:second".to_string()), None, None);
+    assert_eq!(
+      app
+        .pending_start_playback
+        .as_ref()
+        .unwrap()
+        .recovery_attempts,
+      0
+    );
+  }
 
   #[allow(deprecated)]
   fn full_track(id: &str, name: &str) -> FullTrack {

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -402,6 +402,9 @@ impl RouteId {
 pub struct FriendEntry {
   pub id: String,
   pub name: String,
+  /// Lowercased `name`, precomputed once so the per-frame search filter
+  /// doesn't allocate per friend per frame.
+  pub name_lower: String,
   pub is_online: bool,
   pub now_playing: Option<FriendNowPlaying>,
   /// Total listening time in milliseconds (from spotatui.com)
@@ -979,6 +982,12 @@ pub struct QueueState {
   pub queue: Vec<PlayableInfo>,
 }
 
+/// The string payload of `IoEvent::StartPlayback`: (context uri, playable
+/// uris, offset). Parked on `App::pending_start_playback` while the native
+/// backend is recovering, then replayed.
+#[cfg(feature = "streaming")]
+pub type PendingStartPlayback = (Option<String>, Option<Vec<String>>, Option<usize>);
+
 pub struct App {
   /// What the user actually wants the volume to be. We keep this around until
   /// Spotify's API comes back with the same value — otherwise a slow poll
@@ -1087,6 +1096,10 @@ pub struct App {
   pub last_api_seek: Option<Instant>,
   /// Pending seek position for API (throttled to avoid overwhelming Spotify API)
   pub pending_api_seek: Option<u32>,
+  /// Last time a decoded-source seek was dispatched (for throttling drags)
+  pub last_source_seek: Option<Instant>,
+  /// Pending decoded-source seek position (throttled; drags coalesce to the last target)
+  pub pending_source_seek: Option<u32>,
   pub track_table: TrackTable,
   pub episode_table_context: EpisodeTableContext,
   pub selected_show_simplified: Option<SelectedShow>,
@@ -1265,13 +1278,17 @@ pub struct App {
   /// Current folder ID being viewed (0 = root)
   pub current_playlist_folder_id: usize,
   /// Incremented every time playlists are refreshed to guard stale background tasks
-  pub _playlist_refresh_generation: u64,
+  pub playlist_refresh_generation: u64,
   /// Incremented every time the saved tracks view is reloaded to guard stale prefetch tasks
   pub saved_tracks_prefetch_generation: u64,
   pub saved_tracks_prefetch_in_flight: HashSet<u32>,
   /// Incremented every time the playlist track table is reloaded to guard stale prefetch tasks
   pub playlist_tracks_prefetch_generation: u64,
   pub playlist_tracks_prefetch_in_flight: HashSet<u32>,
+  /// Playlist id whose page-1 open fetch is in flight, so spamming Enter on a
+  /// playlist doesn't queue duplicate full fetches. Cleared when the response
+  /// (or its error) lands.
+  pub pending_playlist_open: Option<String>,
   /// Tracks whether a ChangeVolume request is on its way to Spotify.
   /// When true, we hold off on sending another one — rapid key presses
   /// just update `pending_volume` and the latest value wins.
@@ -1314,6 +1331,22 @@ pub struct App {
   #[cfg(feature = "streaming")]
   pub streaming_recovery_tx:
     Option<tokio::sync::mpsc::UnboundedSender<crate::infra::player::StreamingRecoveryRequest>>,
+  /// A StartPlayback request parked while no usable backend exists (native
+  /// session recovering, or startup init still materializing one). Replayed
+  /// once the backend is ready so the user's press isn't silently dropped.
+  #[cfg(feature = "streaming")]
+  pub pending_start_playback: Option<PendingStartPlayback>,
+  /// True while a native backend may materialize soon (recovery in flight, or
+  /// the deferred startup init still running). While set, a playback request
+  /// that finds no active device parks itself for replay instead of routing
+  /// to the full-screen error.
+  #[cfg(feature = "streaming")]
+  pub native_backend_pending: bool,
+  /// Armed when a native load is issued; a Playing/TrackChanged event disarms
+  /// it. If it fires, the session is a zombie (passes `is_connected` but
+  /// silently drops Spirc commands) and recovery is forced.
+  #[cfg(feature = "streaming")]
+  pub native_load_watchdog: Option<Instant>,
   /// Reference to MPRIS manager for emitting Seeked signals after native seeks
   #[cfg(all(feature = "mpris", target_os = "linux"))]
   pub mpris_manager: Option<Arc<crate::infra::mpris::MprisManager>>,
@@ -1490,6 +1523,8 @@ impl Default for App {
       pending_native_seek: None,
       last_api_seek: None,
       pending_api_seek: None,
+      last_source_seek: None,
+      pending_source_seek: None,
       selected_device_index: None,
       selected_playlist_index: None,
       active_playlist_index: None,
@@ -1569,10 +1604,11 @@ impl Default for App {
       _playlist_folder_nodes: None,
       playlist_folder_items: Vec::new(),
       current_playlist_folder_id: 0,
-      _playlist_refresh_generation: 0,
+      playlist_refresh_generation: 0,
       saved_tracks_prefetch_generation: 0,
       saved_tracks_prefetch_in_flight: HashSet::new(),
       playlist_tracks_prefetch_generation: 0,
+      pending_playlist_open: None,
       playlist_tracks_prefetch_in_flight: HashSet::new(),
       is_volume_change_in_flight: false,
       config_save_due: None,
@@ -1590,6 +1626,12 @@ impl Default for App {
       youtube_playback: None,
       #[cfg(feature = "streaming")]
       streaming_recovery_tx: None,
+      #[cfg(feature = "streaming")]
+      pending_start_playback: None,
+      #[cfg(feature = "streaming")]
+      native_backend_pending: false,
+      #[cfg(feature = "streaming")]
+      native_load_watchdog: None,
       #[cfg(all(feature = "mpris", target_os = "linux"))]
       mpris_manager: None,
       #[cfg(feature = "cover-art")]
@@ -1710,23 +1752,19 @@ impl App {
       return;
     }
     if let Some(page) = self.recently_played.result.as_mut() {
-      page.items.sort_by(|a, b| {
-        let order = match sort_state.field {
-          SortField::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-          SortField::Artist => {
-            let artist_a = a.artists.first().map(|s| s.to_lowercase());
-            let artist_b = b.artists.first().map(|s| s.to_lowercase());
-            artist_a.cmp(&artist_b)
-          }
-          SortField::Album => a.album.to_lowercase().cmp(&b.album.to_lowercase()),
-          _ => std::cmp::Ordering::Equal,
-        };
-        if sort_state.order == SortOrder::Descending {
-          order.reverse()
-        } else {
-          order
+      use crate::core::sort::sort_by_key_with_order;
+      match sort_state.field {
+        SortField::Name => {
+          sort_by_key_with_order(&mut page.items, sort_state.order, |t| t.name.to_lowercase())
         }
-      });
+        SortField::Artist => sort_by_key_with_order(&mut page.items, sort_state.order, |t| {
+          t.artists.first().map(|s| s.to_lowercase())
+        }),
+        SortField::Album => sort_by_key_with_order(&mut page.items, sort_state.order, |t| {
+          t.album.to_lowercase()
+        }),
+        _ => {}
+      }
     }
   }
 
@@ -1892,6 +1930,41 @@ impl App {
       queue.insert(0, track.clone());
     }
     Some(crate::core::persisted_playback::PersistedSession { playback, queue })
+  }
+
+  /// Cheap presence check for `current_persisted_session`: same decision
+  /// logic, no snapshot allocation. Lets the tick loop skip building the
+  /// snapshot (which clones the whole native queue) unless a save is due.
+  pub fn has_persistable_session(&self) -> bool {
+    self.has_persistable_playback()
+      || !self.native_queue.is_empty()
+      || self.queue_now_track().is_some()
+  }
+
+  fn has_persistable_playback(&self) -> bool {
+    // Mirrors `current_persisted_playback`: a decoded context suspended past
+    // its end (resume_index == None) does not persist.
+    #[cfg(any(feature = "youtube", feature = "subsonic", feature = "local-files"))]
+    {
+      let context_resumable = !matches!(self.suspended_resume(), Some((None, _)));
+      #[cfg(feature = "youtube")]
+      if self.youtube_playback.is_some() && context_resumable {
+        return true;
+      }
+      #[cfg(feature = "subsonic")]
+      if self.subsonic_playback.is_some() && context_resumable {
+        return true;
+      }
+      #[cfg(feature = "local-files")]
+      if self.local_playback.is_some() && context_resumable {
+        return true;
+      }
+    }
+    #[cfg(feature = "internet-radio")]
+    if self.radio_playback.is_some() {
+      return true;
+    }
+    false
   }
 
   #[allow(dead_code)]
@@ -2117,10 +2190,21 @@ impl App {
       return false;
     }
 
-    // Stop the old spirc before dropping our reference so the dead session
-    // doesn't linger as a ghost Connect device (#297).
-    player.shutdown();
-    self.streaming_player = None;
+    self.force_native_streaming_recovery(reselect_device);
+    true
+  }
+
+  /// Tear down the current native session — even one that still passes
+  /// `is_connected` — and request recovery. Called by the disconnect check
+  /// above and by the load watchdog, which catches zombie sessions (half-open
+  /// TCP: `is_connected` true, Spirc commands silently dropped).
+  #[cfg(feature = "streaming")]
+  pub fn force_native_streaming_recovery(&mut self, reselect_device: bool) {
+    if let Some(player) = self.streaming_player.take() {
+      // Stop the old spirc before dropping our reference so the dead session
+      // doesn't linger as a ghost Connect device (#297).
+      player.shutdown();
+    }
     self.is_streaming_active = false;
     self.native_activation_pending = false;
     self.native_device_id = None;
@@ -2131,6 +2215,10 @@ impl App {
     self.last_track_id = None;
     self.last_device_activation = None;
     self.seek_ms = None;
+    self.native_load_watchdog = None;
+    // Playback requests park for replay until recovery resolves (see
+    // `replay_pending_start_playback`).
+    self.native_backend_pending = true;
     if reselect_device {
       self.current_playback_context = None;
     }
@@ -2140,7 +2228,29 @@ impl App {
       let _ = tx.send(crate::infra::player::StreamingRecoveryRequest { reselect_device });
     }
     self.dispatch(IoEvent::GetCurrentPlayback);
-    true
+  }
+
+  /// Park a StartPlayback request (string form, as `IoEvent::StartPlayback`
+  /// carries it) for replay once a usable backend exists. A newer request
+  /// replaces an older one — the user's latest intent wins.
+  #[cfg(feature = "streaming")]
+  pub fn park_start_playback(
+    &mut self,
+    context_uri: Option<String>,
+    uris: Option<Vec<String>>,
+    offset: Option<usize>,
+  ) {
+    self.pending_start_playback = Some((context_uri, uris, offset));
+  }
+
+  /// Replay a parked StartPlayback through the normal dispatch path. No-op
+  /// when nothing is parked.
+  #[cfg(feature = "streaming")]
+  pub fn replay_pending_start_playback(&mut self) {
+    if let Some((context_uri, uris, offset)) = self.pending_start_playback.take() {
+      self.set_status_message("Resuming playback request…", 4);
+      self.dispatch(IoEvent::StartPlayback(context_uri, uris, offset));
+    }
   }
 
   pub fn playlist_is_editable(&self, playlist: &PlaylistInfo) -> bool {
@@ -2429,6 +2539,26 @@ impl App {
       }
     }
 
+    // Load watchdog: a native load that produces no Playing/TrackChanged
+    // event within the window means the session is a zombie (passes
+    // `is_connected`, drops Spirc commands) — force recovery; the parked
+    // request replays once the new session is up.
+    #[cfg(feature = "streaming")]
+    {
+      const NATIVE_LOAD_WATCHDOG: Duration = Duration::from_secs(5);
+      if self
+        .native_load_watchdog
+        .is_some_and(|armed| armed.elapsed() >= NATIVE_LOAD_WATCHDOG)
+      {
+        self.native_load_watchdog = None;
+        log::warn!(
+          "no player event within {}s of native load; forcing session recovery",
+          NATIVE_LOAD_WATCHDOG.as_secs()
+        );
+        self.force_native_streaming_recovery(true);
+      }
+    }
+
     self.poll_current_playback();
     let playing_now = self.user_config.behavior.keepawake_enabled
       && self
@@ -2629,9 +2759,10 @@ impl App {
     // duration internally). Radio returns None here, so its playbar drags are
     // correct no-ops. Never read the stale Spotify context duration for a source.
     if self.active_source_position_ms().is_some() {
-      self.song_progress_ms = position_ms as u128;
-      self.seek_ms = None;
-      self.dispatch(IoEvent::Seek(position_ms));
+      // Decoded `.seek()` can re-decode forward for many codecs, so a mouse
+      // drag must not dispatch one seek per drag event; coalesce to the last
+      // target with the same throttle-and-flush pattern as the other backends.
+      self.queue_source_seek(position_ms);
       return;
     }
     if let Some(CurrentPlaybackContext {
@@ -2671,6 +2802,46 @@ impl App {
 
       // Fallback: API-based seek for external devices (with throttling)
       self.queue_api_seek(new_progress);
+    }
+  }
+
+  /// Queue a decoded-source (local/Subsonic/YouTube) seek with throttling
+  fn queue_source_seek(&mut self, position_ms: u32) {
+    // Always update UI immediately
+    self.song_progress_ms = position_ms as u128;
+    self.seek_ms = None;
+
+    const SOURCE_SEEK_THROTTLE_MS: u128 = 50;
+    let should_seek_now = self
+      .last_source_seek
+      .is_none_or(|t| t.elapsed().as_millis() >= SOURCE_SEEK_THROTTLE_MS);
+
+    if should_seek_now {
+      self.execute_source_seek(position_ms);
+    } else {
+      // Queue the seek - will be flushed by tick loop or next seek
+      self.pending_source_seek = Some(position_ms);
+    }
+  }
+
+  /// Execute a decoded-source seek and update tracking state
+  fn execute_source_seek(&mut self, position_ms: u32) {
+    self.pending_source_seek = None;
+    self.last_source_seek = Some(Instant::now());
+    self.dispatch(IoEvent::Seek(position_ms));
+  }
+
+  /// Flush any pending decoded-source seek (called from tick loop)
+  pub fn flush_pending_source_seek(&mut self) {
+    if let Some(position) = self.pending_source_seek {
+      const SOURCE_SEEK_THROTTLE_MS: u128 = 50;
+      let should_flush = self
+        .last_source_seek
+        .is_none_or(|t| t.elapsed().as_millis() >= SOURCE_SEEK_THROTTLE_MS);
+
+      if should_flush {
+        self.execute_source_seek(position);
+      }
     }
   }
 
@@ -4130,6 +4301,33 @@ impl App {
     self.track_table.context = Some(TrackTableContext::SavedTracks);
   }
 
+  /// Open a playlist's track table: navigate immediately (the cleared table is
+  /// the loading state) and fetch page 1. The fetch response used to be what
+  /// pushed the route, so a queued or slow fetch made Enter look dead and
+  /// trained users to spam it — each press queuing another full fetch. Now
+  /// the screen opens on the first press, and a repeat press while the same
+  /// open is still in flight only re-ensures navigation instead of dispatching
+  /// a duplicate fetch.
+  pub fn open_playlist_tracks(
+    &mut self,
+    playlist_id: PlaylistId<'static>,
+    context: TrackTableContext,
+  ) {
+    let id_str = playlist_id.id().to_string();
+    if self.pending_playlist_open.as_deref() == Some(id_str.as_str()) {
+      // Same open already in flight: just make sure the screen is shown.
+      if self.get_current_route().id != RouteId::TrackTable {
+        self.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+      }
+      return;
+    }
+    self.pending_playlist_open = Some(id_str.clone());
+    self.reset_playlist_tracks_view(playlist_id, context);
+    self.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+    self.set_status_message("Loading playlist…", 3);
+    self.dispatch(IoEvent::GetPlaylistItems(id_str, self.playlist_offset));
+  }
+
   pub fn reset_playlist_tracks_view(
     &mut self,
     playlist_id: PlaylistId<'static>,
@@ -4436,8 +4634,12 @@ impl App {
   }
 
   pub fn shuffle(&mut self) {
-    if let Some(context) = &self.current_playback_context.clone() {
-      let new_shuffle_state = !context.shuffle_state;
+    if let Some(shuffle_state) = self
+      .current_playback_context
+      .as_ref()
+      .map(|context| context.shuffle_state)
+    {
+      let new_shuffle_state = !shuffle_state;
       info!("toggling shuffle: {}", new_shuffle_state);
 
       // Use native streaming player for instant control (bypasses event channel latency)
@@ -4805,8 +5007,11 @@ impl App {
   }
 
   pub fn repeat(&mut self) {
-    if let Some(context) = &self.current_playback_context.clone() {
-      let current_repeat_state = context.repeat_state;
+    if let Some(current_repeat_state) = self
+      .current_playback_context
+      .as_ref()
+      .map(|context| context.repeat_state)
+    {
       info!("toggling repeat mode: {:?}", current_repeat_state);
 
       // Use native streaming player for instant control (bypasses event channel latency)

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,5 +1,5 @@
 use crate::core::config::{ClientConfig, ConfigPaths, NCSPOT_CLIENT_ID};
-use crate::infra::redirect_uri::redirect_uri_web_server;
+use crate::infra::redirect_uri::redirect_uri_web_server_async;
 use anyhow::{anyhow, Result};
 use log::{info, warn};
 use rspotify::{
@@ -41,6 +41,12 @@ pub struct AuthenticatedClient {
   pub token_cache_path: PathBuf,
   #[cfg(feature = "streaming")]
   pub redirect_uri: String,
+  /// The `/me` response captured while validating the cached token, so later
+  /// startup steps (the native-streaming account probe) can reuse it instead
+  /// of paying a second round trip. `None` when validation didn't run (fresh
+  /// interactive login).
+  #[cfg_attr(not(feature = "streaming"), allow(dead_code))]
+  pub me: Option<rspotify::model::PrivateUser>,
 }
 
 // Manual token cache helpers since rspotify's built-in caching isn't working.
@@ -238,12 +244,15 @@ pub async fn refresh_token_and_cache(
   Ok(expiry)
 }
 
+/// Returns the `/me` response when the cached token was validated with one,
+/// so callers can reuse it instead of re-fetching (`None` after a fresh
+/// interactive login, which skips the validation call).
 async fn ensure_auth_token(
   spotify: &mut AuthCodePkceSpotify,
   token_cache_path: &PathBuf,
   auth_port: u16,
   interactive: bool,
-) -> Result<()> {
+) -> Result<Option<rspotify::model::PrivateUser>> {
   let mut needs_auth = match load_token_from_file(spotify, token_cache_path).await {
     Ok(true) => false,
     Ok(false) => {
@@ -275,31 +284,35 @@ async fn ensure_auth_token(
     }
   }
 
+  let mut validated_me = None;
   if !needs_auth {
-    if let Err(e) = spotify.me().await {
-      let err_text = e.to_string();
-      let err_text_lower = err_text.to_lowercase();
-      let should_reauth = err_text_lower.contains("401")
-        || err_text_lower.contains("unauthorized")
-        || err_text_lower.contains("status code 400")
-        || err_text_lower.contains("invalid_grant")
-        || err_text_lower.contains("access token expired")
-        || err_text_lower.contains("token expired");
+    match spotify.me().await {
+      Ok(user) => validated_me = Some(user),
+      Err(e) => {
+        let err_text = e.to_string();
+        let err_text_lower = err_text.to_lowercase();
+        let should_reauth = err_text_lower.contains("401")
+          || err_text_lower.contains("unauthorized")
+          || err_text_lower.contains("status code 400")
+          || err_text_lower.contains("invalid_grant")
+          || err_text_lower.contains("access token expired")
+          || err_text_lower.contains("token expired");
 
-      if should_reauth {
-        info!("cached authentication token is invalid, re-authentication required");
-        if token_cache_path.exists() {
-          if let Err(remove_err) = fs::remove_file(token_cache_path) {
-            info!(
-              "failed to remove stale token cache {}: {}",
-              token_cache_path.display(),
-              remove_err
-            );
+        if should_reauth {
+          info!("cached authentication token is invalid, re-authentication required");
+          if token_cache_path.exists() {
+            if let Err(remove_err) = fs::remove_file(token_cache_path) {
+              info!(
+                "failed to remove stale token cache {}: {}",
+                token_cache_path.display(),
+                remove_err
+              );
+            }
           }
+          needs_auth = true;
+        } else {
+          return Err(anyhow!(e));
         }
-        needs_auth = true;
-      } else {
-        return Err(anyhow!(e));
       }
     }
   }
@@ -331,7 +344,10 @@ async fn ensure_auth_token(
       auth_port
     );
 
-    match redirect_uri_web_server(auth_port) {
+    // Async server, same as the in-TUI login path: the blocking variant used
+    // to park a tokio worker thread in a std accept() loop with no timeout,
+    // which could hang the whole login on startup (#364).
+    match redirect_uri_web_server_async(auth_port).await {
       Ok(url) => {
         if let Some(code) = spotify.parse_response_code(&url) {
           info!("authorization code received, requesting access token");
@@ -363,7 +379,7 @@ async fn ensure_auth_token(
     }
   }
 
-  Ok(())
+  Ok(validated_me)
 }
 
 /// Authenticate the Spotify client, trying the primary client id then the
@@ -405,6 +421,7 @@ async fn authenticate_candidates(
   #[cfg(feature = "streaming")]
   let mut selected_redirect_uri = client_config.get_redirect_uri();
   let mut last_auth_error = None;
+  let mut validated_me = None;
 
   for (index, client_id) in client_candidates.iter().enumerate() {
     let token_cache_path = token_cache_path_for_client(&config_paths.token_cache_path, client_id);
@@ -417,7 +434,8 @@ async fn authenticate_candidates(
       ensure_auth_token(&mut candidate, &token_cache_path, auth_port, interactive).await;
 
     match auth_result {
-      Ok(()) => {
+      Ok(me) => {
+        validated_me = me;
         if *client_id == NCSPOT_CLIENT_ID {
           info!(
             "Using ncspot shared client ID. If it breaks in the future, configure fallback_client_id in client.yml."
@@ -456,6 +474,7 @@ async fn authenticate_candidates(
     token_cache_path,
     #[cfg(feature = "streaming")]
     redirect_uri: selected_redirect_uri,
+    me: validated_me,
   })
 }
 

--- a/src/core/sort.rs
+++ b/src/core/sort.rs
@@ -248,6 +248,20 @@ impl SortState {
   }
 }
 
+/// Sort by a precomputed key — one key per item (O(n) allocations) instead of
+/// one per comparison (O(n log n)) — honoring the sort direction. Stable in
+/// both directions: equal keys keep their prior relative order.
+pub fn sort_by_key_with_order<T, K: Ord, F: FnMut(&T) -> K>(
+  items: &mut [T],
+  order: SortOrder,
+  mut key: F,
+) {
+  match order {
+    SortOrder::Ascending => items.sort_by_cached_key(|item| key(item)),
+    SortOrder::Descending => items.sort_by_cached_key(|item| std::cmp::Reverse(key(item))),
+  }
+}
+
 pub struct Sorter {
   state: SortState,
 }

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -709,7 +709,7 @@ pub struct KeyBindingsString {
   generate_recap: Option<String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct KeyBindings {
   pub back: Key,
   pub move_up: Key,

--- a/src/infra/network/friends.rs
+++ b/src/infra/network/friends.rs
@@ -109,6 +109,7 @@ async fn fetch_friends(token: &str) -> Result<Vec<FriendEntry>> {
     .into_iter()
     .map(|u| FriendEntry {
       id: u.id,
+      name_lower: u.name.to_lowercase(),
       name: u.name,
       is_online: u.is_online,
       now_playing: u.now_playing.map(|np| FriendNowPlaying {

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -4,8 +4,7 @@ use super::requests::{
 };
 use super::{IoEvent, Network};
 use crate::core::app::{
-  ActiveBlock, App, PlaylistFolder, PlaylistFolderItem, PlaylistFolderNode, PlaylistFolderNodeType,
-  RouteId,
+  App, PlaylistFolder, PlaylistFolderItem, PlaylistFolderNode, PlaylistFolderNodeType,
 };
 use crate::core::plugin_api::{PlaylistInfo, ShowInfo, TrackInfo};
 use anyhow::anyhow;
@@ -381,6 +380,148 @@ impl Network {
   }
 }
 
+/// Detached body of `fetch_all_playlist_tracks_and_sort`. On a page failure
+/// the error routes through `App::handle_error` exactly as the inline version
+/// did.
+async fn fetch_all_playlist_tracks_and_sort_task(
+  spotify: AuthCodePkceSpotify,
+  app: Arc<Mutex<App>>,
+  token_cache_path: std::path::PathBuf,
+  playlist_id: PlaylistId<'static>,
+) {
+  let mut all_tracks = Vec::new();
+  let mut offset = 0u32;
+  let limit = 50u32;
+  let path = format!("playlists/{}/items", playlist_id.id());
+
+  loop {
+    let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+    match spotify_get_typed_compat_for_with_refresh::<Page<PlaylistItem>>(
+      &spotify,
+      &path,
+      &query,
+      &token_cache_path,
+      &app,
+    )
+    .await
+    {
+      Ok(page) => {
+        if page.items.is_empty() {
+          break;
+        }
+
+        for item in page.items {
+          if let Some(PlayableItem::Track(full_track)) = item.item {
+            all_tracks.push(full_track);
+          }
+        }
+
+        if page.next.is_none() {
+          break;
+        }
+        offset += limit;
+      }
+      Err(e) => {
+        let mut app = app.lock().await;
+        app.handle_error(anyhow!(e));
+        return;
+      }
+    }
+  }
+
+  // Apply sort if any
+  let mut app = app.lock().await;
+
+  use crate::core::sort::Sorter;
+  let sorter = Sorter::new(app.playlist_sort);
+  sorter.sort_tracks(&mut all_tracks);
+  let _ = app.apply_sorted_playlist_tracks_if_current(&playlist_id, all_tracks);
+}
+
+/// Background half of `get_current_user_playlists`: fetch the remaining pages
+/// and the librespot rootlist folder structure, then publish the complete list
+/// (unless a newer refresh superseded this one). A page failure here keeps the
+/// already-published pages instead of error-routing the UI.
+#[allow(clippy::too_many_arguments)]
+async fn finish_playlists_fetch(
+  spotify: AuthCodePkceSpotify,
+  app: Arc<Mutex<App>>,
+  token_cache_path: std::path::PathBuf,
+  mut all_playlists: Vec<PlaylistInfo>,
+  has_more: bool,
+  limit: u32,
+  generation: u64,
+) {
+  if has_more {
+    let mut offset = limit;
+    loop {
+      let page = match spotify_get_typed_compat_for_with_refresh::<Page<SimplifiedPlaylist>>(
+        &spotify,
+        "me/playlists",
+        &[("limit", limit.to_string()), ("offset", offset.to_string())],
+        &token_cache_path,
+        &app,
+      )
+      .await
+      {
+        Ok(page) => page,
+        Err(e) => {
+          log::warn!("background playlist page fetch failed at offset {offset}: {e}");
+          break;
+        }
+      };
+      if page.items.is_empty() {
+        break;
+      }
+      all_playlists.extend(page.items.iter().map(PlaylistInfo::from_simplified));
+      if page.next.is_none() {
+        break;
+      }
+      offset += limit;
+    }
+  }
+
+  #[cfg(feature = "streaming")]
+  let folder_nodes = {
+    let streaming_player = {
+      let app = app.lock().await;
+      app.streaming_player.clone()
+    };
+    fetch_rootlist_folders(streaming_player).await
+  };
+  #[cfg(not(feature = "streaming"))]
+  let folder_nodes: Option<Vec<PlaylistFolderNode>> = None;
+
+  let folder_items = if let Some(ref nodes) = folder_nodes {
+    structurize_playlist_folders(nodes, &all_playlists)
+  } else {
+    build_flat_playlist_items(&all_playlists)
+  };
+
+  let mut app = app.lock().await;
+  if app.playlist_refresh_generation != generation {
+    return;
+  }
+  // Re-read the selection: the user may have navigated since page 1 landed.
+  let preferred_playlist_id = app.get_selected_playlist_id();
+  let preferred_folder_id = app.current_playlist_folder_id;
+  let preferred_selected_index = app.selected_playlist_index;
+
+  app.all_playlists = all_playlists;
+  app
+    .plugin_data_generations
+    .bump(crate::core::app::PluginDataKind::Playlists);
+  app._playlist_folder_nodes = folder_nodes;
+  app.playlist_folder_items = folder_items;
+
+  reconcile_playlist_selection(
+    &mut app,
+    preferred_playlist_id.as_deref(),
+    preferred_folder_id,
+    preferred_selected_index,
+  );
+}
+
 impl LibraryNetwork for Network {
   async fn get_current_user_playlists(&mut self) {
     let (preferred_playlist_id, preferred_folder_id, preferred_selected_index) = {
@@ -393,87 +534,79 @@ impl LibraryNetwork for Network {
     };
 
     let limit = 50u32;
-    let mut offset = 0u32;
-    let mut all_playlists = Vec::new();
-    let mut first_page = None;
 
-    loop {
-      // Always use the compat path: parses raw JSON to serde_json::Value first,
-      // which silently deduplicates keys (last-wins). This handles the known Spotify
-      // API bug where "items" appears twice in the same JSON object.
-      let page = match spotify_get_typed_compat_for_with_refresh::<Page<SimplifiedPlaylist>>(
-        self.spotify(),
-        "me/playlists",
-        &[("limit", limit.to_string()), ("offset", offset.to_string())],
-        &self.token_cache_path,
-        &self.app,
-      )
-      .await
-      {
-        Ok(page) => page,
-        Err(e) => {
-          let mut app = self.app.lock().await;
-          app.pending_playlist_track_search = None;
-          drop(app);
-          self.handle_error(anyhow!(e)).await;
-          return;
-        }
-      };
-
-      if offset == 0 {
-        first_page = Some(page.clone());
+    // Page 1 first: publish it immediately so the sidebar is usable, then
+    // fetch the remaining pages and the rootlist folder structure in a
+    // background task instead of blocking the pump for the whole pagination
+    // (each page pays the pacing floor; 500 playlists used to block startup
+    // dispatches for seconds).
+    //
+    // Always use the compat path: parses raw JSON to serde_json::Value first,
+    // which silently deduplicates keys (last-wins). This handles the known Spotify
+    // API bug where "items" appears twice in the same JSON object.
+    let first_page = match spotify_get_typed_compat_for_with_refresh::<Page<SimplifiedPlaylist>>(
+      self.spotify(),
+      "me/playlists",
+      &[("limit", limit.to_string()), ("offset", "0".to_string())],
+      &self.token_cache_path,
+      &self.app,
+    )
+    .await
+    {
+      Ok(page) => page,
+      Err(e) => {
+        let mut app = self.app.lock().await;
+        app.pending_playlist_track_search = None;
+        drop(app);
+        self.handle_error(anyhow!(e)).await;
+        return;
       }
-
-      if page.items.is_empty() {
-        break;
-      }
-
-      all_playlists.extend(page.items);
-
-      if page.next.is_none() {
-        break;
-      }
-      offset += limit;
-    }
+    };
 
     // Convert to source-agnostic domain types at the network boundary.
-    let all_playlists: Vec<PlaylistInfo> = all_playlists
+    let first_items: Vec<PlaylistInfo> = first_page
+      .items
       .iter()
       .map(PlaylistInfo::from_simplified)
       .collect();
-    let first_page = first_page.map(|page| map_page(&page, PlaylistInfo::from_simplified));
+    let has_more = first_page.next.is_some() && !first_page.items.is_empty();
+    let mapped_first = map_page(&first_page, PlaylistInfo::from_simplified);
 
-    #[cfg(feature = "streaming")]
-    let streaming_player = {
-      let app = self.app.lock().await;
-      app.streaming_player.clone()
+    let generation = {
+      let mut app = self.app.lock().await;
+      app.playlist_refresh_generation = app.playlist_refresh_generation.wrapping_add(1);
+      app.playlists = Some(mapped_first);
+      app.all_playlists = first_items.clone();
+      app
+        .plugin_data_generations
+        .bump(crate::core::app::PluginDataKind::Playlists);
+      // Flat items for now; the folder structure is reconciled when the
+      // background fetch delivers the rootlist.
+      app.playlist_folder_items = build_flat_playlist_items(&first_items);
+      reconcile_playlist_selection(
+        &mut app,
+        preferred_playlist_id.as_deref(),
+        preferred_folder_id,
+        preferred_selected_index,
+      );
+      app.playlist_refresh_generation
     };
-    #[cfg(feature = "streaming")]
-    let folder_nodes = fetch_rootlist_folders(streaming_player).await;
-    #[cfg(not(feature = "streaming"))]
-    let folder_nodes: Option<Vec<PlaylistFolderNode>> = None;
 
-    let folder_items = if let Some(ref nodes) = folder_nodes {
-      structurize_playlist_folders(nodes, &all_playlists)
-    } else {
-      build_flat_playlist_items(&all_playlists)
-    };
-
-    let mut app = self.app.lock().await;
-    app.playlists = first_page;
-    app.all_playlists = all_playlists;
-    app
-      .plugin_data_generations
-      .bump(crate::core::app::PluginDataKind::Playlists);
-    app._playlist_folder_nodes = folder_nodes;
-    app.playlist_folder_items = folder_items;
-
-    reconcile_playlist_selection(
-      &mut app,
-      preferred_playlist_id.as_deref(),
-      preferred_folder_id,
-      preferred_selected_index,
-    );
+    let spotify = self.spotify().clone();
+    let app = Arc::clone(&self.app);
+    let token_cache_path = self.token_cache_path.clone();
+    tokio::spawn(async move {
+      finish_playlists_fetch(
+        spotify,
+        app,
+        token_cache_path,
+        first_items,
+        has_more,
+        limit,
+        generation,
+      )
+      .await;
+    });
   }
 
   async fn get_playlist_tracks(&mut self, playlist_id: PlaylistId<'static>, playlist_offset: u32) {
@@ -500,6 +633,9 @@ impl LibraryNetwork for Network {
         app
           .playlist_tracks_prefetch_in_flight
           .remove(&playlist_offset);
+        if app.pending_playlist_open.as_deref() == Some(playlist_id.id()) {
+          app.pending_playlist_open = None;
+        }
         if app.playlist_tracks_prefetch_generation != generation
           || !app.is_playlist_track_table_active_for(&playlist_id)
         {
@@ -513,7 +649,8 @@ impl LibraryNetwork for Network {
 
         let next_offset = app.next_missing_playlist_tracks_offset(playlist_tracks_index);
         let generation = app.playlist_tracks_prefetch_generation;
-        app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+        // Navigation happens in the handler when the user opens the playlist
+        // (`App::open_playlist_tracks`), not here on response arrival.
         drop(app);
 
         if let Some(next_offset) = next_offset {
@@ -525,6 +662,9 @@ impl LibraryNetwork for Network {
         app
           .playlist_tracks_prefetch_in_flight
           .remove(&playlist_offset);
+        if app.pending_playlist_open.as_deref() == Some(playlist_id.id()) {
+          app.pending_playlist_open = None;
+        }
         drop(app);
         self.handle_error(anyhow!(e)).await;
       }
@@ -977,52 +1117,16 @@ impl LibraryNetwork for Network {
   }
 
   async fn fetch_all_playlist_tracks_and_sort(&mut self, playlist_id: PlaylistId<'static>) {
-    let mut all_tracks = Vec::new();
-    let mut offset = 0u32;
-    let limit = 50u32;
-    let path = format!("playlists/{}/items", playlist_id.id());
-
-    loop {
-      let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
-      match spotify_get_typed_compat_for_with_refresh::<Page<PlaylistItem>>(
-        self.spotify(),
-        &path,
-        &query,
-        &self.token_cache_path,
-        &self.app,
-      )
-      .await
-      {
-        Ok(page) => {
-          if page.items.is_empty() {
-            break;
-          }
-
-          for item in page.items {
-            if let Some(PlayableItem::Track(full_track)) = item.item {
-              all_tracks.push(full_track);
-            }
-          }
-
-          if page.next.is_none() {
-            break;
-          }
-          offset += limit;
-        }
-        Err(e) => {
-          self.handle_error(anyhow!(e)).await;
-          return;
-        }
-      }
-    }
-
-    // Apply sort if any
-    let mut app = self.app.lock().await;
-
-    use crate::core::sort::Sorter;
-    let sorter = Sorter::new(app.playlist_sort);
-    sorter.sort_tracks(&mut all_tracks);
-    let _ = app.apply_sorted_playlist_tracks_if_current(&playlist_id, all_tracks);
+    // The full pagination pays the pacing floor per page (a 3,000-track
+    // playlist is 60 pages, 15s+), so it runs detached instead of
+    // head-of-line-blocking playback controls and polling on the serial pump.
+    // `apply_sorted_playlist_tracks_if_current` already guards a stale result.
+    let spotify = self.spotify().clone();
+    let app = Arc::clone(&self.app);
+    let token_cache_path = self.token_cache_path.clone();
+    tokio::spawn(async move {
+      fetch_all_playlist_tracks_and_sort_task(spotify, app, token_cache_path, playlist_id).await;
+    });
   }
 
   async fn create_new_playlist(&mut self, name: String, track_ids: Vec<TrackId<'static>>) {

--- a/src/infra/network/library.rs
+++ b/src/infra/network/library.rs
@@ -389,12 +389,22 @@ async fn fetch_all_playlist_tracks_and_sort_task(
   token_cache_path: std::path::PathBuf,
   playlist_id: PlaylistId<'static>,
 ) {
+  let playlist_id_string = playlist_id.id().to_string();
   let mut all_tracks = Vec::new();
   let mut offset = 0u32;
   let limit = 50u32;
   let path = format!("playlists/{}/items", playlist_id.id());
 
   loop {
+    {
+      let mut app = app.lock().await;
+      if !app.is_playlist_track_table_active_for(&playlist_id) {
+        app
+          .playlist_sort_fetch_in_flight
+          .remove(&playlist_id_string);
+        return;
+      }
+    }
     let query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
     match spotify_get_typed_compat_for_with_refresh::<Page<PlaylistItem>>(
       &spotify,
@@ -423,6 +433,9 @@ async fn fetch_all_playlist_tracks_and_sort_task(
       }
       Err(e) => {
         let mut app = app.lock().await;
+        app
+          .playlist_sort_fetch_in_flight
+          .remove(&playlist_id_string);
         app.handle_error(anyhow!(e));
         return;
       }
@@ -431,6 +444,9 @@ async fn fetch_all_playlist_tracks_and_sort_task(
 
   // Apply sort if any
   let mut app = app.lock().await;
+  app
+    .playlist_sort_fetch_in_flight
+    .remove(&playlist_id_string);
 
   use crate::core::sort::Sorter;
   let sorter = Sorter::new(app.playlist_sort);
@@ -451,25 +467,48 @@ async fn finish_playlists_fetch(
   has_more: bool,
   limit: u32,
   generation: u64,
+  original_selection: (Option<String>, usize, Option<usize>),
+  page_one_selection: (Option<String>, usize, Option<usize>),
+  previous_complete: (
+    Vec<PlaylistInfo>,
+    Option<Vec<PlaylistFolderNode>>,
+    Vec<PlaylistFolderItem>,
+  ),
 ) {
+  let mut pagination_error = None;
   if has_more {
     let mut offset = limit;
     loop {
-      let page = match spotify_get_typed_compat_for_with_refresh::<Page<SimplifiedPlaylist>>(
-        &spotify,
-        "me/playlists",
-        &[("limit", limit.to_string()), ("offset", offset.to_string())],
-        &token_cache_path,
-        &app,
-      )
-      .await
       {
-        Ok(page) => page,
-        Err(e) => {
-          log::warn!("background playlist page fetch failed at offset {offset}: {e}");
-          break;
+        let app = app.lock().await;
+        if app.playlist_refresh_generation != generation {
+          return;
+        }
+      }
+      let mut attempts = 0u8;
+      let page = loop {
+        match spotify_get_typed_compat_for_with_refresh::<Page<SimplifiedPlaylist>>(
+          &spotify,
+          "me/playlists",
+          &[("limit", limit.to_string()), ("offset", offset.to_string())],
+          &token_cache_path,
+          &app,
+        )
+        .await
+        {
+          Ok(page) => break Some(page),
+          Err(e) if attempts < 2 => {
+            attempts += 1;
+            log::warn!("playlist page fetch failed at offset {offset}; retry {attempts}/2: {e}");
+            tokio::time::sleep(Duration::from_millis(250 * u64::from(attempts))).await;
+          }
+          Err(e) => {
+            pagination_error = Some(e.to_string());
+            break None;
+          }
         }
       };
+      let Some(page) = page else { break };
       if page.items.is_empty() {
         break;
       }
@@ -479,6 +518,28 @@ async fn finish_playlists_fetch(
       }
       offset += limit;
     }
+  }
+
+  if let Some(error) = pagination_error {
+    log::warn!("playlist refresh incomplete: {error}");
+    let mut app = app.lock().await;
+    if app.playlist_refresh_generation != generation {
+      return;
+    }
+    let (previous_playlists, previous_nodes, previous_items) = previous_complete;
+    if !previous_playlists.is_empty() {
+      app.all_playlists = previous_playlists;
+      app._playlist_folder_nodes = previous_nodes;
+      app.playlist_folder_items = previous_items;
+      reconcile_playlist_selection(
+        &mut app,
+        original_selection.0.as_deref(),
+        original_selection.1,
+        original_selection.2,
+      );
+    }
+    app.set_status_message("Playlist refresh incomplete; kept the previous list.", 8);
+    return;
   }
 
   #[cfg(feature = "streaming")]
@@ -502,10 +563,18 @@ async fn finish_playlists_fetch(
   if app.playlist_refresh_generation != generation {
     return;
   }
-  // Re-read the selection: the user may have navigated since page 1 landed.
-  let preferred_playlist_id = app.get_selected_playlist_id();
-  let preferred_folder_id = app.current_playlist_folder_id;
-  let preferred_selected_index = app.selected_playlist_index;
+  // Restore the original selection only if the user has not navigated since
+  // page 1 was published. Otherwise their newer choice wins.
+  let current_selection = (
+    app.get_selected_playlist_id(),
+    app.current_playlist_folder_id,
+    app.selected_playlist_index,
+  );
+  let preferred = if current_selection == page_one_selection {
+    original_selection
+  } else {
+    current_selection
+  };
 
   app.all_playlists = all_playlists;
   app
@@ -514,17 +583,12 @@ async fn finish_playlists_fetch(
   app._playlist_folder_nodes = folder_nodes;
   app.playlist_folder_items = folder_items;
 
-  reconcile_playlist_selection(
-    &mut app,
-    preferred_playlist_id.as_deref(),
-    preferred_folder_id,
-    preferred_selected_index,
-  );
+  reconcile_playlist_selection(&mut app, preferred.0.as_deref(), preferred.1, preferred.2);
 }
 
 impl LibraryNetwork for Network {
   async fn get_current_user_playlists(&mut self) {
-    let (preferred_playlist_id, preferred_folder_id, preferred_selected_index) = {
+    let original_selection = {
       let app = self.app.lock().await;
       (
         app.get_selected_playlist_id(),
@@ -572,24 +636,52 @@ impl LibraryNetwork for Network {
     let has_more = first_page.next.is_some() && !first_page.items.is_empty();
     let mapped_first = map_page(&first_page, PlaylistInfo::from_simplified);
 
-    let generation = {
+    let (generation, page_one_selection, previous_complete) = {
       let mut app = self.app.lock().await;
+      let had_previous_complete = !app.all_playlists.is_empty();
+      // Snapshot the existing complete list only when background pagination can
+      // fail partway (`has_more`) and there is something worth restoring. A
+      // single-page refresh or a first-ever load never uses this, so skip the
+      // clone in the common case.
+      let previous_complete = if has_more && had_previous_complete {
+        (
+          app.all_playlists.clone(),
+          app._playlist_folder_nodes.clone(),
+          app.playlist_folder_items.clone(),
+        )
+      } else {
+        (Vec::new(), None, Vec::new())
+      };
       app.playlist_refresh_generation = app.playlist_refresh_generation.wrapping_add(1);
       app.playlists = Some(mapped_first);
-      app.all_playlists = first_items.clone();
-      app
-        .plugin_data_generations
-        .bump(crate::core::app::PluginDataKind::Playlists);
-      // Flat items for now; the folder structure is reconciled when the
-      // background fetch delivers the rootlist.
-      app.playlist_folder_items = build_flat_playlist_items(&first_items);
-      reconcile_playlist_selection(
-        &mut app,
-        preferred_playlist_id.as_deref(),
-        preferred_folder_id,
-        preferred_selected_index,
+      let selected_is_in_first_page = original_selection.0.as_ref().is_some_and(|selected| {
+        first_items
+          .iter()
+          .any(|playlist| playlist.id.as_deref() == Some(selected.as_str()))
+      });
+      if !had_previous_complete || original_selection.0.is_none() || selected_is_in_first_page {
+        app.all_playlists = first_items.clone();
+        app
+          .plugin_data_generations
+          .bump(crate::core::app::PluginDataKind::Playlists);
+        app.playlist_folder_items = build_flat_playlist_items(&first_items);
+        reconcile_playlist_selection(
+          &mut app,
+          original_selection.0.as_deref(),
+          original_selection.1,
+          original_selection.2,
+        );
+      }
+      let page_one_selection = (
+        app.get_selected_playlist_id(),
+        app.current_playlist_folder_id,
+        app.selected_playlist_index,
       );
-      app.playlist_refresh_generation
+      (
+        app.playlist_refresh_generation,
+        page_one_selection,
+        previous_complete,
+      )
     };
 
     let spotify = self.spotify().clone();
@@ -604,6 +696,9 @@ impl LibraryNetwork for Network {
         has_more,
         limit,
         generation,
+        original_selection,
+        page_one_selection,
+        previous_complete,
       )
       .await;
     });
@@ -1121,6 +1216,15 @@ impl LibraryNetwork for Network {
     // playlist is 60 pages, 15s+), so it runs detached instead of
     // head-of-line-blocking playback controls and polling on the serial pump.
     // `apply_sorted_playlist_tracks_if_current` already guards a stale result.
+    {
+      let mut app = self.app.lock().await;
+      if !app
+        .playlist_sort_fetch_in_flight
+        .insert(playlist_id.id().to_string())
+      {
+        return;
+      }
+    }
     let spotify = self.spotify().clone();
     let app = Arc::clone(&self.app);
     let token_cache_path = self.token_cache_path.clone();

--- a/src/infra/network/metadata.rs
+++ b/src/infra/network/metadata.rs
@@ -18,6 +18,60 @@ use rspotify::model::{
 use rspotify::prelude::*;
 use serde::Deserialize;
 
+/// Minimal id-keyed TTL cache for metadata responses, so re-entering the same
+/// album/artist from a list within the TTL doesn't pay a fresh round trip plus
+/// the pacing tax. Deliberately tiny: no LRU crate, oldest-entry eviction at
+/// capacity, entries expire on read.
+pub(super) struct MetadataTtlCache<T> {
+  entries: std::collections::HashMap<String, (std::time::Instant, T)>,
+}
+
+const METADATA_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+const METADATA_CACHE_CAP: usize = 32;
+
+impl<T> Default for MetadataTtlCache<T> {
+  fn default() -> Self {
+    Self {
+      entries: std::collections::HashMap::new(),
+    }
+  }
+}
+
+impl<T: Clone> MetadataTtlCache<T> {
+  pub(super) fn get(&mut self, key: &str) -> Option<T> {
+    match self.entries.get(key) {
+      Some((stored_at, value)) if stored_at.elapsed() < METADATA_CACHE_TTL => Some(value.clone()),
+      Some(_) => {
+        self.entries.remove(key);
+        None
+      }
+      None => None,
+    }
+  }
+
+  pub(super) fn put(&mut self, key: String, value: T) {
+    if self.entries.len() >= METADATA_CACHE_CAP && !self.entries.contains_key(&key) {
+      if let Some(oldest) = self
+        .entries
+        .iter()
+        .min_by_key(|(_, (stored_at, _))| *stored_at)
+        .map(|(k, _)| k.clone())
+      {
+        self.entries.remove(&oldest);
+      }
+    }
+    self.entries.insert(key, (std::time::Instant::now(), value));
+  }
+}
+
+/// The raw responses `get_artist` assembles, cached as one unit.
+#[derive(Clone)]
+pub(super) struct CachedArtistData {
+  top_tracks: Vec<FullTrack>,
+  related_artists: Vec<FullArtist>,
+  album_items: Vec<SimplifiedAlbum>,
+}
+
 #[derive(Deserialize)]
 struct ArtistTopTracksResponse {
   tracks: Vec<FullTrack>,
@@ -94,66 +148,85 @@ impl MetadataNetwork for Network {
     country: Option<Country>,
   ) {
     let artist_id_str = artist_id.id().to_string();
-    let artist_path = format!("artists/{}", artist_id.id());
-    let top_tracks_path = format!("{}/top-tracks", artist_path);
-    let related_artists_path = format!("{}/related-artists", artist_path);
-    let mut top_tracks_query = Vec::new();
-    if let Some(country) = country {
-      top_tracks_query.push(("market", country_code(country)));
-    }
+    let cache_key = format!("{}:{:?}", artist_id_str, country);
 
-    let (top_tracks_res, related_artists_res) = tokio::join!(
-      self.spotify_get_typed::<ArtistTopTracksResponse>(&top_tracks_path, &top_tracks_query),
-      self.spotify_get_typed::<RelatedArtistsResponse>(&related_artists_path, &[])
-    );
-
-    let top_tracks = match top_tracks_res {
-      Ok(res) => res.tracks,
-      Err(e) => {
-        self.handle_error(anyhow!(e)).await;
-        return;
-      }
-    };
-    let related_artists = match related_artists_res {
-      Ok(res) => res.artists,
-      Err(e) => {
-        self.handle_error(anyhow!(e)).await;
-        return;
-      }
-    };
-
-    let mut album_items = Vec::new();
-    let mut offset = 0u32;
-    let limit = 50u32;
-    loop {
-      let mut query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+    let cached = self.artist_cache.get(&cache_key);
+    let CachedArtistData {
+      top_tracks,
+      related_artists,
+      album_items,
+    } = if let Some(data) = cached {
+      data
+    } else {
+      let artist_path = format!("artists/{}", artist_id.id());
+      let top_tracks_path = format!("{}/top-tracks", artist_path);
+      let related_artists_path = format!("{}/related-artists", artist_path);
+      let mut top_tracks_query = Vec::new();
       if let Some(country) = country {
-        query.push(("market", country_code(country)));
+        top_tracks_query.push(("market", country_code(country)));
       }
-      let page = match self
-        .spotify_get_typed::<Page<SimplifiedAlbum>>(&format!("{}/albums", artist_path), &query)
-        .await
-      {
-        Ok(page) => page,
+
+      let (top_tracks_res, related_artists_res) = tokio::join!(
+        self.spotify_get_typed::<ArtistTopTracksResponse>(&top_tracks_path, &top_tracks_query),
+        self.spotify_get_typed::<RelatedArtistsResponse>(&related_artists_path, &[])
+      );
+
+      let top_tracks = match top_tracks_res {
+        Ok(res) => res.tracks,
         Err(e) => {
           self.handle_error(anyhow!(e)).await;
           return;
         }
       };
-      let next = page.next.is_some();
-      album_items.extend(page.items);
-      if !next {
-        break;
+      let related_artists = match related_artists_res {
+        Ok(res) => res.artists,
+        Err(e) => {
+          self.handle_error(anyhow!(e)).await;
+          return;
+        }
+      };
+
+      let mut album_items = Vec::new();
+      let mut offset = 0u32;
+      let limit = 50u32;
+      loop {
+        let mut query = vec![("limit", limit.to_string()), ("offset", offset.to_string())];
+        if let Some(country) = country {
+          query.push(("market", country_code(country)));
+        }
+        let page = match self
+          .spotify_get_typed::<Page<SimplifiedAlbum>>(&format!("{}/albums", artist_path), &query)
+          .await
+        {
+          Ok(page) => page,
+          Err(e) => {
+            self.handle_error(anyhow!(e)).await;
+            return;
+          }
+        };
+        let next = page.next.is_some();
+        album_items.extend(page.items);
+        if !next {
+          break;
+        }
+        offset += limit;
       }
-      offset += limit;
-    }
+
+      let data = CachedArtistData {
+        top_tracks,
+        related_artists,
+        album_items,
+      };
+      self.artist_cache.put(cache_key, data.clone());
+      data
+    };
 
     // Convert rspotify types to domain types before storing — conversion stays
     // inside infra/network per the multi-source boundary contract.
     let albums_rspotify_page = Page {
       items: album_items,
       href: String::new(),
-      limit,
+      limit: 50,
       next: None,
       offset: 0,
       previous: None,
@@ -209,7 +282,19 @@ impl MetadataNetwork for Network {
   async fn get_album_tracks(&mut self, album: Box<SimplifiedAlbum>) {
     let album_id = album.id.clone();
     if let Some(id) = album_id {
-      match fetch_album_tracks_from(self, id.id(), 0).await {
+      let fetched = match self.album_tracks_cache.get(id.id()) {
+        Some(tracks) => Ok(tracks),
+        None => match fetch_album_tracks_from(self, id.id(), 0).await {
+          Ok(tracks) => {
+            self
+              .album_tracks_cache
+              .put(id.id().to_string(), tracks.clone());
+            Ok(tracks)
+          }
+          Err(e) => Err(e),
+        },
+      };
+      match fetched {
         Ok(track_items) => {
           let album_info = crate::core::plugin_api::AlbumInfo::from(album.as_ref());
           // Check if these tracks are liked (before `track_items` is consumed).
@@ -243,23 +328,34 @@ impl MetadataNetwork for Network {
   }
 
   async fn get_album(&mut self, album_id: AlbumId<'static>) {
-    match self
-      .spotify_get_typed::<FullAlbum>(&format!("albums/{}", album_id.id()), &[])
-      .await
-    {
+    let fetched = if let Some(album) = self.album_cache.get(album_id.id()) {
+      Ok(album)
+    } else {
+      self
+        .spotify_get_typed::<FullAlbum>(&format!("albums/{}", album_id.id()), &[])
+        .await
+    };
+    match fetched {
       Ok(mut album) => {
         // A full album embeds only the first page of its tracklist (50 tracks
         // max); fetch the rest so longer albums render completely.
         if album.tracks.next.is_some() {
           let offset = album.tracks.items.len() as u32;
           match fetch_album_tracks_from(self, album_id.id(), offset).await {
-            Ok(rest) => album.tracks.items.extend(rest),
+            Ok(rest) => {
+              album.tracks.items.extend(rest);
+              // Mark the tracklist complete so a cache hit doesn't re-page.
+              album.tracks.next = None;
+            }
             Err(e) => {
               self.handle_error(anyhow!(e)).await;
               return;
             }
           }
         }
+        self
+          .album_cache
+          .put(album_id.id().to_string(), album.clone());
         let album_info = crate::core::plugin_api::AlbumInfo::from(&album);
         let mut app = self.app.lock().await;
         // Check if these tracks are liked.

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -410,6 +410,9 @@ impl Network {
   /// Keep in sync with the handlers: an event listed here MUST NOT read or
   /// write anything on `Network` besides `app`.
   pub fn runs_on_service_lane(io_event: &IoEvent) -> bool {
+    if !Self::event_bypasses_spotify_auth(io_event) {
+      return false;
+    }
     #[cfg(feature = "cover-art")]
     if matches!(io_event, IoEvent::FetchCoverArt(_)) {
       return true;
@@ -433,6 +436,10 @@ impl Network {
 
   #[allow(clippy::cognitive_complexity)]
   pub async fn handle_network_event(&mut self, io_event: IoEvent) {
+    let pending_playlist_id = match &io_event {
+      IoEvent::GetPlaylistItems(id, _) => Some(id.clone()),
+      _ => None,
+    };
     // Events whose handlers never touch the Spotify client run regardless of
     // whether a Spotify session exists (see `event_bypasses_spotify_auth`).
     // Everything else is Spotify-bound: when launched against a free source with
@@ -450,9 +457,21 @@ impl Network {
           .await;
         let mut app = self.app.lock().await;
         app.is_loading = false;
+        if pending_playlist_id
+          .as_deref()
+          .is_some_and(|id| app.pending_playlist_open.as_deref() == Some(id))
+        {
+          app.pending_playlist_open = None;
+        }
         return;
       }
       if !self.ensure_authentication_fresh(false).await {
+        if let Some(id) = pending_playlist_id.as_deref() {
+          let mut app = self.app.lock().await;
+          if app.pending_playlist_open.as_deref() == Some(id) {
+            app.pending_playlist_open = None;
+          }
+        }
         return;
       }
     }
@@ -486,6 +505,12 @@ impl Network {
       IoEvent::GetPlaylistItems(playlist_id, playlist_offset) => {
         if let Some(id) = ids::playlist_id(&playlist_id) {
           self.get_playlist_tracks(id, playlist_offset).await;
+        } else {
+          let mut app = self.app.lock().await;
+          if app.pending_playlist_open.as_deref() == Some(playlist_id.as_str()) {
+            app.pending_playlist_open = None;
+          }
+          app.set_status_message("Invalid playlist identifier.", 5);
         }
       }
       IoEvent::SearchPlaylistTracks(playlist_id, query) => {
@@ -1499,6 +1524,29 @@ mod tests {
     ))
   }
 
+  #[test]
+  fn every_service_lane_event_bypasses_spotify_auth() {
+    use crate::infra::history::RecapPeriod;
+    let events = [
+      IoEvent::FetchGlobalSongCount,
+      IoEvent::IncrementGlobalSongCount,
+      IoEvent::FetchAnnouncements,
+      IoEvent::GetLyrics(String::new(), String::new(), 0.0),
+      IoEvent::GetFriendCode,
+      IoEvent::GetFriends,
+      IoEvent::AddFriendByCode(String::new()),
+      IoEvent::AddFriendByUserId(String::new()),
+      IoEvent::UnfollowFriend(String::new()),
+      IoEvent::SearchFriendUsers(String::new()),
+      IoEvent::LoadListeningStats(RecapPeriod::SevenDays),
+      IoEvent::GenerateRecap(RecapPeriod::SevenDays),
+    ];
+    for event in events {
+      assert!(Network::runs_on_service_lane(&event));
+      assert!(Network::event_bypasses_spotify_auth(&event));
+    }
+  }
+
   #[tokio::test]
   async fn pre_event_auth_failure_clears_loading_state() {
     let expired_token_without_refresh = Token {
@@ -1536,5 +1584,23 @@ mod tests {
     assert!(!app.auth_refresh_in_progress);
 
     let _ = std::fs::remove_file(token_cache_path);
+  }
+
+  #[tokio::test]
+  async fn auth_gate_clears_pending_playlist_open() {
+    let (io_tx, _io_rx) = std::sync::mpsc::channel();
+    let app = Arc::new(Mutex::new(App::new(
+      io_tx,
+      UserConfig::new(),
+      Some(SystemTime::now()),
+    )));
+    app.lock().await.pending_playlist_open = Some("playlist-id".to_string());
+    let mut network = Network::new(None, ClientConfig::new(), &app, temp_token_cache_path());
+
+    network
+      .handle_network_event(IoEvent::GetPlaylistItems("playlist-id".to_string(), 0))
+      .await;
+
+    assert!(app.lock().await.pending_playlist_open.is_none());
   }
 }

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -278,6 +278,11 @@ pub struct Network {
   pub token_cache_path: PathBuf,
   /// In-flight in-TUI Spotify login, if any (see `begin_spotify_login`).
   pending_login: Option<PendingLogin>,
+  /// TTL caches so re-visiting the same artist/album skips the round trip +
+  /// pacing tax (see `metadata::MetadataTtlCache`).
+  artist_cache: metadata::MetadataTtlCache<metadata::CachedArtistData>,
+  album_cache: metadata::MetadataTtlCache<rspotify::model::album::FullAlbum>,
+  album_tracks_cache: metadata::MetadataTtlCache<Vec<rspotify::model::track::SimplifiedTrack>>,
 }
 
 impl Network {
@@ -299,6 +304,9 @@ impl Network {
       party_incoming_rx: None,
       token_cache_path,
       pending_login: None,
+      artist_cache: Default::default(),
+      album_cache: Default::default(),
+      album_tracks_cache: Default::default(),
     }
   }
 
@@ -319,6 +327,9 @@ impl Network {
       party_incoming_rx: None,
       token_cache_path,
       pending_login: None,
+      artist_cache: Default::default(),
+      album_cache: Default::default(),
+      album_tracks_cache: Default::default(),
     }
   }
 
@@ -387,6 +398,36 @@ impl Network {
         | IoEvent::DeleteYouTubePlaylist(_)
         | IoEvent::AddTrackToYouTubePlaylist(..)
         | IoEvent::RemoveTrackFromYouTubePlaylist(..)
+    )
+  }
+
+  /// Events that run on the concurrent service lane in `start_tokio`: a strict
+  /// subset of [`Self::event_bypasses_spotify_auth`] whose handlers touch only
+  /// `self.app` (plus their own HTTP clients / `spawn_blocking`) — never the
+  /// Spotify client, API pacing, or `Network` state (party connection, pending
+  /// login, search limits) — so they can execute on a detached task with a
+  /// throwaway `Network` instead of head-of-line-blocking the serial pump.
+  /// Keep in sync with the handlers: an event listed here MUST NOT read or
+  /// write anything on `Network` besides `app`.
+  pub fn runs_on_service_lane(io_event: &IoEvent) -> bool {
+    #[cfg(feature = "cover-art")]
+    if matches!(io_event, IoEvent::FetchCoverArt(_)) {
+      return true;
+    }
+    matches!(
+      io_event,
+      IoEvent::FetchGlobalSongCount
+        | IoEvent::IncrementGlobalSongCount
+        | IoEvent::FetchAnnouncements
+        | IoEvent::GetLyrics(..)
+        | IoEvent::GetFriendCode
+        | IoEvent::GetFriends
+        | IoEvent::AddFriendByCode(_)
+        | IoEvent::AddFriendByUserId(_)
+        | IoEvent::UnfollowFriend(_)
+        | IoEvent::SearchFriendUsers(_)
+        | IoEvent::LoadListeningStats(_)
+        | IoEvent::GenerateRecap(_)
     )
   }
 

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1062,6 +1062,9 @@ impl PlaybackNetwork for Network {
     // (e.g. consecutive tracks that share an album cover): just mark it loaded.
     {
       let mut app = self.app.lock().await;
+      if app.desired_cover_art_key.as_deref() != Some(key.as_str()) {
+        return;
+      }
       if app.cover_art.get_url().as_deref() == Some(key.as_str()) {
         app.cover_art_status = CoverArtStatus::Loaded;
         return;
@@ -1085,6 +1088,9 @@ impl PlaybackNetwork for Network {
     };
 
     let mut app = self.app.lock().await;
+    if app.desired_cover_art_key.as_deref() != Some(key.as_str()) {
+      return;
+    }
     match result {
       Ok(img) => {
         app.cover_art.store_decoded(key, img);
@@ -1490,6 +1496,12 @@ impl PlaybackNetwork for Network {
   }
 
   async fn pause_playback(&mut self) {
+    #[cfg(feature = "streaming")]
+    {
+      let mut app = self.app.lock().await;
+      app.pending_start_playback = None;
+      app.native_load_watchdog = None;
+    }
     // Check if using native streaming
     #[cfg(feature = "streaming")]
     if let PlaybackBackend::Native(player) = symmetric_playback_backend(self).await {
@@ -1525,6 +1537,12 @@ impl PlaybackNetwork for Network {
 
   async fn next_track(&mut self) {
     #[cfg(feature = "streaming")]
+    {
+      let mut app = self.app.lock().await;
+      app.pending_start_playback = None;
+      app.native_load_watchdog = None;
+    }
+    #[cfg(feature = "streaming")]
     if let PlaybackBackend::Native(player) = symmetric_playback_backend(self).await {
       player.next();
       return;
@@ -1544,6 +1562,12 @@ impl PlaybackNetwork for Network {
   }
 
   async fn previous_track(&mut self) {
+    #[cfg(feature = "streaming")]
+    {
+      let mut app = self.app.lock().await;
+      app.pending_start_playback = None;
+      app.native_load_watchdog = None;
+    }
     #[cfg(feature = "streaming")]
     if let PlaybackBackend::Native(player) = symmetric_playback_backend(self).await {
       player.prev();

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -9,7 +9,7 @@ use crate::infra::player::{select_native, PlaybackBackend};
 use anyhow::anyhow;
 use chrono::TimeDelta;
 #[cfg(feature = "streaming")]
-use log::info;
+use log::{info, warn};
 use reqwest::Method;
 #[cfg(feature = "streaming")]
 use rspotify::model::device::DevicePayload;
@@ -383,6 +383,24 @@ fn spotify_payload_confirms_native_device(payload: &DevicePayload, native_device
 fn is_no_active_device_error(e: &anyhow::Error) -> bool {
   let text = e.to_string().to_ascii_lowercase();
   text.contains("no_active_device") || text.contains("no active device")
+}
+
+/// While a native backend is expected to materialize (recovery in flight, or
+/// the deferred startup init still running), a transport command that 404s
+/// with NO_ACTIVE_DEVICE is expected noise — surface a status message instead
+/// of routing to the full-screen Error. Returns true when the error was
+/// handled that way.
+#[cfg(feature = "streaming")]
+async fn suppressed_no_device_error_while_pending(network: &Network, e: &anyhow::Error) -> bool {
+  if !is_no_active_device_error(e) {
+    return false;
+  }
+  let mut app = network.app.lock().await;
+  if !app.native_backend_pending {
+    return false;
+  }
+  app.set_status_message("Reconnecting native streaming…", 5);
+  true
 }
 
 fn api_confirms_native_info_is_current(
@@ -1112,6 +1130,17 @@ impl PlaybackNetwork for Network {
     // Check if we should use native streaming for playback
     #[cfg(feature = "streaming")]
     if request_native_streaming_recovery_if_disconnected(self).await {
+      // Park the request instead of dropping it: the recovery handler replays
+      // it once the new session and device selection are in place, so the
+      // press that detected the disconnect still plays.
+      let mut app = self.app.lock().await;
+      app.park_start_playback(
+        context_id.as_ref().map(|c| c.uri()),
+        uris
+          .as_ref()
+          .map(|list| list.iter().map(|u| u.uri()).collect()),
+        offset,
+      );
       return;
     }
 
@@ -1149,7 +1178,11 @@ impl PlaybackNetwork for Network {
       };
 
       if should_transfer {
-        let _ = player.transfer(None);
+        // A failed transfer on a zombie session used to vanish silently; the
+        // load watchdog below is the recovery net, but keep the evidence.
+        if let Err(e) = player.transfer(None) {
+          warn!("native transfer failed: {e}");
+        }
       }
 
       player.activate();
@@ -1274,6 +1307,13 @@ impl PlaybackNetwork for Network {
         }
       }
 
+      // Keep the string form for the load watchdog: if the session turns out
+      // to be a zombie (load accepted, no player event follows), recovery
+      // replays this exact request.
+      let parked_context = context_id.as_ref().map(|c| c.uri());
+      let parked_uris = uris
+        .as_ref()
+        .map(|list| list.iter().map(|u| u.uri()).collect::<Vec<_>>());
       let Some(request) = native_load_request(context_id, uris, offset) else {
         return;
       };
@@ -1284,8 +1324,11 @@ impl PlaybackNetwork for Network {
         app.handle_error(anyhow!("Failed to start native playback: {}", e));
       } else {
         let _ = player.set_shuffle(desired_shuffle_state);
-        // Optimistic UI update
+        // Optimistic UI update; the watchdog corrects it if no player event
+        // ever confirms the load (zombie session).
         let mut app = self.app.lock().await;
+        app.park_start_playback(parked_context, parked_uris, offset);
+        app.native_load_watchdog = Some(Instant::now());
         if let Some(ctx) = &mut app.current_playback_context {
           ctx.is_playing = true;
           ctx.shuffle_state = desired_shuffle_state;
@@ -1363,6 +1406,10 @@ impl PlaybackNetwork for Network {
                 );
               }
 
+              let parked_context = context_id.as_ref().map(|c| c.uri());
+              let parked_uris = uris
+                .as_ref()
+                .map(|list| list.iter().map(|u| u.uri()).collect::<Vec<_>>());
               if let Some(request) = native_load_request(context_id, uris, offset) {
                 info!("default Spotify playback had no active device; falling back to native load");
                 if let Err(load_err) = player.load(request) {
@@ -1371,6 +1418,9 @@ impl PlaybackNetwork for Network {
                 } else {
                   let _ = player.set_shuffle(desired_shuffle_state);
                   let mut app = self.app.lock().await;
+                  // Same zombie-session net as the direct load route.
+                  app.park_start_playback(parked_context, parked_uris, offset);
+                  app.native_load_watchdog = Some(Instant::now());
                   if let Some(ctx) = &mut app.current_playback_context {
                     ctx.is_playing = true;
                     ctx.shuffle_state = desired_shuffle_state;
@@ -1412,6 +1462,25 @@ impl PlaybackNetwork for Network {
               return;
             }
           }
+
+          // No usable backend right now, but one may materialize shortly
+          // (recovery in flight, or deferred startup init still running):
+          // park the request for replay instead of routing to the
+          // full-screen error, which is what made every press during the
+          // recovery window cost a paced round trip ending on Error.
+          let mut app = self.app.lock().await;
+          if app.native_backend_pending {
+            app.park_start_playback(
+              context_id.as_ref().map(|c| c.uri()),
+              uris
+                .as_ref()
+                .map(|list| list.iter().map(|u| u.uri()).collect()),
+              offset,
+            );
+            app.set_status_message("Reconnecting native streaming; playback will resume.", 6);
+            return;
+          }
+          drop(app);
         }
 
         let mut app = self.app.lock().await;
@@ -1444,6 +1513,10 @@ impl PlaybackNetwork for Network {
         }
       }
       Err(e) => {
+        #[cfg(feature = "streaming")]
+        if suppressed_no_device_error_while_pending(self, &e).await {
+          return;
+        }
         let mut app = self.app.lock().await;
         app.handle_error(anyhow!(e));
       }
@@ -1461,6 +1534,10 @@ impl PlaybackNetwork for Network {
       .spotify_api_request_json(Method::POST, "me/player/next", &[], None)
       .await
     {
+      #[cfg(feature = "streaming")]
+      if suppressed_no_device_error_while_pending(self, &e).await {
+        return;
+      }
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -1477,6 +1554,10 @@ impl PlaybackNetwork for Network {
       .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
       .await
     {
+      #[cfg(feature = "streaming")]
+      if suppressed_no_device_error_while_pending(self, &e).await {
+        return;
+      }
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -1486,8 +1567,13 @@ impl PlaybackNetwork for Network {
     #[cfg(feature = "streaming")]
     if let PlaybackBackend::Native(player) = symmetric_playback_backend(self).await {
       player.prev();
-      tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-      player.prev();
+      // The second prev (which actually skips back once the position has reset
+      // to 0) runs on a detached task so the intentional 500ms gap doesn't
+      // block every other IoEvent on the serial pump.
+      tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        player.prev();
+      });
       return;
     }
 
@@ -1498,20 +1584,26 @@ impl PlaybackNetwork for Network {
       .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
       .await
     {
+      #[cfg(feature = "streaming")]
+      if suppressed_no_device_error_while_pending(self, &e).await {
+        return;
+      }
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
       return;
     }
 
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    if let Err(e) = self
-      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
-      .await
-    {
-      let mut app = self.app.lock().await;
-      app.handle_error(anyhow!(e));
-    }
+    // Re-dispatch the second call after the delay instead of sleeping on the
+    // pump: a plain PreviousTrack with the position back at 0 skips to the
+    // previous track, which is exactly the second half of the double-press
+    // semantics.
+    let io_tx = self.app.lock().await.io_tx_clone();
+    tokio::spawn(async move {
+      tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+      if let Some(io_tx) = io_tx {
+        let _ = io_tx.send(IoEvent::PreviousTrack);
+      }
+    });
   }
 
   async fn seek(&mut self, position_ms: u32) {
@@ -1530,6 +1622,10 @@ impl PlaybackNetwork for Network {
       )
       .await
     {
+      #[cfg(feature = "streaming")]
+      if suppressed_no_device_error_while_pending(self, &e).await {
+        return;
+      }
       let mut app = self.app.lock().await;
       app.handle_error(anyhow!(e));
     }
@@ -1562,6 +1658,10 @@ impl PlaybackNetwork for Network {
         }
       }
       Err(e) => {
+        #[cfg(feature = "streaming")]
+        if suppressed_no_device_error_while_pending(self, &e).await {
+          return;
+        }
         let mut app = self.app.lock().await;
         app.handle_error(anyhow!(e));
       }
@@ -1596,6 +1696,10 @@ impl PlaybackNetwork for Network {
         }
       }
       Err(e) => {
+        #[cfg(feature = "streaming")]
+        if suppressed_no_device_error_while_pending(self, &e).await {
+          return;
+        }
         let mut app = self.app.lock().await;
         app.handle_error(anyhow!(e));
       }
@@ -1644,10 +1748,17 @@ impl PlaybackNetwork for Network {
         // Keep pending_volume set — cleared when get_current_playback confirms
       }
       Err(e) => {
+        {
+          let mut app = self.app.lock().await;
+          app.is_volume_change_in_flight = false;
+          app.pending_volume = None;
+          app.last_dispatched_volume = None;
+        }
+        #[cfg(feature = "streaming")]
+        if suppressed_no_device_error_while_pending(self, &e).await {
+          return;
+        }
         let mut app = self.app.lock().await;
-        app.is_volume_change_in_flight = false;
-        app.pending_volume = None;
-        app.last_dispatched_volume = None;
         app.handle_error(anyhow!(e));
       }
     }

--- a/src/infra/network/requests.rs
+++ b/src/infra/network/requests.rs
@@ -15,8 +15,14 @@ use std::{
 };
 use tokio::sync::Mutex;
 
+// Leaky-bucket pacing state: the theoretical arrival time (GCRA "TAT") of the
+// next request. Sustained throughput is one request per SPOTIFY_API_MIN_INTERVAL,
+// with up to SPOTIFY_API_BURST requests allowed to start at once so the
+// concurrent fan-outs (search joins five queries, the artist page two) aren't
+// artificially staggered.
 static SPOTIFY_API_PACING: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
 const SPOTIFY_API_MIN_INTERVAL: Duration = Duration::from_millis(250);
+const SPOTIFY_API_BURST: u32 = 5;
 const SPOTIFY_API_BASE_URL: &str = "https://api.spotify.com/v1/";
 
 static SHARED_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -58,17 +64,26 @@ fn response_is_json(response: &reqwest::Response) -> bool {
 }
 
 pub async fn pace_spotify_api_call() {
-  let pacing_lock = SPOTIFY_API_PACING.get_or_init(|| Mutex::new(None));
-  let mut last_request_started_at = pacing_lock.lock().await;
+  // Reserve a start slot under the lock, then sleep OUTSIDE it. The previous
+  // implementation held the lock across the sleep, which serialized every
+  // "concurrent" tokio::join! call site into 250ms-apart starts (adding ~1s of
+  // pure pacing to every search).
+  let burst_allowance = SPOTIFY_API_MIN_INTERVAL * (SPOTIFY_API_BURST - 1);
+  let start_at = {
+    let pacing_lock = SPOTIFY_API_PACING.get_or_init(|| Mutex::new(None));
+    let mut theoretical_arrival = pacing_lock.lock().await;
+    let now = Instant::now();
+    // Clamp to `now` so idle time never banks more than one burst of credit.
+    let tat = theoretical_arrival.map_or(now, |t| t.max(now));
+    *theoretical_arrival = Some(tat + SPOTIFY_API_MIN_INTERVAL);
+    // A call may start up to `burst_allowance` ahead of its theoretical slot.
+    tat.checked_sub(burst_allowance).map_or(now, |t| t.max(now))
+  };
 
-  if let Some(last) = *last_request_started_at {
-    let elapsed = last.elapsed();
-    if elapsed < SPOTIFY_API_MIN_INTERVAL {
-      tokio::time::sleep(SPOTIFY_API_MIN_INTERVAL - elapsed).await;
-    }
+  let now = Instant::now();
+  if start_at > now {
+    tokio::time::sleep(start_at - now).await;
   }
-
-  *last_request_started_at = Some(Instant::now());
 }
 
 pub async fn spotify_api_request_json_for_with_refresh(

--- a/src/infra/network/user.rs
+++ b/src/infra/network/user.rs
@@ -214,17 +214,24 @@ impl UserNetwork for Network {
       }
     };
 
-    let mut all_tracks = Vec::new();
-
-    // 2. Get top tracks for each artist
-    for artist in artists {
+    // 2. Get top tracks for each artist, concurrently — the pacing limiter
+    // allows a burst of 5, sized to exactly this fan-out shape.
+    let this: &Self = self;
+    let track_fetches = artists.iter().map(|artist| {
       let path = format!("artists/{}/top-tracks", artist.id.id());
-      if let Ok(res) = self
-        .spotify_get_typed::<ArtistTopTracksResponse>(&path, &[])
-        .await
-      {
-        all_tracks.extend(res.tracks);
+      async move {
+        this
+          .spotify_get_typed::<ArtistTopTracksResponse>(&path, &[])
+          .await
       }
+    });
+    let mut all_tracks = Vec::new();
+    for res in futures::future::join_all(track_fetches)
+      .await
+      .into_iter()
+      .flatten()
+    {
+      all_tracks.extend(res.tracks);
     }
 
     // 3. Shuffle

--- a/src/infra/network/utils.rs
+++ b/src/infra/network/utils.rs
@@ -216,17 +216,12 @@ impl UtilsNetwork for Network {
       return;
     }
 
-    let client = match reqwest::Client::builder()
-      .timeout(Duration::from_secs(5))
-      .build()
-    {
-      Ok(client) => client,
-      Err(_) => return,
-    };
+    let client = super::requests::shared_http_client();
 
     let response = match client
       .get(&resolved_url)
       .header(reqwest::header::ACCEPT, "application/json")
+      .timeout(Duration::from_secs(5))
       .send()
       .await
     {

--- a/src/infra/network/utils.rs
+++ b/src/infra/network/utils.rs
@@ -72,6 +72,7 @@ pub trait UtilsNetwork {
 
 impl UtilsNetwork for Network {
   async fn get_lyrics(&mut self, track: String, artist: String, duration: f64) {
+    let request_identity = (track.clone(), artist.clone());
     let client = super::requests::shared_http_client();
     let query = vec![
       ("track_name", track.clone()),
@@ -82,6 +83,9 @@ impl UtilsNetwork for Network {
     // Update state to loading
     {
       let mut app = self.app.lock().await;
+      if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
+        return;
+      }
       app.lyrics_status = LyricsStatus::Loading;
       app.lyrics = None;
     }
@@ -105,6 +109,9 @@ impl UtilsNetwork for Network {
               .unwrap_or_default();
 
             let mut app = self.app.lock().await;
+            if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
+              return;
+            }
             if !synced.is_empty() {
               app.lyrics = Some(synced);
               app.lyrics_status = LyricsStatus::Found;
@@ -123,6 +130,9 @@ impl UtilsNetwork for Network {
               .bump(crate::core::app::PluginDataKind::Lyrics);
           } else {
             let mut app = self.app.lock().await;
+            if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
+              return;
+            }
             app.lyrics_status = LyricsStatus::NotFound;
             app
               .plugin_data_generations
@@ -130,6 +140,9 @@ impl UtilsNetwork for Network {
           }
         } else {
           let mut app = self.app.lock().await;
+          if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
+            return;
+          }
           app.lyrics_status = LyricsStatus::NotFound;
           app
             .plugin_data_generations
@@ -138,6 +151,9 @@ impl UtilsNetwork for Network {
       }
       Err(_) => {
         let mut app = self.app.lock().await;
+        if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
+          return;
+        }
         app.lyrics_status = LyricsStatus::NotFound;
         app
           .plugin_data_generations

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -440,6 +440,8 @@ async fn handle_player_events(
         // A TrackChanged proves the session is processing loads: disarm the
         // zombie-session watchdog.
         app.native_load_watchdog = None;
+        app.pending_start_playback = None;
+        app.native_backend_pending = false;
         app.native_track_info = Some(app::NativeTrackInfo {
           name: audio_item.name.clone(),
           artists_display: artists.join(", "),
@@ -634,12 +636,15 @@ async fn handle_player_events(
         // failure was completely silent (#282). Surface it to the user.
         consecutive_unavailable += 1;
 
-        // Clear the ghost native track so the playbar doesn't show a track that
-        // never actually plays, mirroring the EndOfTrack/Stopped arms. Use
-        // try_lock to avoid stalling on the render loop; skipping a reset is fine.
-        if let Ok(mut app) = app.try_lock() {
+        // Clear the ghost native track and the request/watchdog together so an
+        // unavailable track cannot be replayed as a supposed session failure.
+        {
+          let mut app = app.lock().await;
           app.song_progress_ms = 0;
           app.native_track_info = None;
+          app.native_load_watchdog = None;
+          app.pending_start_playback = None;
+          app.native_backend_pending = false;
           if let Some(ref mut ctx) = app.current_playback_context {
             ctx.is_playing = false;
           }
@@ -672,6 +677,12 @@ async fn handle_player_events(
             "Several tracks in a row couldn't be played natively, so playback was stopped. They may be unavailable on your account or region. Press 'd' to switch to an official Spotify Connect device.",
             20,
           );
+        }
+      }
+      PlayerEvent::Loading { .. } | PlayerEvent::Preloading { .. } => {
+        let mut app = app.lock().await;
+        if app.native_load_watchdog.is_some() {
+          app.native_load_watchdog = Some(std::time::Instant::now());
         }
       }
       _ => {}

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -63,6 +63,11 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
     }
 
     if active_streaming_player(&ctx.app).await.is_some() {
+      // A live player already exists (e.g. a queued duplicate request): the
+      // pending window is over, so replay anything parked against it.
+      let mut app = ctx.app.lock().await;
+      app.native_backend_pending = false;
+      app.replay_pending_start_playback();
       continue;
     }
 
@@ -107,6 +112,11 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
               false,
             ));
           }
+          // Replay the request that triggered (or arrived during) recovery.
+          // Dispatched after AutoSelectStreamingDevice, so the serial pump
+          // completes the device selection before the playback starts.
+          app.native_backend_pending = false;
+          app.replay_pending_start_playback();
         }
 
         spawn_player_event_handler(PlayerEventContext {
@@ -126,7 +136,15 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
       Err(e) => {
         info!("native streaming recovery failed: {}", e);
         let mut app = ctx.app.lock().await;
-        app.set_status_message(format!("Native recovery failed: {}", e), 8);
+        app.native_backend_pending = false;
+        if app.pending_start_playback.take().is_some() {
+          app.set_status_message(
+            format!("Native recovery failed; playback request dropped: {}", e),
+            8,
+          );
+        } else {
+          app.set_status_message(format!("Native recovery failed: {}", e), 8);
+        }
       }
     }
   }
@@ -269,6 +287,11 @@ async fn handle_player_events(
         {
           let mut app_lock = app.lock().await;
           app_lock.native_is_playing = Some(true);
+          // A real Playing event proves the session is alive: disarm the load
+          // watchdog and drop any request parked for its potential recovery.
+          app_lock.native_load_watchdog = None;
+          app_lock.pending_start_playback = None;
+          app_lock.native_backend_pending = false;
         }
 
         if let Ok(mut app) = app.try_lock() {
@@ -414,6 +437,9 @@ async fn handle_player_events(
         }
 
         let mut app = app.lock().await;
+        // A TrackChanged proves the session is processing loads: disarm the
+        // zombie-session watchdog.
+        app.native_load_watchdog = None;
         app.native_track_info = Some(app::NativeTrackInfo {
           name: audio_item.name.clone(),
           artists_display: artists.join(", "),

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -663,7 +663,11 @@ impl StreamingPlayer {
 
   /// Activate the device (make it the active playback device)
   pub fn activate(&self) {
-    let _ = self.spirc.activate();
+    // Not fatal (transfer() is the reliable route), but a failure here used to
+    // vanish entirely, hiding zombie sessions from the logs.
+    if let Err(e) = self.spirc.activate() {
+      log::warn!("spirc activate failed: {e:?}");
+    }
   }
 
   /// Transfer playback to this device via Spotify Connect.

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -8,6 +8,7 @@ use librespot_core::{
   authentication::Credentials,
   cache::Cache,
   config::{DeviceType, SessionConfig},
+  error::ErrorKind,
   session::Session,
   spclient::TransferRequest,
   SpotifyUri,
@@ -156,8 +157,6 @@ const SPOTIFY_PLAYER_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 const SPOTIFY_PLAYER_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
 fn request_streaming_oauth_credentials() -> Result<Credentials> {
-  println!("Streaming authentication required - opening browser...");
-
   let client_builder = OAuthClientBuilder::new(
     SPOTIFY_PLAYER_CLIENT_ID,
     SPOTIFY_PLAYER_REDIRECT_URI,
@@ -174,6 +173,34 @@ fn request_streaming_oauth_credentials() -> Result<Credentials> {
     .map_err(|e| anyhow!("OAuth authentication failed: {:?}", e))?;
 
   Ok(Credentials::with_access_token(token.access_token))
+}
+
+/// Populate the reusable credential cache before the TUI enters raw mode.
+/// Deferred player initialization and recovery can then remain cache-only.
+pub fn ensure_streaming_credentials_cached() -> Result<()> {
+  let cache_path = get_default_cache_path();
+  if let Some(path) = cache_path.as_ref() {
+    std::fs::create_dir_all(path)?;
+  }
+  let cache = Cache::new(cache_path, None, None, None)?;
+  if cache.credentials().is_none() {
+    println!("Streaming authentication required - opening browser...");
+    let credentials = request_streaming_oauth_credentials()?;
+    cache.save_credentials(&credentials);
+  }
+  Ok(())
+}
+
+pub fn streaming_credentials_are_cached() -> Result<bool> {
+  let cache_path = get_default_cache_path();
+  if let Some(path) = cache_path.as_ref() {
+    std::fs::create_dir_all(path)?;
+  }
+  Ok(
+    Cache::new(cache_path, None, None, None)?
+      .credentials()
+      .is_some(),
+  )
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -211,14 +238,14 @@ fn clear_cached_streaming_credentials(cache_path: &Option<PathBuf>) {
 
   match std::fs::remove_file(&credentials_path) {
     Ok(()) => {
-      println!(
+      info!(
         "Cleared cached streaming credentials at {}",
         credentials_path.display()
       );
     }
     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
     Err(e) => {
-      eprintln!(
+      warn!(
         "Failed to clear cached streaming credentials at {}: {}",
         credentials_path.display(),
         e
@@ -456,6 +483,19 @@ impl StreamingPlayer {
           retried_with_fresh_credentials = true;
         }
         Ok(Err(e)) => {
+          // Only discard cached credentials when Spotify actually rejected them.
+          // A transient failure (network down, service unavailable) must NOT wipe
+          // valid credentials and force a browser re-auth next launch — same
+          // reasoning as the timeout arm below.
+          if matches!(auth_mode, StreamingAuthMode::CacheOnly)
+            && used_cached_credentials
+            && matches!(
+              e.kind,
+              ErrorKind::Unauthenticated | ErrorKind::PermissionDenied
+            )
+          {
+            clear_cached_streaming_credentials(&cache_path);
+          }
           warn!("Spirc creation error: {:?}", e);
           return Err(anyhow!("Failed to create Spirc: {:?}", e));
         }

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -28,6 +28,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
@@ -156,7 +157,40 @@ const SPOTIFY_PLAYER_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 /// spotify-player's redirect_uri - must match what's registered with their client_id
 const SPOTIFY_PLAYER_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
+fn wait_for_oauth_callback_port(
+  address: &str,
+  max_wait: Duration,
+  retry_delay: Duration,
+) -> Result<()> {
+  let deadline = Instant::now() + max_wait;
+  loop {
+    match std::net::TcpListener::bind(address) {
+      Ok(listener) => {
+        drop(listener);
+        return Ok(());
+      }
+      Err(_) if Instant::now() < deadline => {
+        std::thread::sleep(retry_delay.min(deadline.saturating_duration_since(Instant::now())));
+      }
+      Err(error) => {
+        return Err(anyhow!(
+          "OAuth callback port {address} did not become available: {error}"
+        ));
+      }
+    }
+  }
+}
+
 fn request_streaming_oauth_credentials() -> Result<Credentials> {
+  // The Web API and streaming OAuth clients both use port 8989. On a fresh
+  // profile their callback servers run back-to-back, so wait for the first
+  // listener to be fully released before librespot opens the second consent.
+  wait_for_oauth_callback_port(
+    "127.0.0.1:8989",
+    Duration::from_secs(5),
+    Duration::from_millis(50),
+  )?;
+
   let client_builder = OAuthClientBuilder::new(
     SPOTIFY_PLAYER_CLIENT_ID,
     SPOTIFY_PLAYER_REDIRECT_URI,
@@ -802,7 +836,27 @@ fn new_device_id_string() -> String {
 
 #[cfg(test)]
 mod tests {
-  use super::{get_or_create_device_id, new_device_id_string, should_retry_with_fresh_credentials};
+  use super::{
+    get_or_create_device_id, new_device_id_string, should_retry_with_fresh_credentials,
+    wait_for_oauth_callback_port,
+  };
+  use std::time::Duration;
+
+  #[test]
+  fn oauth_callback_port_waits_for_previous_listener_to_release() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap().to_string();
+    let release = std::thread::spawn(move || {
+      std::thread::sleep(Duration::from_millis(100));
+      drop(listener);
+    });
+
+    wait_for_oauth_callback_port(&address, Duration::from_secs(1), Duration::from_millis(10))
+      .expect("callback port should become available after the first listener exits");
+    release.join().unwrap();
+
+    std::net::TcpListener::bind(address).expect("callback port should remain available");
+  }
 
   #[test]
   fn auth_failure_with_cached_creds_triggers_retry() {

--- a/src/infra/radio/mod.rs
+++ b/src/infra/radio/mod.rs
@@ -130,10 +130,16 @@ pub struct RadioSource {
   http: reqwest::Client,
 }
 
-impl RadioSource {
-  pub fn new() -> Self {
-    RadioSource {
-      http: reqwest::Client::builder()
+/// Process-wide radio-browser HTTP client. Dispatch constructs a fresh
+/// `RadioSource` per event, so the client (TLS state + connection pool) is
+/// built once and cheaply cloned into each source — otherwise every radio
+/// action pays a fresh TLS handshake (same pattern as `shared_http_client`
+/// on the Spotify path).
+fn shared_radio_client() -> reqwest::Client {
+  static RADIO_HTTP_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+  RADIO_HTTP_CLIENT
+    .get_or_init(|| {
+      reqwest::Client::builder()
         .user_agent(USER_AGENT)
         // Blanket per-request timeout so a mirror that connects then stalls the
         // body can never hang the pump. The per-mirror `tokio::time::timeout` in
@@ -143,7 +149,15 @@ impl RadioSource {
         .build()
         // Falls back to a default client only if TLS init fails, which would
         // break every other request in the app too.
-        .unwrap_or_default(),
+        .unwrap_or_default()
+    })
+    .clone()
+}
+
+impl RadioSource {
+  pub fn new() -> Self {
+    RadioSource {
+      http: shared_radio_client(),
     }
   }
 

--- a/src/infra/redirect_uri.rs
+++ b/src/infra/redirect_uri.rs
@@ -1,13 +1,9 @@
-use std::{
-  io::prelude::*,
-  net::{TcpListener, TcpStream},
-};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-/// Shared acceptance logic for both the blocking and async callback servers:
-/// given a raw HTTP request, return the full callback URL when it carries an
-/// OAuth `code=` query parameter, else `None` (browser noise like /favicon.ico,
-/// pre-flight requests, or malformed input).
+/// Acceptance logic for the callback server: given a raw HTTP request, return
+/// the full callback URL when it carries an OAuth `code=` query parameter,
+/// else `None` (browser noise like /favicon.ico, pre-flight requests, or
+/// malformed input).
 fn extract_callback_url(request: &str) -> Option<String> {
   let split: Vec<&str> = request.split_whitespace().collect();
   if split.len() <= 1 {
@@ -29,64 +25,13 @@ fn extract_callback_url(request: &str) -> Option<String> {
   Some(format!("http://{}{}", host, path))
 }
 
-pub fn redirect_uri_web_server(port: u16) -> Result<String, ()> {
-  let listener = TcpListener::bind(format!("127.0.0.1:{}", port));
-
-  match listener {
-    Ok(listener) => {
-      for stream in listener.incoming() {
-        match stream {
-          Ok(stream) => {
-            if let Some(url) = handle_connection(stream) {
-              return Ok(url);
-            }
-          }
-          Err(e) => {
-            println!("Error: {}", e);
-          }
-        };
-      }
-    }
-    Err(e) => {
-      println!("Error: {}", e);
-    }
-  }
-
-  Err(())
-}
-
-fn handle_connection(mut stream: TcpStream) -> Option<String> {
-  // The request will be quite large (> 512) so just assign plenty just in case
-  let mut buffer = [0; 1000];
-  let _ = stream.read(&mut buffer).unwrap();
-
-  // convert buffer into string and 'parse' the URL
-  match String::from_utf8(buffer.to_vec()) {
-    Ok(request) => {
-      if let Some(full_url) = extract_callback_url(&request) {
-        respond_with_success(stream);
-        return Some(full_url);
-      }
-
-      // Browser noise / malformed pre-flight — send 400 silently; the loop keeps
-      // waiting for the real OAuth callback.
-      send_error_response("Not a callback request".to_string(), stream);
-    }
-    Err(e) => {
-      let msg = format!("Invalid UTF-8 sequence: {}", e);
-      println!("Error: {}", msg);
-      send_error_response(msg, stream);
-    }
-  };
-
-  None
-}
-
-/// Async variant of [`redirect_uri_web_server`] for in-TUI Spotify login: it never
-/// blocks the caller's task (the network event pump), so the UI keeps rendering
-/// while the browser round-trips. Returns the callback URL, or `Err(())` on
-/// bind/accept failure. The caller applies the overall timeout (e.g. via
-/// `tokio::time::timeout`) so an abandoned login doesn't leak the listener.
+/// OAuth callback server, used by both the pre-TUI startup login and the
+/// in-TUI login flow: it never blocks the caller's thread (the old blocking
+/// variant parked a tokio worker in a std accept() loop with no timeout and
+/// could hang the startup login entirely, #364). Returns the callback URL, or
+/// `Err(())` on bind/accept failure. Callers that need an overall timeout
+/// (e.g. the in-TUI flow) apply it via `tokio::time::timeout` so an abandoned
+/// login doesn't leak the listener.
 pub async fn redirect_uri_web_server_async(port: u16) -> Result<String, ()> {
   let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port))
     .await
@@ -138,61 +83,14 @@ async fn write_async_response(
   stream.flush().await
 }
 
-fn respond_with_success(mut stream: TcpStream) {
-  let contents = include_str!("redirect_uri.html");
-
-  let response = format!(
-    "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-    contents.len(),
-    contents
-  );
-
-  stream.write_all(response.as_bytes()).unwrap();
-  stream.flush().unwrap();
-  // Give the browser time to receive the response before closing
-  std::thread::sleep(std::time::Duration::from_millis(100));
-}
-
-fn send_error_response(error_message: String, mut stream: TcpStream) {
-  let body = format!("400 - Bad Request - {}", error_message);
-  let response = format!(
-    "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-    body.len(),
-    body
-  );
-
-  let _ = stream.write_all(response.as_bytes());
-  let _ = stream.flush();
-  std::thread::sleep(std::time::Duration::from_millis(100));
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
 
-  fn send_to_handle_connection(request: &[u8]) -> Option<String> {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    let request = request.to_vec();
-    let writer_thread = std::thread::spawn(move || {
-      let mut client = TcpStream::connect(addr).unwrap();
-      client.write_all(&request).unwrap();
-      // Read and discard the response so handle_connection's write doesn't block
-      let mut buf = Vec::new();
-      let _ = client.read_to_end(&mut buf);
-    });
-
-    let (server_side, _) = listener.accept().unwrap();
-    let result = handle_connection(server_side);
-    writer_thread.join().unwrap();
-    result
-  }
-
   #[test]
   fn valid_callback_returns_url_with_code() {
-    let request = b"GET /login?code=abc&state=xyz HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
-    let url = send_to_handle_connection(request);
+    let request = "GET /login?code=abc&state=xyz HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
+    let url = extract_callback_url(request);
     assert!(url.is_some());
     let url = url.unwrap();
     assert!(
@@ -208,31 +106,27 @@ mod tests {
   }
 
   #[test]
-  fn whitespace_only_request_returns_none_without_printing() {
+  fn whitespace_only_request_returns_none() {
     // Whitespace-only payload: split_whitespace() returns empty vec (len 0 ≤ 1) → None silently
-    let result = send_to_handle_connection(b" \r\n\r\n");
-    assert!(result.is_none());
+    assert!(extract_callback_url(" \r\n\r\n").is_none());
   }
 
   #[test]
   fn preflight_single_token_returns_none() {
     // A single token (no path) also triggers the malformed branch → None, no panic
-    let result = send_to_handle_connection(b"GET");
-    assert!(result.is_none());
+    assert!(extract_callback_url("GET").is_none());
   }
 
   #[test]
   fn favicon_request_returns_none() {
-    let request = b"GET /favicon.ico HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
-    let result = send_to_handle_connection(request);
-    assert!(result.is_none());
+    let request = "GET /favicon.ico HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
+    assert!(extract_callback_url(request).is_none());
   }
 
   #[test]
   fn root_request_returns_none() {
-    let request = b"GET / HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
-    let result = send_to_handle_connection(request);
-    assert!(result.is_none());
+    let request = "GET / HTTP/1.1\r\nHost: 127.0.0.1:8989\r\n\r\n";
+    assert!(extract_callback_url(request).is_none());
   }
 
   // --- async server tests --------------------------------------------------

--- a/src/infra/redirect_uri.rs
+++ b/src/infra/redirect_uri.rs
@@ -42,12 +42,22 @@ pub async fn redirect_uri_web_server_async(port: u16) -> Result<String, ()> {
 /// Accept-loop extracted so tests can inject a pre-bound listener (port 0) and
 /// avoid races caused by hard-coding a port that might already be in use.
 async fn run_accept_loop(listener: tokio::net::TcpListener) -> Result<String, ()> {
+  const MAX_CONSECUTIVE_ACCEPT_ERRORS: u8 = 20;
+  let mut consecutive_accept_errors = 0u8;
   loop {
     let mut stream = match listener.accept().await {
-      Ok((stream, _)) => stream,
+      Ok((stream, _)) => {
+        consecutive_accept_errors = 0;
+        stream
+      }
       Err(e) => {
+        consecutive_accept_errors = consecutive_accept_errors.saturating_add(1);
         log::warn!("[login] callback accept error: {e}");
-        return Err(());
+        if consecutive_accept_errors >= MAX_CONSECUTIVE_ACCEPT_ERRORS {
+          return Err(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        continue;
       }
     };
 

--- a/src/infra/scripting/engine.rs
+++ b/src/infra/scripting/engine.rs
@@ -129,6 +129,42 @@ impl ScriptEngine {
   /// `plugins/<name>/main.lua` (falling back to `init.lua`). Each group is sorted by filename.
   /// Missing files/dir are fine. A failing file logs an error and queues a Notify effect but
   /// never aborts the others. Returns the number of plugins loaded successfully.
+  /// Cheap discovery-only mirror of [`Self::load_user_scripts`]: reports
+  /// whether any loadable script exists (`init.lua`, `plugins/*.lua`, or
+  /// `plugins/<name>/{main,init}.lua`) so the runner can skip constructing
+  /// the Lua VM (and its HTTP client) entirely when there is nothing to
+  /// load. Keep the discovery rules in sync with `load_user_scripts`.
+  pub fn has_user_scripts(config_dir: &Path) -> bool {
+    if config_dir.join("init.lua").is_file() {
+      return true;
+    }
+    let plugins_dir = config_dir.join("plugins");
+    if !plugins_dir.is_dir() {
+      return false;
+    }
+    std::fs::read_dir(&plugins_dir)
+      .into_iter()
+      .flatten()
+      .flatten()
+      .map(|e| e.path())
+      .any(|p| {
+        let hidden = p
+          .file_name()
+          .and_then(|n| n.to_str())
+          .is_none_or(|n| n.starts_with('.'));
+        if hidden {
+          return false;
+        }
+        if p.is_file() {
+          p.extension().and_then(|e| e.to_str()) == Some("lua")
+        } else if p.is_dir() {
+          ["main.lua", "init.lua"].iter().any(|f| p.join(f).is_file())
+        } else {
+          false
+        }
+      })
+  }
+
   pub fn load_user_scripts(&mut self, config_dir: &Path) -> usize {
     *self.shared.config_dir.borrow_mut() = Some(config_dir.to_path_buf());
     let mut loaded = 0;

--- a/src/infra/scripting/engine.rs
+++ b/src/infra/scripting/engine.rs
@@ -1,5 +1,5 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use mlua::{Lua, LuaSerdeExt, Value};
@@ -135,112 +135,28 @@ impl ScriptEngine {
   /// the Lua VM (and its HTTP client) entirely when there is nothing to
   /// load. Keep the discovery rules in sync with `load_user_scripts`.
   pub fn has_user_scripts(config_dir: &Path) -> bool {
-    if config_dir.join("init.lua").is_file() {
-      return true;
-    }
-    let plugins_dir = config_dir.join("plugins");
-    if !plugins_dir.is_dir() {
-      return false;
-    }
-    std::fs::read_dir(&plugins_dir)
-      .into_iter()
-      .flatten()
-      .flatten()
-      .map(|e| e.path())
-      .any(|p| {
-        let hidden = p
-          .file_name()
-          .and_then(|n| n.to_str())
-          .is_none_or(|n| n.starts_with('.'));
-        if hidden {
-          return false;
-        }
-        if p.is_file() {
-          p.extension().and_then(|e| e.to_str()) == Some("lua")
-        } else if p.is_dir() {
-          ["main.lua", "init.lua"].iter().any(|f| p.join(f).is_file())
-        } else {
-          false
-        }
-      })
+    !discover_user_scripts(config_dir).is_empty()
   }
 
   pub fn load_user_scripts(&mut self, config_dir: &Path) -> usize {
     *self.shared.config_dir.borrow_mut() = Some(config_dir.to_path_buf());
     let mut loaded = 0;
 
-    let init_path = config_dir.join("init.lua");
-    if init_path.is_file() && self.load_file(&init_path, "init.lua") {
-      loaded += 1;
-    }
-
-    let plugins_dir = config_dir.join("plugins");
-    if plugins_dir.is_dir() {
-      let entries: Vec<_> = std::fs::read_dir(&plugins_dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .map(|e| e.path())
-        .collect();
-
-      // Single-file plugins: plugins/<name>.lua. Real files only (a directory named
-      // `foo.lua` is handled by the directory branch below), and hidden files are skipped to
-      // match the directory branch and avoid loading OS cruft like `._foo.lua`.
-      let mut files: Vec<_> = entries
-        .iter()
-        .filter(|p| p.is_file())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("lua"))
-        .filter(|p| {
-          p.file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| !n.starts_with('.'))
-        })
-        .cloned()
-        .collect();
-      files.sort();
-      for path in files {
-        let name = path
-          .file_name()
-          .and_then(|n| n.to_str())
-          .unwrap_or("plugin")
-          .to_string();
-        if self.load_file(&path, &name) {
-          loaded += 1;
-        }
-      }
-
-      // Directory plugins: plugins/<name>/main.lua (or init.lua). These are how git-installed
-      // plugins (`spotatui plugin add`) ship. Hidden dirs (e.g. dotfiles) are ignored.
-      let mut dirs: Vec<_> = entries
-        .iter()
-        .filter(|p| p.is_dir())
-        .filter(|p| {
-          p.file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| !n.starts_with('.'))
-        })
-        .cloned()
-        .collect();
-      dirs.sort();
-      for dir in dirs {
-        let name = dir
-          .file_name()
-          .and_then(|n| n.to_str())
-          .unwrap_or("plugin")
-          .to_string();
-        let entry = ["main.lua", "init.lua"]
-          .iter()
-          .map(|f| dir.join(f))
-          .find(|p| p.is_file());
-        let Some(entry) = entry else {
-          continue;
-        };
+    for (path, module_dir) in discover_user_scripts(config_dir) {
+      let name = module_dir
+        .as_ref()
+        .and_then(|dir| dir.file_name())
+        .or_else(|| path.file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("plugin")
+        .to_string();
+      if let Some(dir) = module_dir {
         if let Err(e) = self.add_plugin_module_path(&dir) {
           log::warn!("[lua] failed to extend package.path for plugin '{name}': {e}");
         }
-        if self.load_file(&entry, &name) {
-          loaded += 1;
-        }
+      }
+      if self.load_file(&path, &name) {
+        loaded += 1;
       }
     }
 
@@ -1139,6 +1055,46 @@ impl ScriptEngine {
     let effects: Vec<ScriptEffect> = self.shared.effects.borrow_mut().drain(..).collect();
     apply_effects(effects, app);
   }
+}
+
+fn discover_user_scripts(config_dir: &Path) -> Vec<(PathBuf, Option<PathBuf>)> {
+  let mut discovered = Vec::new();
+  let init = config_dir.join("init.lua");
+  if init.is_file() {
+    discovered.push((init, None));
+  }
+  let plugins_dir = config_dir.join("plugins");
+  let entries: Vec<_> = std::fs::read_dir(&plugins_dir)
+    .into_iter()
+    .flatten()
+    .flatten()
+    .map(|entry| entry.path())
+    .filter(|path| {
+      path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| !name.starts_with('.'))
+    })
+    .collect();
+  let mut files: Vec<_> = entries
+    .iter()
+    .filter(|path| path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("lua"))
+    .cloned()
+    .collect();
+  files.sort();
+  discovered.extend(files.into_iter().map(|path| (path, None)));
+  let mut dirs: Vec<_> = entries.into_iter().filter(|path| path.is_dir()).collect();
+  dirs.sort();
+  for dir in dirs {
+    if let Some(entry) = ["main.lua", "init.lua"]
+      .iter()
+      .map(|name| dir.join(name))
+      .find(|path| path.is_file())
+    {
+      discovered.push((entry, Some(dir)));
+    }
+  }
+  discovered
 }
 
 /// Serialize the plugin-facing snapshot for a data kind from `App` state.

--- a/src/infra/subsonic/mod.rs
+++ b/src/infra/subsonic/mod.rs
@@ -147,6 +147,33 @@ pub struct SubsonicSource {
   http: Client,
 }
 
+/// Process-wide Subsonic HTTP client. Dispatch constructs a fresh
+/// `SubsonicSource` per event, so the client (which owns the TLS state and
+/// connection pool) is built once and cheaply cloned into each source —
+/// otherwise every Subsonic action pays a fresh TLS handshake (same pattern
+/// as `shared_http_client` on the Spotify path).
+///
+/// A bare `Client::new()` has no timeouts: a server that connects then
+/// stalls the body wedges the serial IoEvent pump permanently, killing
+/// transport for every source. Bound both the handshake and the whole
+/// request. `.timeout()` applies per request, so it also caps the streamed
+/// download in `download_track` (each chunk read must make progress within
+/// the window) without needing a separate wrapper there.
+fn shared_subsonic_client() -> Client {
+  static SUBSONIC_HTTP_CLIENT: std::sync::OnceLock<Client> = std::sync::OnceLock::new();
+  SUBSONIC_HTTP_CLIENT
+    .get_or_init(|| {
+      Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        // Falls back to a default (untimed) client only if TLS init fails, which
+        // would break every other request in the app too.
+        .unwrap_or_default()
+    })
+    .clone()
+}
+
 impl SubsonicSource {
   /// Create a new source for the given server.
   ///
@@ -163,19 +190,7 @@ impl SubsonicSource {
       base_url: base_url.trim_end_matches('/').to_string(),
       username: username.into(),
       password: password.into(),
-      // A bare `Client::new()` has no timeouts: a server that connects then
-      // stalls the body wedges the serial IoEvent pump permanently, killing
-      // transport for every source. Bound both the handshake and the whole
-      // request. `.timeout()` applies per request, so it also caps the streamed
-      // download in `download_track` (each chunk read must make progress within
-      // the window) without needing a separate wrapper there.
-      http: Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
-        .build()
-        // Falls back to a default (untimed) client only if TLS init fails, which
-        // would break every other request in the app too.
-        .unwrap_or_default(),
+      http: shared_subsonic_client(),
     }
   }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -691,143 +691,145 @@ fn deferred_streaming_startup(ctx: DeferredStreamingContext) {
 
 #[cfg(feature = "streaming")]
 async fn deferred_streaming_startup_inner(ctx: DeferredStreamingContext) {
+  let (supported, status_message) =
+    account_supports_native_streaming(&ctx.spotify, ctx.cached_me, &ctx.token_cache_path, &ctx.app)
+      .await;
+  if let Some(message) = status_message {
+    ctx.app.lock().await.set_status_message(message, 12);
+  }
+  if !supported {
+    return;
+  }
+
+  info!("initializing native streaming player");
+  let streaming_config = player::StreamingConfig {
+    device_name: ctx.client_config.streaming_device_name.clone(),
+    bitrate: ctx.client_config.streaming_bitrate,
+    audio_cache: ctx.client_config.streaming_audio_cache,
+    cache_path: player::get_default_cache_path(),
+    initial_volume: ctx.volume_percent,
+  };
+  let client_id = ctx.client_config.client_id.clone();
+  let redirect_uri = ctx.redirect_uri.clone();
+
+  // Internal Spirc timeout defaults to 30s (configurable via
+  // SPOTATUI_STREAMING_INIT_TIMEOUT_SECS). The outer timeout here is a safety net
+  // that catches hangs *outside* Spirc init (e.g. OAuth callback never arriving,
+  // blocking I/O in credential retrieval). Set it above the internal timeout.
+  let internal_timeout_secs: u64 = std::env::var("SPOTATUI_STREAMING_INIT_TIMEOUT_SECS")
+    .ok()
+    .and_then(|v| v.parse().ok())
+    .filter(|&v: &u64| v > 0)
+    .unwrap_or(30);
+  let outer_timeout = Duration::from_secs(internal_timeout_secs.saturating_add(15));
+
+  let init_task = tokio::spawn(async move {
+    player::StreamingPlayer::new_cache_only(&client_id, &redirect_uri, streaming_config).await
+  });
+  let abort_handle = init_task.abort_handle();
+
+  let streaming_player = match tokio::time::timeout(outer_timeout, init_task).await {
+    Ok(Ok(Ok(p))) => {
+      info!(
+        "native streaming player initialized as '{}'",
+        p.device_name()
+      );
+      // Note: We don't activate() here - that's handled by AutoSelectStreamingDevice
+      // which respects the user's saved device preference (e.g., spotifyd)
+      Arc::new(p)
+    }
+    Ok(Ok(Err(e))) => {
+      info!(
+        "failed to initialize streaming: {} - falling back to web api",
+        e
+      );
+      ctx.app.lock().await.set_status_message(
+        "Native streaming didn't start; using Spotify Connect for now. Restart spotatui to reconnect native playback.",
+        12,
+      );
+      return;
+    }
+    Ok(Err(e)) => {
+      info!(
+        "streaming initialization panicked: {} - falling back to web api",
+        e
+      );
+      return;
+    }
+    Err(_) => {
+      abort_handle.abort();
+      warn!(
+        "streaming initialization hung unexpectedly (outer timeout {}s) - falling back to web api",
+        outer_timeout.as_secs()
+      );
+      return;
+    }
+  };
+
+  info!("native playback enabled - spotatui is available as a spotify connect device");
+
+  // Store streaming player reference in App for direct control (bypasses event channel)
   {
-    let (supported, status_message) = account_supports_native_streaming(
+    let mut app_mut = ctx.app.lock().await;
+    app_mut.streaming_player = Some(Arc::clone(&streaming_player));
+    // Startup playlist loading may have fallen back to a flat list while the
+    // deferred player was unavailable. Refresh once so rootlist folders are
+    // reconciled now that librespot is ready.
+    app_mut.dispatch(IoEvent::GetPlaylists);
+  }
+
+  // Spawn player event listener (updates app state from native player events)
+  player::spawn_player_event_handler(player::PlayerEventContext {
+    player: Arc::clone(&streaming_player),
+    app: Arc::clone(&ctx.app),
+    shared_position: ctx.shared_position,
+    shared_is_playing: ctx.shared_is_playing,
+    recovery_tx: ctx.recovery_tx,
+    #[cfg(all(feature = "mpris", target_os = "linux"))]
+    mpris_manager: ctx.mpris_manager,
+    #[cfg(all(feature = "macos-media", target_os = "macos"))]
+    macos_media_manager: ctx.macos_media_manager,
+    #[cfg(all(feature = "windows-media", target_os = "windows"))]
+    windows_media_manager: ctx.windows_media_manager,
+  });
+
+  // Auto-select the saved playback device when available (fallback to native
+  // streaming). This used to run inline in the network task before the pump
+  // started; the decision's outcome now dispatches through the pump.
+  let device_name = streaming_player.device_name().to_string();
+  let saved_device_id = ctx.client_config.device_id.clone();
+  let mut devices_snapshot = None;
+  if let Ok(devices) =
+    spotify_get_typed_compat_for_with_refresh::<rspotify::model::device::DevicePayload>(
       &ctx.spotify,
-      ctx.cached_me,
+      "me/player/devices",
+      &[],
       &ctx.token_cache_path,
       &ctx.app,
     )
-    .await;
-    if let Some(message) = status_message {
-      ctx.app.lock().await.set_status_message(message, 12);
-    }
-    if !supported {
-      return;
-    }
-
-    info!("initializing native streaming player");
-    let streaming_config = player::StreamingConfig {
-      device_name: ctx.client_config.streaming_device_name.clone(),
-      bitrate: ctx.client_config.streaming_bitrate,
-      audio_cache: ctx.client_config.streaming_audio_cache,
-      cache_path: player::get_default_cache_path(),
-      initial_volume: ctx.volume_percent,
-    };
-    let client_id = ctx.client_config.client_id.clone();
-    let redirect_uri = ctx.redirect_uri.clone();
-
-    // Internal Spirc timeout defaults to 30s (configurable via
-    // SPOTATUI_STREAMING_INIT_TIMEOUT_SECS). The outer timeout here is a safety net
-    // that catches hangs *outside* Spirc init (e.g. OAuth callback never arriving,
-    // blocking I/O in credential retrieval). Set it above the internal timeout.
-    let internal_timeout_secs: u64 = std::env::var("SPOTATUI_STREAMING_INIT_TIMEOUT_SECS")
-      .ok()
-      .and_then(|v| v.parse().ok())
-      .filter(|&v: &u64| v > 0)
-      .unwrap_or(30);
-    let outer_timeout = Duration::from_secs(internal_timeout_secs.saturating_add(15));
-
-    let init_task = tokio::spawn(async move {
-      player::StreamingPlayer::new(&client_id, &redirect_uri, streaming_config).await
-    });
-    let abort_handle = init_task.abort_handle();
-
-    let streaming_player = match tokio::time::timeout(outer_timeout, init_task).await {
-      Ok(Ok(Ok(p))) => {
-        info!(
-          "native streaming player initialized as '{}'",
-          p.device_name()
-        );
-        // Note: We don't activate() here - that's handled by AutoSelectStreamingDevice
-        // which respects the user's saved device preference (e.g., spotifyd)
-        Arc::new(p)
-      }
-      Ok(Ok(Err(e))) => {
-        info!(
-          "failed to initialize streaming: {} - falling back to web api",
-          e
-        );
-        return;
-      }
-      Ok(Err(e)) => {
-        info!(
-          "streaming initialization panicked: {} - falling back to web api",
-          e
-        );
-        return;
-      }
-      Err(_) => {
-        abort_handle.abort();
-        warn!(
-          "streaming initialization hung unexpectedly (outer timeout {}s) - falling back to web api",
-          outer_timeout.as_secs()
-        );
-        return;
-      }
-    };
-
-    info!("native playback enabled - spotatui is available as a spotify connect device");
-
-    // Store streaming player reference in App for direct control (bypasses event channel)
-    {
-      let mut app_mut = ctx.app.lock().await;
-      app_mut.streaming_player = Some(Arc::clone(&streaming_player));
-    }
-
-    // Spawn player event listener (updates app state from native player events)
-    player::spawn_player_event_handler(player::PlayerEventContext {
-      player: Arc::clone(&streaming_player),
-      app: Arc::clone(&ctx.app),
-      shared_position: ctx.shared_position,
-      shared_is_playing: ctx.shared_is_playing,
-      recovery_tx: ctx.recovery_tx,
-      #[cfg(all(feature = "mpris", target_os = "linux"))]
-      mpris_manager: ctx.mpris_manager,
-      #[cfg(all(feature = "macos-media", target_os = "macos"))]
-      macos_media_manager: ctx.macos_media_manager,
-      #[cfg(all(feature = "windows-media", target_os = "windows"))]
-      windows_media_manager: ctx.windows_media_manager,
-    });
-
-    // Auto-select the saved playback device when available (fallback to native
-    // streaming). This used to run inline in the network task before the pump
-    // started; the decision's outcome now dispatches through the pump.
-    let device_name = streaming_player.device_name().to_string();
-    let saved_device_id = ctx.client_config.device_id.clone();
-    let mut devices_snapshot = None;
-    if let Ok(devices) =
-      spotify_get_typed_compat_for_with_refresh::<rspotify::model::device::DevicePayload>(
-        &ctx.spotify,
-        "me/player/devices",
-        &[],
-        &ctx.token_cache_path,
-        &ctx.app,
-      )
-      .await
-    {
-      let devices_vec = devices.devices;
-      let mut app_mut = ctx.app.lock().await;
-      app_mut.devices = Some(rspotify::model::device::DevicePayload {
-        devices: devices_vec.clone(),
-      });
-      devices_snapshot = Some(devices_vec);
-    }
-
-    let startup_decision = startup_device_decision(
-      ctx.device_startup_behavior,
-      saved_device_id,
-      devices_snapshot.as_deref(),
-      &device_name,
-    );
-
+    .await
+  {
+    let devices_vec = devices.devices;
     let mut app_mut = ctx.app.lock().await;
-    if let Some(message) = startup_decision.status_message {
-      app_mut.set_status_message(message, 5);
-    }
-    if let Some(event) = startup_decision.event {
-      app_mut.dispatch(event.into_io_event());
-    }
+    app_mut.devices = Some(rspotify::model::device::DevicePayload {
+      devices: devices_vec.clone(),
+    });
+    devices_snapshot = Some(devices_vec);
+  }
+
+  let startup_decision = startup_device_decision(
+    ctx.device_startup_behavior,
+    saved_device_id,
+    devices_snapshot.as_deref(),
+    &device_name,
+  );
+
+  let mut app_mut = ctx.app.lock().await;
+  if let Some(message) = startup_decision.status_message {
+    app_mut.set_status_message(message, 5);
+  }
+  if let Some(event) = startup_decision.event {
+    app_mut.dispatch(event.into_io_event());
   }
 }
 
@@ -1205,6 +1207,38 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   // Launch the UI (async)
   } else {
     info!("launching interactive terminal ui");
+    #[cfg(feature = "streaming")]
+    if client_config.enable_streaming
+      && !player::streaming_credentials_are_cached().unwrap_or(false)
+    {
+      if let Some(spotify) = spotify.as_ref() {
+        let (supported, status_message) = account_supports_native_streaming(
+          spotify,
+          cached_me.clone(),
+          &final_token_cache_path,
+          &app,
+        )
+        .await;
+        if let Some(message) = status_message {
+          app.lock().await.set_status_message(message, 12);
+        }
+        if supported {
+          // The OAuth flow spins up a blocking local callback server and waits on
+          // the browser; keep it off the async reactor so it never ties up a
+          // worker thread while the user completes sign-in.
+          let cached = tokio::task::spawn_blocking(player::ensure_streaming_credentials_cached)
+            .await
+            .unwrap_or_else(|e| Err(anyhow::anyhow!("credential caching task panicked: {e}")));
+          if let Err(error) = cached {
+            warn!("native streaming authentication unavailable: {error}");
+            app.lock().await.set_status_message(
+              "Native streaming authentication failed; using Spotify Connect.",
+              10,
+            );
+          }
+        }
+      }
+    }
     crate::infra::history::spawn_history_collector(Arc::clone(&app));
     // Native streaming needs a Spotify session; when it will be attempted, the
     // account probe and librespot handshake run in a background task after the
@@ -1579,7 +1613,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     let shared_pos_for_start_ui: Option<Arc<AtomicU64>> = Some(shared_position_for_ui);
     #[cfg(not(feature = "streaming"))]
     let shared_pos_for_start_ui: Option<Arc<AtomicU64>> = None;
-    crate::tui::runner::start_ui(
+    let ui_result = crate::tui::runner::start_ui(
       user_config,
       &cloned_app,
       shared_pos_for_start_ui,
@@ -1589,7 +1623,11 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
       None,
       discord_rpc_manager,
     )
-    .await?;
+    .await;
+    if ui_result.is_err() {
+      cloned_app.lock().await.flush_config_save(true);
+    }
+    ui_result?;
   }
 
   Ok(())
@@ -1762,7 +1800,7 @@ async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Ne
         Some(io_event) => io_event,
         None => break,
       },
-      _ = party_poll.tick() => {
+      _ = party_poll.tick(), if network.party_incoming_rx.is_some() => {
         network.process_party_messages().await;
         continue;
       }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -227,21 +227,31 @@ fn subscription_level_label(level: rspotify::model::SubscriptionLevel) -> &'stat
   }
 }
 
+/// Runs after the UI is up (see `deferred_streaming_startup`), so outcomes are
+/// reported via `info!` + the returned status message only — never `println!`,
+/// which would corrupt the TUI. Reuses the `/me` captured during token
+/// validation when available instead of paying a second round trip.
 #[cfg(feature = "streaming")]
 async fn account_supports_native_streaming(
   spotify: &AuthCodePkceSpotify,
+  cached_me: Option<PrivateUser>,
   token_cache_path: &Path,
   app: &Arc<Mutex<App>>,
 ) -> (bool, Option<&'static str>) {
-  match spotify_get_typed_compat_for_with_refresh::<PrivateUser>(
-    spotify,
-    "me",
-    &[],
-    token_cache_path,
-    app,
-  )
-  .await
-  {
+  let user_result = match cached_me {
+    Some(user) => Ok(user),
+    None => {
+      spotify_get_typed_compat_for_with_refresh::<PrivateUser>(
+        spotify,
+        "me",
+        &[],
+        token_cache_path,
+        app,
+      )
+      .await
+    }
+  };
+  match user_result {
     #[allow(deprecated)]
     Ok(user) => match user.product {
       Some(rspotify::model::SubscriptionLevel::Premium) => (true, None),
@@ -251,10 +261,6 @@ async fn account_supports_native_streaming(
           "spotify {} account detected: playback is unavailable (native streaming and Web API playback controls require premium)",
           plan
         );
-        println!(
-          "Spotify {} account detected. Playback is unavailable in spotatui: native streaming (librespot) and Web API playback controls both require Premium. Browsing/search/library views still work.",
-          plan
-        );
         (
           false,
           Some("Spotify Free account: playback controls unavailable (Premium required)"),
@@ -262,9 +268,6 @@ async fn account_supports_native_streaming(
       }
       None => {
         info!("spotify account level unknown: native streaming disabled to avoid librespot exit");
-        println!(
-          "Could not determine Spotify subscription level. Native streaming is disabled to avoid startup exit. If this account is not Premium, playback controls will not work; browsing/search/library views still work."
-        );
         (
           false,
           Some("Could not verify Spotify plan: native streaming disabled"),
@@ -275,9 +278,6 @@ async fn account_supports_native_streaming(
       info!(
         "spotify account level check failed ({}); native streaming disabled to avoid librespot exit",
         e
-      );
-      println!(
-        "Could not verify Spotify subscription level. Native streaming is disabled to avoid startup exit. If this account is not Premium, playback controls will not work; browsing/search/library views still work."
       );
       (
         false,
@@ -619,6 +619,218 @@ async fn run_auto_update(matches: &ArgMatches, user_config: &UserConfig) {
 #[cfg(not(feature = "self-update"))]
 async fn run_auto_update(_matches: &ArgMatches, _user_config: &UserConfig) {}
 
+/// Everything native streaming needs that used to gate the first frame:
+/// account probe, librespot session handshake, player event handler, and the
+/// saved-device startup decision. Bundled so `deferred_streaming_startup` can
+/// run it all on a background task after the UI is already up.
+#[cfg(feature = "streaming")]
+struct DeferredStreamingContext {
+  app: Arc<Mutex<App>>,
+  spotify: AuthCodePkceSpotify,
+  cached_me: Option<PrivateUser>,
+  token_cache_path: PathBuf,
+  client_config: ClientConfig,
+  redirect_uri: String,
+  volume_percent: u8,
+  device_startup_behavior: StartupBehavior,
+  /// Spotify startup Play/Pause, run after the device decision so it lands on
+  /// the selected device instead of 404ing with NO_ACTIVE_DEVICE while init is
+  /// still in flight. `None` when a non-Spotify session restore owns startup.
+  spotify_startup_behavior: Option<StartupBehavior>,
+  initial_shuffle_enabled: bool,
+  recovery_tx: tokio::sync::mpsc::UnboundedSender<player::StreamingRecoveryRequest>,
+  shared_position: Arc<AtomicU64>,
+  shared_is_playing: Arc<std::sync::atomic::AtomicBool>,
+  #[cfg(all(feature = "mpris", target_os = "linux"))]
+  mpris_manager: Option<Arc<mpris::MprisManager>>,
+  #[cfg(all(feature = "macos-media", target_os = "macos"))]
+  macos_media_manager: Option<Arc<macos_media::MacMediaManager>>,
+  #[cfg(all(feature = "windows-media", target_os = "windows"))]
+  windows_media_manager: Option<Arc<smtc_tokio::WindowsMediaManager>>,
+}
+
+/// Initialize native streaming in the background (D1). The UI renders its
+/// first frame immediately; this task probes the account (reusing the auth
+/// `/me` when available), performs the librespot handshake with the same
+/// double-timeout as before, stores the player in `App`, spawns the player
+/// event handler, and finally makes the saved-device startup decision —
+/// dispatching its outcome through the normal IoEvent pump.
+#[cfg(feature = "streaming")]
+fn deferred_streaming_startup(ctx: DeferredStreamingContext) {
+  tokio::spawn(async move {
+    let app = Arc::clone(&ctx.app);
+    let spotify_startup_behavior = ctx.spotify_startup_behavior;
+    let initial_shuffle_enabled = ctx.initial_shuffle_enabled;
+    deferred_streaming_startup_inner(ctx).await;
+    // Whatever happened above (backend up, unsupported account, failed or
+    // timed-out init), the pending window is over.
+    let mut app = app.lock().await;
+    app.native_backend_pending = false;
+    // The Spotify startup Play/Pause runs here, after the device decision:
+    // before init was deferred, the device transfer always completed first,
+    // and firing these earlier 404s with NO_ACTIVE_DEVICE straight onto the
+    // Error screen. A request the user parked during init takes precedence
+    // over the configured startup behavior — their intent is newer.
+    if app.pending_start_playback.is_none() {
+      match spotify_startup_behavior {
+        Some(StartupBehavior::Play) => {
+          app.dispatch(IoEvent::Shuffle(initial_shuffle_enabled));
+          app.dispatch(IoEvent::StartPlayback(None, None, None));
+        }
+        Some(StartupBehavior::Pause) => {
+          app.dispatch(IoEvent::PausePlayback);
+        }
+        Some(StartupBehavior::Continue) | None => {}
+      }
+    }
+    // A StartPlayback parked during init replays now — against the native
+    // backend when it exists, else through the normal Connect path.
+    app.replay_pending_start_playback();
+  });
+}
+
+#[cfg(feature = "streaming")]
+async fn deferred_streaming_startup_inner(ctx: DeferredStreamingContext) {
+  {
+    let (supported, status_message) = account_supports_native_streaming(
+      &ctx.spotify,
+      ctx.cached_me,
+      &ctx.token_cache_path,
+      &ctx.app,
+    )
+    .await;
+    if let Some(message) = status_message {
+      ctx.app.lock().await.set_status_message(message, 12);
+    }
+    if !supported {
+      return;
+    }
+
+    info!("initializing native streaming player");
+    let streaming_config = player::StreamingConfig {
+      device_name: ctx.client_config.streaming_device_name.clone(),
+      bitrate: ctx.client_config.streaming_bitrate,
+      audio_cache: ctx.client_config.streaming_audio_cache,
+      cache_path: player::get_default_cache_path(),
+      initial_volume: ctx.volume_percent,
+    };
+    let client_id = ctx.client_config.client_id.clone();
+    let redirect_uri = ctx.redirect_uri.clone();
+
+    // Internal Spirc timeout defaults to 30s (configurable via
+    // SPOTATUI_STREAMING_INIT_TIMEOUT_SECS). The outer timeout here is a safety net
+    // that catches hangs *outside* Spirc init (e.g. OAuth callback never arriving,
+    // blocking I/O in credential retrieval). Set it above the internal timeout.
+    let internal_timeout_secs: u64 = std::env::var("SPOTATUI_STREAMING_INIT_TIMEOUT_SECS")
+      .ok()
+      .and_then(|v| v.parse().ok())
+      .filter(|&v: &u64| v > 0)
+      .unwrap_or(30);
+    let outer_timeout = Duration::from_secs(internal_timeout_secs.saturating_add(15));
+
+    let init_task = tokio::spawn(async move {
+      player::StreamingPlayer::new(&client_id, &redirect_uri, streaming_config).await
+    });
+    let abort_handle = init_task.abort_handle();
+
+    let streaming_player = match tokio::time::timeout(outer_timeout, init_task).await {
+      Ok(Ok(Ok(p))) => {
+        info!(
+          "native streaming player initialized as '{}'",
+          p.device_name()
+        );
+        // Note: We don't activate() here - that's handled by AutoSelectStreamingDevice
+        // which respects the user's saved device preference (e.g., spotifyd)
+        Arc::new(p)
+      }
+      Ok(Ok(Err(e))) => {
+        info!(
+          "failed to initialize streaming: {} - falling back to web api",
+          e
+        );
+        return;
+      }
+      Ok(Err(e)) => {
+        info!(
+          "streaming initialization panicked: {} - falling back to web api",
+          e
+        );
+        return;
+      }
+      Err(_) => {
+        abort_handle.abort();
+        warn!(
+          "streaming initialization hung unexpectedly (outer timeout {}s) - falling back to web api",
+          outer_timeout.as_secs()
+        );
+        return;
+      }
+    };
+
+    info!("native playback enabled - spotatui is available as a spotify connect device");
+
+    // Store streaming player reference in App for direct control (bypasses event channel)
+    {
+      let mut app_mut = ctx.app.lock().await;
+      app_mut.streaming_player = Some(Arc::clone(&streaming_player));
+    }
+
+    // Spawn player event listener (updates app state from native player events)
+    player::spawn_player_event_handler(player::PlayerEventContext {
+      player: Arc::clone(&streaming_player),
+      app: Arc::clone(&ctx.app),
+      shared_position: ctx.shared_position,
+      shared_is_playing: ctx.shared_is_playing,
+      recovery_tx: ctx.recovery_tx,
+      #[cfg(all(feature = "mpris", target_os = "linux"))]
+      mpris_manager: ctx.mpris_manager,
+      #[cfg(all(feature = "macos-media", target_os = "macos"))]
+      macos_media_manager: ctx.macos_media_manager,
+      #[cfg(all(feature = "windows-media", target_os = "windows"))]
+      windows_media_manager: ctx.windows_media_manager,
+    });
+
+    // Auto-select the saved playback device when available (fallback to native
+    // streaming). This used to run inline in the network task before the pump
+    // started; the decision's outcome now dispatches through the pump.
+    let device_name = streaming_player.device_name().to_string();
+    let saved_device_id = ctx.client_config.device_id.clone();
+    let mut devices_snapshot = None;
+    if let Ok(devices) =
+      spotify_get_typed_compat_for_with_refresh::<rspotify::model::device::DevicePayload>(
+        &ctx.spotify,
+        "me/player/devices",
+        &[],
+        &ctx.token_cache_path,
+        &ctx.app,
+      )
+      .await
+    {
+      let devices_vec = devices.devices;
+      let mut app_mut = ctx.app.lock().await;
+      app_mut.devices = Some(rspotify::model::device::DevicePayload {
+        devices: devices_vec.clone(),
+      });
+      devices_snapshot = Some(devices_vec);
+    }
+
+    let startup_decision = startup_device_decision(
+      ctx.device_startup_behavior,
+      saved_device_id,
+      devices_snapshot.as_deref(),
+      &device_name,
+    );
+
+    let mut app_mut = ctx.app.lock().await;
+    if let Some(message) = startup_decision.status_message {
+      app_mut.set_status_message(message, 5);
+    }
+    if let Some(event) = startup_decision.event {
+      app_mut.dispatch(event.into_io_event());
+    }
+  }
+}
+
 pub async fn run() -> Result<()> {
   setup_logging()?;
   info!("spotatui {} starting up", env!("CARGO_PKG_VERSION"));
@@ -729,8 +941,6 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   }
   user_config.load_config()?;
   info!("user config loaded successfully");
-
-  run_auto_update(&matches, &user_config).await;
 
   let initial_shuffle_enabled = user_config.behavior.shuffle_enabled;
   let initial_startup_behavior = user_config.behavior.startup_behavior;
@@ -897,11 +1107,23 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   let spotify_required = matches.subcommand_name().is_some()
     || user_config.behavior.active_source == crate::core::source::Source::Spotify;
 
-  let authenticated: Option<auth::AuthenticatedClient> = if spotify_required {
-    Some(auth::authenticate_with_fallback(&mut client_config, &config_paths).await?)
-  } else {
-    auth::try_load_spotify_silently(&mut client_config, &config_paths).await
-  };
+  // The GitHub update check runs concurrently with authentication: both are
+  // network round trips and neither depends on the other, so the check no
+  // longer adds its own latency to startup. (An update that actually installs
+  // still restarts the process, exactly as before.)
+  let (authenticated, _) = tokio::join!(
+    async {
+      if spotify_required {
+        auth::authenticate_with_fallback(&mut client_config, &config_paths)
+          .await
+          .map(Some)
+      } else {
+        Ok(auth::try_load_spotify_silently(&mut client_config, &config_paths).await)
+      }
+    },
+    run_auto_update(&matches, &user_config)
+  );
+  let authenticated: Option<auth::AuthenticatedClient> = authenticated?;
 
   // Redirect URI for native streaming: from the authenticated client when a
   // Spotify session exists, else the configured default (streaming stays off
@@ -918,6 +1140,11 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     .unwrap_or_else(|| {
       auth::token_cache_path_for_client(&config_paths.token_cache_path, &client_config.client_id)
     });
+
+  // The /me captured while validating the cached token; the streaming account
+  // probe reuses it instead of a second round trip.
+  #[cfg(feature = "streaming")]
+  let cached_me = authenticated.as_ref().and_then(|a| a.me.clone());
 
   // Persist whatever token is now in memory and verify it. All later Spotify
   // requests go through spotatui's refresh-and-cache path so the on-disk token
@@ -979,107 +1206,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   } else {
     info!("launching interactive terminal ui");
     crate::infra::history::spawn_history_collector(Arc::clone(&app));
-    // Native streaming needs a Spotify session; skip the probe entirely when
-    // launched against a free source (spotify is None).
+    // Native streaming needs a Spotify session; when it will be attempted, the
+    // account probe and librespot handshake run in a background task after the
+    // UI is up (see `deferred_streaming_startup`) instead of gating the first
+    // frame for seconds (worst case tens of seconds).
     #[cfg(feature = "streaming")]
-    let (streaming_supported_for_account, streaming_startup_status_message) =
-      if let (true, Some(spotify_client)) = (client_config.enable_streaming, spotify.as_ref()) {
-        account_supports_native_streaming(spotify_client, &final_token_cache_path, &app).await
-      } else {
-        (false, None)
-      };
-
-    #[cfg(feature = "streaming")]
-    if let Some(message) = streaming_startup_status_message {
-      let mut app_mut = app.lock().await;
-      app_mut.set_status_message(message, 12);
-    }
-
-    // Initialize streaming player if enabled
-    #[cfg(feature = "streaming")]
-    let streaming_player = if client_config.enable_streaming && streaming_supported_for_account {
-      info!("initializing native streaming player");
-      let streaming_config = player::StreamingConfig {
-        device_name: client_config.streaming_device_name.clone(),
-        bitrate: client_config.streaming_bitrate,
-        audio_cache: client_config.streaming_audio_cache,
-        cache_path: player::get_default_cache_path(),
-        initial_volume: user_config.behavior.volume_percent,
-      };
-
-      let client_id = client_config.client_id.clone();
-      let redirect_uri = selected_redirect_uri.clone();
-
-      // Internal Spirc timeout defaults to 30s (configurable via
-      // SPOTATUI_STREAMING_INIT_TIMEOUT_SECS). The outer timeout here is a safety net
-      // that catches hangs *outside* Spirc init (e.g. OAuth callback never arriving,
-      // blocking I/O in credential retrieval). Set it above the internal timeout.
-      let internal_timeout_secs: u64 = std::env::var("SPOTATUI_STREAMING_INIT_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&v: &u64| v > 0)
-        .unwrap_or(30);
-      let outer_timeout = Duration::from_secs(internal_timeout_secs.saturating_add(15));
-
-      let init_task = tokio::spawn(async move {
-        player::StreamingPlayer::new(&client_id, &redirect_uri, streaming_config).await
-      });
-      let abort_handle = init_task.abort_handle();
-
-      match tokio::time::timeout(outer_timeout, init_task).await {
-        Ok(Ok(Ok(p))) => {
-          info!(
-            "native streaming player initialized as '{}'",
-            p.device_name()
-          );
-          // Note: We don't activate() here - that's handled by AutoSelectStreamingDevice
-          // which respects the user's saved device preference (e.g., spotifyd)
-          Some(Arc::new(p))
-        }
-        Ok(Ok(Err(e))) => {
-          info!(
-            "failed to initialize streaming: {} - falling back to web api",
-            e
-          );
-          None
-        }
-        Ok(Err(e)) => {
-          info!(
-            "streaming initialization panicked: {} - falling back to web api",
-            e
-          );
-          None
-        }
-        Err(_) => {
-          abort_handle.abort();
-          warn!(
-            "streaming initialization hung unexpectedly (outer timeout {}s) - falling back to web api",
-            outer_timeout.as_secs()
-          );
-          None
-        }
-      }
-    } else {
-      None
-    };
-
-    #[cfg(feature = "streaming")]
-    if streaming_player.is_some() {
-      info!("native playback enabled - spotatui is available as a spotify connect device");
-    }
-
-    // Store streaming player reference in App for direct control (bypasses event channel)
-    #[cfg(feature = "streaming")]
-    {
-      let mut app_mut = app.lock().await;
-      app_mut.streaming_player = streaming_player.clone();
-    }
-
-    // Clone the device name for startup device selection in the network task.
-    #[cfg(feature = "streaming")]
-    let streaming_device_name = streaming_player
-      .as_ref()
-      .map(|p| p.device_name().to_string());
+    let streaming_attempted = client_config.enable_streaming && spotify.is_some();
 
     // Create shared atomic for real-time position updates from native player
     // This avoids lock contention - the player event handler can update position
@@ -1137,45 +1269,47 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
 
     // Initialize macOS Now Playing integration for media key control
     // This registers with MPRemoteCommandCenter for media key events
+    // Gated on whether streaming will be attempted (the player itself now
+    // initializes in the background): registering media keys for a session
+    // whose native init later fails is harmless — the handlers just no-op.
     #[cfg(all(feature = "macos-media", target_os = "macos"))]
-    let macos_media_manager: Option<Arc<macos_media::MacMediaManager>> =
-      if streaming_player.is_some() {
-        match macos_media::MacMediaManager::new() {
-          Ok(mgr) => {
-            info!("macos now playing interface registered - media keys enabled");
-            Some(Arc::new(mgr))
-          }
-          Err(e) => {
-            info!(
-              "failed to initialize macos media control: {} - media keys disabled",
-              e
-            );
-            None
-          }
+    let macos_media_manager: Option<Arc<macos_media::MacMediaManager>> = if streaming_attempted {
+      match macos_media::MacMediaManager::new() {
+        Ok(mgr) => {
+          info!("macos now playing interface registered - media keys enabled");
+          Some(Arc::new(mgr))
         }
-      } else {
-        None
-      };
+        Err(e) => {
+          info!(
+            "failed to initialize macos media control: {} - media keys disabled",
+            e
+          );
+          None
+        }
+      }
+    } else {
+      None
+    };
 
     #[cfg(all(feature = "windows-media", target_os = "windows"))]
-    let windows_media_manager: Option<Arc<smtc_tokio::WindowsMediaManager>> =
-      if streaming_player.is_some() {
-        match smtc_tokio::WindowsMediaManager::new() {
-          Ok(mgr) => {
-            info!("windows smtc com registered - media keys enabled");
-            Some(Arc::new(mgr))
-          }
-          Err(e) => {
-            info!(
-              "failed to initialize windows smtc com: {} - media keys disabled",
-              e
-            );
-            None
-          }
+    let windows_media_manager: Option<Arc<smtc_tokio::WindowsMediaManager>> = if streaming_attempted
+    {
+      match smtc_tokio::WindowsMediaManager::new() {
+        Ok(mgr) => {
+          info!("windows smtc com registered - media keys enabled");
+          Some(Arc::new(mgr))
         }
-      } else {
-        None
-      };
+        Err(e) => {
+          info!(
+            "failed to initialize windows smtc com: {} - media keys disabled",
+            e
+          );
+          None
+        }
+      }
+    } else {
+      None
+    };
 
     #[cfg(feature = "discord-rpc")]
     let discord_rpc_manager: DiscordRpcHandle = if user_config.behavior.enable_discord_rpc {
@@ -1309,15 +1443,47 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     #[cfg(all(feature = "windows-media", target_os = "windows"))]
     let windows_media_for_events = windows_media_manager.clone();
 
-    // Spawn player event listener (updates app state from native player events)
+    // Kick off the deferred native-streaming startup: account probe, librespot
+    // handshake, player event handler, and saved-device startup decision all
+    // run on a background task while the UI renders (see
+    // `deferred_streaming_startup`).
     #[cfg(feature = "streaming")]
-    if let Some(ref player) = streaming_player {
-      player::spawn_player_event_handler(player::PlayerEventContext {
-        player: Arc::clone(player),
+    if streaming_attempted {
+      // When resuming a non-Spotify session, never transfer Spotify playback
+      // to a device on startup — that would fight the restored source for the
+      // audio output. Treat the device decision as passive (Continue); the
+      // device list is still fetched for the UI.
+      let device_startup_behavior = if restore_playback.is_some() {
+        StartupBehavior::Continue
+      } else {
+        initial_startup_behavior
+      };
+      // While init is running, a playback request that finds no active device
+      // parks itself for replay instead of erroring (the task clears this and
+      // replays whatever parked when it finishes, whatever the outcome).
+      app.lock().await.native_backend_pending = true;
+      deferred_streaming_startup(DeferredStreamingContext {
         app: Arc::clone(&app),
+        spotify: spotify
+          .clone()
+          .expect("streaming_attempted implies a Spotify session"),
+        cached_me,
+        token_cache_path: final_token_cache_path.clone(),
+        client_config: client_config.clone(),
+        redirect_uri: selected_redirect_uri.clone(),
+        volume_percent: user_config.behavior.volume_percent,
+        device_startup_behavior,
+        // A restored non-Spotify session owns the startup play/pause decision;
+        // otherwise the deferred task fires it once the device is selected.
+        spotify_startup_behavior: if restore_playback.is_some() {
+          None
+        } else {
+          Some(initial_startup_behavior)
+        },
+        initial_shuffle_enabled,
+        recovery_tx: streaming_recovery_tx.clone(),
         shared_position: shared_position_for_events,
         shared_is_playing: shared_is_playing_for_events,
-        recovery_tx: streaming_recovery_tx.clone(),
         #[cfg(all(feature = "mpris", target_os = "linux"))]
         mpris_manager: mpris_for_events,
         #[cfg(all(feature = "macos-media", target_os = "macos"))]
@@ -1354,49 +1520,9 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
       #[cfg(not(feature = "streaming"))]
       let mut network = Network::new(spotify, client_config, &app, final_token_cache_path);
 
-      // Auto-select the saved playback device when available (fallback to native streaming).
-      #[cfg(feature = "streaming")]
-      if let Some(device_name) = streaming_device_name {
-        let saved_device_id = network.client_config.device_id.clone();
-        let mut devices_snapshot = None;
-
-        if let Ok(devices) = network
-          .spotify_get_typed::<rspotify::model::device::DevicePayload>("me/player/devices", &[])
-          .await
-        {
-          let devices_vec = devices.devices;
-          let mut app = network.app.lock().await;
-          app.devices = Some(rspotify::model::device::DevicePayload {
-            devices: devices_vec.clone(),
-          });
-          devices_snapshot = Some(devices_vec);
-        }
-
-        // When resuming a non-Spotify session, never transfer Spotify playback
-        // to a device on startup — that would fight the restored source for the
-        // audio output. Treat the device decision as passive (Continue); the
-        // device list is still fetched above for the UI.
-        let device_startup_behavior = if restore_playback.is_some() {
-          StartupBehavior::Continue
-        } else {
-          initial_startup_behavior
-        };
-        let startup_decision = startup_device_decision(
-          device_startup_behavior,
-          saved_device_id,
-          devices_snapshot.as_deref(),
-          &device_name,
-        );
-
-        if let Some(message) = startup_decision.status_message {
-          let mut app = network.app.lock().await;
-          app.set_status_message(message, 5);
-        }
-
-        if let Some(event) = startup_decision.event {
-          network.handle_network_event(event.into_io_event()).await;
-        }
-      }
+      // The saved-device startup decision moved into
+      // `deferred_streaming_startup` (it needs the native player's device
+      // name, which now materializes in the background).
 
       // Resume a persisted non-Spotify session if there is one; it honors the
       // startup behavior for its own play/pause decision. Otherwise fall back to
@@ -1419,19 +1545,28 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
         });
       } else if network.spotify.is_some() {
         // Spotify startup play/pause only applies with a Spotify session; a
-        // free-source launch has nothing to activate here.
-        match initial_startup_behavior {
-          StartupBehavior::Continue => {}
-          StartupBehavior::Play => {
-            network
-              .handle_network_event(IoEvent::Shuffle(initial_shuffle_enabled))
-              .await;
-            network
-              .handle_network_event(IoEvent::StartPlayback(None, None, None))
-              .await;
-          }
-          StartupBehavior::Pause => {
-            network.handle_network_event(IoEvent::PausePlayback).await;
+        // free-source launch has nothing to activate here. When native
+        // streaming init is deferred, `deferred_streaming_startup` fires this
+        // after the device decision instead — running it here would race the
+        // init and 404 with NO_ACTIVE_DEVICE onto the Error screen.
+        #[cfg(feature = "streaming")]
+        let startup_behavior_runs_here = !streaming_attempted;
+        #[cfg(not(feature = "streaming"))]
+        let startup_behavior_runs_here = true;
+        if startup_behavior_runs_here {
+          match initial_startup_behavior {
+            StartupBehavior::Continue => {}
+            StartupBehavior::Play => {
+              network
+                .handle_network_event(IoEvent::Shuffle(initial_shuffle_enabled))
+                .await;
+              network
+                .handle_network_event(IoEvent::StartPlayback(None, None, None))
+                .await;
+            }
+            StartupBehavior::Pause => {
+              network.handle_network_event(IoEvent::PausePlayback).await;
+            }
           }
         }
       }
@@ -1603,78 +1738,119 @@ async fn restore_playback_session(
 }
 
 async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Network) {
+  // Bridge the sync dispatch channel onto the async runtime: a dedicated
+  // thread does blocking recv() and forwards into a tokio channel the pump can
+  // await, replacing the old try_recv() + 5ms sleep poll (which added 0-5ms
+  // latency to every event and busy-woke the task while idle).
+  let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::unbounded_channel::<IoEvent>();
+  std::thread::spawn(move || {
+    while let Ok(io_event) = io_rx.recv() {
+      if bridge_tx.send(io_event).is_err() {
+        break;
+      }
+    }
+  });
+
+  // Party relay messages used to piggyback on the 5ms poll loop; with the pump
+  // parked on recv(), drain them on an interval instead.
+  let mut party_poll = tokio::time::interval(std::time::Duration::from_millis(25));
+  party_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
   loop {
-    match io_rx.try_recv() {
-      Ok(io_event) => {
-        // The native queue router runs first: it owns `AdvanceNativeQueue` and
-        // the queue slot's transport controls, and relinquishes the slot on an
-        // unrelated `StartPlayback` (returning false so the per-source
-        // teardowns/starts still run). Compiled unconditionally.
-        let handled_queue =
-          crate::infra::queue::dispatch::route_queue_event(&network.app, &io_event).await;
-        // Local-file playback is intercepted before the Spotify network so the
-        // network stays Spotify-only (see infra::local::dispatch).
-        let handled_locally = !handled_queue && {
-          #[cfg(feature = "local-files")]
-          {
-            crate::infra::local::dispatch::route_local_event(&network.app, &io_event).await
-          }
-          #[cfg(not(feature = "local-files"))]
-          {
-            false
-          }
-        };
-        // Subsonic is intercepted after local and before the Spotify network. A
-        // `subsonic:` URI falls through the local dispatch (its `is_file_uri` is
-        // false) and is caught here (see infra::subsonic::dispatch). Skipped when
-        // local already consumed the event.
-        #[cfg(feature = "subsonic")]
-        let handled_subsonic = !handled_queue
-          && !handled_locally
-          && crate::infra::subsonic::dispatch::route_subsonic_event(&network.app, &io_event).await;
-        #[cfg(not(feature = "subsonic"))]
-        let handled_subsonic = false;
-        // Internet radio is intercepted last before the Spotify network. A
-        // `radio:` URI falls through both earlier dispatches and is caught here
-        // (see infra::radio::dispatch). Skipped when already consumed.
-        #[cfg(feature = "internet-radio")]
-        let handled_radio = !handled_queue
-          && !handled_locally
-          && !handled_subsonic
-          && crate::infra::radio::dispatch::route_radio_event(&network.app, &io_event).await;
-        #[cfg(not(feature = "internet-radio"))]
-        let handled_radio = false;
-        // YouTube is intercepted last before the Spotify network. A `youtube:`
-        // URI falls through the three earlier dispatches and is caught here
-        // (see infra::youtube::dispatch). Skipped when already consumed.
-        #[cfg(feature = "youtube")]
-        let handled_youtube = !handled_queue
-          && !handled_locally
-          && !handled_subsonic
-          && !handled_radio
-          && crate::infra::youtube::dispatch::route_youtube_event(&network.app, &io_event).await;
-        #[cfg(not(feature = "youtube"))]
-        let handled_youtube = false;
-        if !handled_queue
-          && !handled_locally
-          && !handled_subsonic
-          && !handled_radio
-          && !handled_youtube
+    let io_event = tokio::select! {
+      maybe_event = bridge_rx.recv() => match maybe_event {
+        Some(io_event) => io_event,
+        None => break,
+      },
+      _ = party_poll.tick() => {
+        network.process_party_messages().await;
+        continue;
+      }
+    };
+
+    // Source-agnostic service events (lyrics, cover art, telemetry,
+    // announcements, friends, stats/recap) only touch `App` and their own HTTP
+    // clients — never the Spotify client, pacing, or `Network` state — so they
+    // run concurrently on a detached task instead of queueing behind
+    // rate-limited Spotify calls on this serial pump (and vice versa).
+    if Network::runs_on_service_lane(&io_event) {
+      let mut service_network = Network::new(
+        None,
+        network.client_config.clone(),
+        &network.app,
+        network.token_cache_path.clone(),
+      );
+      tokio::spawn(async move {
+        service_network.handle_network_event(io_event).await;
+      });
+      continue;
+    }
+
+    {
+      // The native queue router runs first: it owns `AdvanceNativeQueue` and
+      // the queue slot's transport controls, and relinquishes the slot on an
+      // unrelated `StartPlayback` (returning false so the per-source
+      // teardowns/starts still run). Compiled unconditionally.
+      let handled_queue =
+        crate::infra::queue::dispatch::route_queue_event(&network.app, &io_event).await;
+      // Local-file playback is intercepted before the Spotify network so the
+      // network stays Spotify-only (see infra::local::dispatch).
+      let handled_locally = !handled_queue && {
+        #[cfg(feature = "local-files")]
         {
-          network.handle_network_event(io_event).await;
-        } else {
-          // A source router consumed the event and returned without touching
-          // `is_loading`, which `App::dispatch` set to true. Only
-          // `handle_network_event` resets it, and we skipped that path, so clear
-          // it here — otherwise selecting/loading Local, Subsonic, Radio, or
-          // YouTube content leaves the UI stuck on the loading indicator.
-          network.app.lock().await.is_loading = false;
+          crate::infra::local::dispatch::route_local_event(&network.app, &io_event).await
         }
+        #[cfg(not(feature = "local-files"))]
+        {
+          false
+        }
+      };
+      // Subsonic is intercepted after local and before the Spotify network. A
+      // `subsonic:` URI falls through the local dispatch (its `is_file_uri` is
+      // false) and is caught here (see infra::subsonic::dispatch). Skipped when
+      // local already consumed the event.
+      #[cfg(feature = "subsonic")]
+      let handled_subsonic = !handled_queue
+        && !handled_locally
+        && crate::infra::subsonic::dispatch::route_subsonic_event(&network.app, &io_event).await;
+      #[cfg(not(feature = "subsonic"))]
+      let handled_subsonic = false;
+      // Internet radio is intercepted last before the Spotify network. A
+      // `radio:` URI falls through both earlier dispatches and is caught here
+      // (see infra::radio::dispatch). Skipped when already consumed.
+      #[cfg(feature = "internet-radio")]
+      let handled_radio = !handled_queue
+        && !handled_locally
+        && !handled_subsonic
+        && crate::infra::radio::dispatch::route_radio_event(&network.app, &io_event).await;
+      #[cfg(not(feature = "internet-radio"))]
+      let handled_radio = false;
+      // YouTube is intercepted last before the Spotify network. A `youtube:`
+      // URI falls through the three earlier dispatches and is caught here
+      // (see infra::youtube::dispatch). Skipped when already consumed.
+      #[cfg(feature = "youtube")]
+      let handled_youtube = !handled_queue
+        && !handled_locally
+        && !handled_subsonic
+        && !handled_radio
+        && crate::infra::youtube::dispatch::route_youtube_event(&network.app, &io_event).await;
+      #[cfg(not(feature = "youtube"))]
+      let handled_youtube = false;
+      if !handled_queue
+        && !handled_locally
+        && !handled_subsonic
+        && !handled_radio
+        && !handled_youtube
+      {
+        network.handle_network_event(io_event).await;
+      } else {
+        // A source router consumed the event and returned without touching
+        // `is_loading`, which `App::dispatch` set to true. Only
+        // `handle_network_event` resets it, and we skipped that path, so clear
+        // it here — otherwise selecting/loading Local, Subsonic, Radio, or
+        // YouTube content leaves the UI stuck on the loading indicator.
+        network.app.lock().await.is_loading = false;
       }
-      Err(std::sync::mpsc::TryRecvError::Empty) => {
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-      }
-      Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
     }
     network.process_party_messages().await;
   }

--- a/src/tui/event/events.rs
+++ b/src/tui/event/events.rs
@@ -71,8 +71,10 @@ impl Events {
       loop {
         let tick_rate = Duration::from_millis(event_tick_rate_milliseconds.load(Ordering::Relaxed));
 
-        // poll for tick rate duration, if no event, sent tick event.
-        if event::poll(tick_rate).unwrap() {
+        // Poll only until the next tick is due, so input events don't push the
+        // tick schedule back.
+        let poll_timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if event::poll(poll_timeout).unwrap() {
           match event::read().unwrap() {
             // Only process key press events, not release or repeat.
             // This fixes duplicate key events on Windows where both
@@ -96,11 +98,18 @@ impl Events {
           }
         }
 
-        // If send fails, the receiver has been dropped (app is closing)
+        // Only send a tick when one is actually due. Ticks used to be sent
+        // unconditionally here, so every keypress enqueued an extra Tick right
+        // after its Input, and the main loop drew two full frames per
+        // keystroke. Input events keep their own immediate redraw; the tick
+        // cadence stays fixed at tick_rate regardless of input.
         let elapsed = last_tick.elapsed();
-        last_tick = Instant::now();
-        if event_tx.send(Event::Tick(elapsed)).is_err() {
-          break;
+        if elapsed >= tick_rate {
+          last_tick = Instant::now();
+          // If send fails, the receiver has been dropped (app is closing)
+          if event_tx.send(Event::Tick(elapsed)).is_err() {
+            break;
+          }
         }
       }
     });

--- a/src/tui/handlers/input.rs
+++ b/src/tui/handlers/input.rs
@@ -188,7 +188,12 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
 
   let (playlist_id, matched) = spotify_resource_id(base, input, sep, "playlist");
   if matched {
-    app.dispatch(IoEvent::GetPlaylistItems(playlist_id, 0));
+    if let Some(playlist_id) = crate::infra::network::ids::playlist_id(&playlist_id) {
+      app.open_playlist_tracks(
+        playlist_id,
+        crate::core::app::TrackTableContext::MyPlaylists,
+      );
+    }
     return true;
   }
 

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -599,7 +599,12 @@ fn handle_jump_to_context(app: &mut App) {
         rspotify::model::enums::Type::Album => handle_jump_to_album(app),
         rspotify::model::enums::Type::Artist => handle_jump_to_artist_album(app),
         rspotify::model::enums::Type::Playlist => {
-          app.dispatch(IoEvent::GetPlaylistItems(play_context.uri.clone(), 0));
+          if let Some(playlist_id) = crate::infra::network::ids::playlist_id(&play_context.uri) {
+            app.open_playlist_tracks(
+              playlist_id,
+              crate::core::app::TrackTableContext::MyPlaylists,
+            );
+          }
         }
         _ => {}
       }

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -509,9 +509,21 @@ fn select_clicked_content_table_item(
   let selected_index =
     content_table_selected_index(active_block, app).min(item_count.saturating_sub(1));
 
-  let Some(clicked_index) =
-    table_item_index_from_click(table_area, mouse_row, selected_index, item_count)
-  else {
+  // The track table anchors its view to a persisted scroll offset (the cursor
+  // can sit anywhere in the window), so clicks must use that offset instead of
+  // re-deriving one from the selection.
+  let anchored_offset = match active_block {
+    ActiveBlock::TrackTable => Some(app.track_table.scroll_offset.get()),
+    _ => None,
+  };
+
+  let Some(clicked_index) = table_item_index_from_click(
+    table_area,
+    mouse_row,
+    selected_index,
+    anchored_offset,
+    item_count,
+  ) else {
     return;
   };
 
@@ -651,6 +663,7 @@ fn table_item_index_from_click(
   table_area: Rect,
   mouse_row: u16,
   selected_index: usize,
+  anchored_offset: Option<usize>,
   item_count: usize,
 ) -> Option<usize> {
   if item_count == 0 || table_area.height <= 5 {
@@ -668,7 +681,7 @@ fn table_item_index_from_click(
     return None;
   }
 
-  let offset = table_scroll_offset(selected_index, visible_rows);
+  let offset = anchored_offset.unwrap_or_else(|| table_scroll_offset(selected_index, visible_rows));
 
   let row_index = (mouse_row - first_data_row) as usize;
   let row_index = row_index.min(visible_rows.saturating_sub(1));
@@ -1923,8 +1936,22 @@ mod tests {
     let selected_index = 15;
     let item_count = 40;
 
-    let first = table_item_index_from_click(area, 2, selected_index, item_count);
-    let second = table_item_index_from_click(area, 3, selected_index, item_count);
+    let first = table_item_index_from_click(area, 2, selected_index, None, item_count);
+    let second = table_item_index_from_click(area, 3, selected_index, None, item_count);
+
+    assert_eq!(first, Some(9));
+    assert_eq!(second, Some(10));
+  }
+
+  #[test]
+  fn table_click_mapping_uses_anchored_offset_when_present() {
+    let area = Rect::new(0, 0, 80, 12);
+    let item_count = 40;
+
+    // Cursor sits mid-window (selection 12) while the view is anchored at
+    // row 9; the first data row must map to the anchor, not the selection.
+    let first = table_item_index_from_click(area, 2, 12, Some(9), item_count);
+    let second = table_item_index_from_click(area, 3, 12, Some(9), item_count);
 
     assert_eq!(first, Some(9));
     assert_eq!(second, Some(10));

--- a/src/tui/handlers/playlist.rs
+++ b/src/tui/handlers/playlist.rs
@@ -204,17 +204,16 @@ pub fn handler(key: Key, app: &mut App) {
               app.selected_playlist_index = Some(0);
             }
             PlaylistFolderItem::Playlist { index, .. } => {
-              // Open the playlist tracks. The dispatch carries the string id; the
-              // app-state view still tracks an rspotify PlaylistId (deferred).
+              // Open the playlist tracks: navigates immediately with the
+              // cleared table as the loading state (see open_playlist_tracks).
               let index = *index;
               if let Some(id_str) = app.all_playlists.get(index).and_then(|p| p.id.clone()) {
                 if let Ok(playlist_id) = PlaylistId::from_id(id_str.as_str()) {
                   app.active_playlist_index = Some(index);
-                  app.reset_playlist_tracks_view(
+                  app.open_playlist_tracks(
                     playlist_id.into_static(),
                     TrackTableContext::MyPlaylists,
                   );
-                  app.dispatch(IoEvent::GetPlaylistItems(id_str, app.playlist_offset));
                 }
               }
             }
@@ -277,6 +276,40 @@ mod tests {
       _ => panic!("expected playlist page fetch"),
     }
 
+    assert!(rx.try_recv().is_err());
+  }
+
+  #[test]
+  fn enter_playlist_navigates_immediately_and_dedups_inflight_open() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.all_playlists = vec![playlist_info(
+      "37i9dQZF1DXcBWIGoYBM5M",
+      "Test Playlist",
+      "spotatui-test-user",
+      false,
+    )];
+    app.playlist_folder_items = vec![PlaylistFolderItem::Playlist {
+      index: 0,
+      current_id: 0,
+    }];
+    app.selected_playlist_index = Some(0);
+
+    handler(Key::Enter, &mut app);
+
+    // The screen opens on the press itself, not on response arrival.
+    assert_eq!(app.get_current_route().id, RouteId::TrackTable);
+    match rx.recv().unwrap() {
+      IoEvent::GetPlaylistItems(_, 0) => {}
+      _ => panic!("expected playlist page fetch"),
+    }
+
+    // Pressing Enter again while the same open is in flight (after navigating
+    // back to the sidebar) re-opens the screen but dispatches no duplicate
+    // fetch.
+    app.pop_navigation_stack();
+    handler(Key::Enter, &mut app);
+    assert_eq!(app.get_current_route().id, RouteId::TrackTable);
     assert!(rx.try_recv().is_err());
   }
 

--- a/src/tui/handlers/resize.rs
+++ b/src/tui/handlers/resize.rs
@@ -17,7 +17,7 @@ pub fn decrease_sidebar_width(app: &mut App) {
     .behavior
     .sidebar_width_percent
     .saturating_sub(SIDEBAR_STEP);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Increase sidebar width by SIDEBAR_STEP percent (maximum 100%).
@@ -28,7 +28,7 @@ pub fn increase_sidebar_width(app: &mut App) {
     .sidebar_width_percent
     .saturating_add(SIDEBAR_STEP)
     .min(100);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Decrease playbar height by PLAYBAR_STEP rows (minimum 0 = hidden).
@@ -38,7 +38,7 @@ pub fn decrease_playbar_height(app: &mut App) {
     .behavior
     .playbar_height_rows
     .saturating_sub(PLAYBAR_STEP);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Increase playbar height by PLAYBAR_STEP rows (capped at MAX_PLAYBAR_ROWS).
@@ -49,7 +49,7 @@ pub fn increase_playbar_height(app: &mut App) {
     .playbar_height_rows
     .saturating_add(PLAYBAR_STEP)
     .min(MAX_PLAYBAR_ROWS);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Decrease the library section height within the sidebar (minimum 0% = hidden).
@@ -59,7 +59,7 @@ pub fn decrease_library_height(app: &mut App) {
     .behavior
     .library_height_percent
     .saturating_sub(LIBRARY_STEP);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Increase the library section height within the sidebar (maximum 100%).
@@ -70,7 +70,7 @@ pub fn increase_library_height(app: &mut App) {
     .library_height_percent
     .saturating_add(LIBRARY_STEP)
     .min(100);
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 /// Reset all pane sizes to their defaults.
@@ -78,7 +78,7 @@ pub fn reset_layout(app: &mut App) {
   app.user_config.behavior.sidebar_width_percent = DEFAULT_SIDEBAR_WIDTH;
   app.user_config.behavior.playbar_height_rows = DEFAULT_PLAYBAR_HEIGHT;
   app.user_config.behavior.library_height_percent = DEFAULT_LIBRARY_HEIGHT;
-  let _ = app.user_config.save_config();
+  app.schedule_config_save();
 }
 
 #[cfg(test)]

--- a/src/tui/handlers/search_results.rs
+++ b/src/tui/handlers/search_results.rs
@@ -324,14 +324,10 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
         if let Some(playlist) = playlists_result.items.get(index) {
           if let Some(ref id_str) = playlist.id {
             if let Ok(playlist_id) = PlaylistId::from_id(id_str.as_str()) {
-              // Go to playlist tracks table. The app-state view still tracks an
-              // rspotify PlaylistId (deferred); the dispatch carries the string id.
-              let id_owned = id_str.clone();
-              app.reset_playlist_tracks_view(
-                playlist_id.into_static(),
-                TrackTableContext::PlaylistSearch,
-              );
-              app.dispatch(IoEvent::GetPlaylistItems(id_owned, app.playlist_offset));
+              // Go to playlist tracks table: navigates immediately with the
+              // cleared table as the loading state (see open_playlist_tracks).
+              app
+                .open_playlist_tracks(playlist_id.into_static(), TrackTableContext::PlaylistSearch);
             }
           }
         };

--- a/src/tui/handlers/sort_menu.rs
+++ b/src/tui/handlers/sort_menu.rs
@@ -131,83 +131,47 @@ fn get_sort_state_mut(app: &mut App, ctx: SortContext) -> &mut crate::core::sort
 }
 
 fn sort_saved_albums(app: &mut App) {
-  use crate::core::sort::SortOrder;
+  use crate::core::sort::sort_by_key_with_order;
 
   let sort_state = app.album_sort;
 
   // Sort library.saved_albums pages
   for page in &mut app.library.saved_albums.pages {
-    page.items.sort_by(|a, b| {
-      let cmp = match sort_state.field {
-        SortField::Default => std::cmp::Ordering::Equal,
-        SortField::Name => a
-          .album
-          .name
-          .to_lowercase()
-          .cmp(&b.album.name.to_lowercase()),
-        SortField::Artist => {
-          let artist_a = a
-            .album
-            .artists
-            .first()
-            .map(|a| a.name.to_lowercase())
-            .unwrap_or_default();
-          let artist_b = b
-            .album
-            .artists
-            .first()
-            .map(|a| a.name.to_lowercase())
-            .unwrap_or_default();
-          artist_a.cmp(&artist_b)
-        }
-        SortField::DateAdded => a.added_at.cmp(&b.added_at),
-        _ => std::cmp::Ordering::Equal,
-      };
-
-      if sort_state.order == SortOrder::Descending {
-        cmp.reverse()
-      } else {
-        cmp
+    match sort_state.field {
+      SortField::Name => sort_by_key_with_order(&mut page.items, sort_state.order, |a| {
+        a.album.name.to_lowercase()
+      }),
+      SortField::Artist => sort_by_key_with_order(&mut page.items, sort_state.order, |a| {
+        a.album
+          .artists
+          .first()
+          .map(|artist| artist.name.to_lowercase())
+          .unwrap_or_default()
+      }),
+      SortField::DateAdded => {
+        sort_by_key_with_order(&mut page.items, sort_state.order, |a| a.added_at.clone())
       }
-    });
+      _ => {}
+    }
   }
 }
 
 fn sort_saved_artists(app: &mut App) {
-  use crate::core::sort::SortOrder;
+  use crate::core::sort::sort_by_key_with_order;
 
   let sort_state = app.artist_sort;
+  if sort_state.field != SortField::Name {
+    return;
+  }
 
   // Sort library.saved_artists pages
   for page in &mut app.library.saved_artists.pages {
-    page.items.sort_by(|a, b| {
-      let cmp = match sort_state.field {
-        SortField::Default => std::cmp::Ordering::Equal,
-        SortField::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-        _ => std::cmp::Ordering::Equal,
-      };
-
-      if sort_state.order == SortOrder::Descending {
-        cmp.reverse()
-      } else {
-        cmp
-      }
-    });
+    sort_by_key_with_order(&mut page.items, sort_state.order, |a| a.name.to_lowercase());
   }
 
   // Also sort the app.artists vec
-  app.artists.sort_by(|a, b| {
-    let cmp = match sort_state.field {
-      SortField::Default => std::cmp::Ordering::Equal,
-      SortField::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-      _ => std::cmp::Ordering::Equal,
-    };
-
-    if sort_state.order == SortOrder::Descending {
-      cmp.reverse()
-    } else {
-      cmp
-    }
+  sort_by_key_with_order(&mut app.artists, sort_state.order, |a| {
+    a.name.to_lowercase()
   });
 }
 

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -374,6 +374,7 @@ fn on_enter(app: &mut App) {
     context,
     selected_index,
     tracks,
+    ..
   } = &app.track_table;
   if let Some(context) = &context {
     match context {

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -806,6 +806,7 @@ pub async fn start_ui(
         app.flush_pending_native_seek();
         app.flush_pending_api_seek();
         app.flush_pending_volume();
+        app.flush_config_save(false);
 
         #[cfg(feature = "scripting")]
         if let Some(engine) = script_engine.as_mut() {
@@ -1286,6 +1287,13 @@ pub async fn start_ui(
   if let Some(engine) = script_engine.as_mut() {
     let mut app = app.lock().await;
     engine.on_quit(&mut app);
+  }
+
+  // A volume/resize/shuffle change may still be inside its debounce window;
+  // persist it before the process exits.
+  {
+    let mut app = app.lock().await;
+    app.flush_config_save(true);
   }
 
   #[cfg(feature = "streaming")]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -581,18 +581,30 @@ pub async fn start_ui(
   #[cfg(feature = "internet-radio")]
   let mut radio_stream_started = false;
 
+  // The Lua VM (plus its HTTP client) is only constructed when the user
+  // actually has script files; a zero-plugin install skips the engine — and
+  // its per-tick `on_tick` dispatch — entirely.
   #[cfg(feature = "scripting")]
-  let mut script_engine: Option<ScriptEngine> = match ScriptEngine::new() {
-    Ok(mut engine) => {
-      if let Some(config_dir) = crate::core::user_config::default_app_config_dir() {
-        let loaded = engine.load_user_scripts(&config_dir);
-        info!("loaded {loaded} lua plugin file(s)");
+  let mut script_engine: Option<ScriptEngine> = {
+    let config_dir = crate::core::user_config::default_app_config_dir();
+    match config_dir {
+      Some(config_dir) if ScriptEngine::has_user_scripts(&config_dir) => {
+        match ScriptEngine::new() {
+          Ok(mut engine) => {
+            let loaded = engine.load_user_scripts(&config_dir);
+            info!("loaded {loaded} lua plugin file(s)");
+            Some(engine)
+          }
+          Err(e) => {
+            log::error!("failed to initialize lua scripting engine: {e}");
+            None
+          }
+        }
       }
-      Some(engine)
-    }
-    Err(e) => {
-      log::error!("failed to initialize lua scripting engine: {e}");
-      None
+      _ => {
+        info!("no lua plugin files found; scripting engine not started");
+        None
+      }
     }
   };
 
@@ -807,6 +819,7 @@ pub async fn start_ui(
         #[cfg(feature = "streaming")]
         app.flush_pending_native_seek();
         app.flush_pending_api_seek();
+        app.flush_pending_source_seek();
         app.flush_pending_volume();
         app.flush_config_save(false);
 
@@ -1115,13 +1128,15 @@ pub async fn start_ui(
         // Persist the active non-Spotify session so it resumes on next launch.
         // Throttled to avoid churning the file every tick; a Some -> None
         // transition (queue ended, or switched to Spotify) clears it instead.
-        match app.current_persisted_session() {
-          Some(session) => {
-            let due = last_session_save
-              .map(|t| t.elapsed() >= SESSION_SAVE_INTERVAL)
-              .unwrap_or(true);
-            if due {
-              last_session_save = Some(Instant::now());
+        if app.has_persistable_session() {
+          let due = last_session_save
+            .map(|t| t.elapsed() >= SESSION_SAVE_INTERVAL)
+            .unwrap_or(true);
+          if due {
+            last_session_save = Some(Instant::now());
+            // Snapshot (clones the queue) only when a save is actually due,
+            // not on every tick.
+            if let Some(session) = app.current_persisted_session() {
               // Fire-and-forget on the blocking pool: file I/O never blocks the
               // UI tick, and a dropped handle still runs to completion.
               tokio::task::spawn_blocking(move || {
@@ -1132,21 +1147,20 @@ pub async fn start_ui(
                 }
               });
             }
-            session_was_present = true;
           }
-          None => {
-            if session_was_present {
-              last_session_save = None;
-              tokio::task::spawn_blocking(|| {
-                if let Ok(path) = crate::core::persisted_playback::default_session_path() {
-                  if let Err(e) = crate::core::persisted_playback::clear(&path) {
-                    log::warn!("[session] failed to clear playback session: {e}");
-                  }
+          session_was_present = true;
+        } else {
+          if session_was_present {
+            last_session_save = None;
+            tokio::task::spawn_blocking(|| {
+              if let Ok(path) = crate::core::persisted_playback::default_session_path() {
+                if let Err(e) = crate::core::persisted_playback::clear(&path) {
+                  log::warn!("[session] failed to clear playback session: {e}");
                 }
-              });
-            }
-            session_was_present = false;
+              }
+            });
           }
+          session_was_present = false;
         }
 
         #[cfg(feature = "streaming")]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -638,10 +638,12 @@ pub async fn start_ui(
       };
 
       let current_route = app.get_current_route();
-      let animation_active = matches!(
-        current_route.active_block,
-        ActiveBlock::Analysis | ActiveBlock::Home
-      ) || app.liked_song_animation_frame.is_some();
+      // The banner animates whenever the Home screen is displayed, regardless
+      // of which block has focus (on Home the focused block is usually Empty
+      // or Library, not Home), so gate the fast tick on the route.
+      let animation_active = current_route.id == RouteId::Home
+        || current_route.active_block == ActiveBlock::Analysis
+        || app.liked_song_animation_frame.is_some();
       let current_tick_rate = if animation_active {
         app.user_config.behavior.animation_tick_rate_milliseconds
       } else {

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -860,12 +860,16 @@ pub async fn start_ui(
                 // episodes have no lyrics, so skip the lookup and show the
                 // not-found message rather than stale lyrics.
                 if snapshot.item_kind == PlaybackItemKind::Track {
+                  let title = snapshot.metadata.title.clone();
+                  let artist = snapshot.primary_artist();
+                  app.desired_lyrics_identity = Some((title.clone(), artist.clone()));
                   app.dispatch(IoEvent::GetLyrics(
-                    snapshot.metadata.title.clone(),
-                    snapshot.primary_artist(),
+                    title,
+                    artist,
                     snapshot.metadata.duration_ms as f64 / 1000.0,
                   ));
                 } else {
+                  app.desired_lyrics_identity = None;
                   app.lyrics = None;
                   app.lyrics_status = crate::core::app::LyricsStatus::NotFound;
                   app
@@ -874,6 +878,7 @@ pub async fn start_ui(
                 }
               }
               None => {
+                app.desired_lyrics_identity = None;
                 // Nothing is playing: reset so no stale lyrics linger.
                 app.lyrics = None;
                 app.lyrics_status = crate::core::app::LyricsStatus::NotStarted;
@@ -908,6 +913,7 @@ pub async fn start_ui(
             };
             match desired {
               Some(request) => {
+                app.desired_cover_art_key = Some(request.key().to_string());
                 if last_cover_art_key.as_deref() != Some(request.key()) {
                   last_cover_art_key = Some(request.key().to_string());
                   // Keep the previous image on screen until the new one
@@ -917,6 +923,7 @@ pub async fn start_ui(
                 }
               }
               None => {
+                app.desired_cover_art_key = None;
                 // No art to show (radio, art disabled, nothing playing): drop
                 // any stale image once, so the pane shows the placeholder.
                 if last_cover_art_key.take().is_some() || app.cover_art.available() {

--- a/src/tui/ui/friends.rs
+++ b/src/tui/ui/friends.rs
@@ -535,7 +535,7 @@ pub fn filtered_friends(app: &App) -> Vec<&FriendEntry> {
         FriendFilter::All => true,
         FriendFilter::Online => f.is_online,
       };
-      let passes_search = q.is_empty() || f.name.to_lowercase().contains(&q);
+      let passes_search = q.is_empty() || f.name_lower.contains(&q);
       passes_filter && passes_search
     })
     .collect()

--- a/src/tui/ui/home.rs
+++ b/src/tui/ui/home.rs
@@ -124,14 +124,29 @@ pub fn draw_home(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     counter_style,
   )]));
   changelog_lines.push(Line::from(""));
-  changelog_lines.extend(base_changelog_lines.iter().map(borrow_line));
+
+  // The cached changelog lines are pre-wrapped to the area width (one line ==
+  // one row), so slice out the visible window ourselves instead of using
+  // Paragraph::scroll, which re-composes every line above the offset each
+  // frame. Only the visible cached lines get re-spanned (borrow_line).
+  let scroll = usize::from(app.home_scroll);
+  let height = usize::from(changelog_area.height);
+  let prefix_len = changelog_lines.len();
+  let mut visible: Vec<Line> = Vec::with_capacity(height);
+  visible.extend(changelog_lines.drain(..).skip(scroll).take(height));
+  let base_start = scroll.saturating_sub(prefix_len);
+  let remaining = height.saturating_sub(visible.len());
+  if remaining > 0 {
+    if let Some(slice) = base_changelog_lines.get(base_start..) {
+      visible.extend(slice.iter().take(remaining).map(borrow_line));
+    }
+  }
 
   // CHANGELOG
-  let bottom_text = Paragraph::new(Text::from(changelog_lines))
+  let bottom_text = Paragraph::new(Text::from(visible))
     .block(Block::default())
     .style(app.user_config.theme.base_style())
-    .wrap(Wrap { trim: false })
-    .scroll((app.home_scroll, 0));
+    .wrap(Wrap { trim: false });
   f.render_widget(bottom_text, changelog_area);
 }
 
@@ -440,6 +455,62 @@ fn wrap_segments_with_indent(
   lines
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::app::App;
+  use ratatui::{backend::TestBackend, Terminal};
+
+  // draw_home layout at 100x40: margin 2 -> inner rows 2..38, banner rows
+  // 2..9, changelog rows 9..38. Row strings exclude the outer border columns.
+  fn rendered_rows(app: &App) -> Vec<String> {
+    let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+    terminal.draw(|f| draw_home(f, app, f.area())).unwrap();
+    let buffer = terminal.backend().buffer();
+    (0..40)
+      .map(|y| {
+        (2..98)
+          .filter_map(|x| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+          .collect::<String>()
+      })
+      .collect()
+  }
+
+  #[test]
+  fn home_changelog_scroll_shifts_rows_one_to_one() {
+    let mut app = App::default();
+    let rows_at_top = rendered_rows(&app);
+    assert!(
+      rows_at_top[9..38].iter().any(|row| !row.trim().is_empty()),
+      "changelog area should have content"
+    );
+
+    app.home_scroll = 3;
+    let rows_scrolled = rendered_rows(&app);
+    for y in 9..35 {
+      assert_eq!(
+        rows_scrolled[y],
+        rows_at_top[y + 3],
+        "scrolling by 3 should shift row {} up by exactly 3 rows",
+        y + 3
+      );
+    }
+  }
+
+  #[test]
+  fn home_changelog_scroll_past_end_renders_blank() {
+    let mut app = App::default();
+    app.home_scroll = u16::MAX;
+    let rows = rendered_rows(&app);
+    for (y, row) in rows.iter().enumerate().take(38).skip(9) {
+      assert!(
+        row.trim().is_empty(),
+        "row {y} should be blank when scrolled past the end: {row:?}"
+      );
+    }
+  }
+}
+
 fn build_changelog_lines(
   changelog: &str,
   theme: &crate::core::user_config::Theme,
@@ -448,18 +519,40 @@ fn build_changelog_lines(
   let mut lines: Vec<Line<'static>> = vec![];
   let max_width = usize::from(max_width);
 
-  lines.push(Line::from(Span::styled(
-    format!(
-      "Log located in /tmp/spotatui_logs/spotatuilog{}",
-      std::process::id()
-    ),
-    Style::default().fg(theme.hint),
-  )));
+  // Every line is wrapped to max_width here so that one cached line is one
+  // rendered row: draw_home slices this list by the scroll offset instead of
+  // paying Paragraph's per-frame wrap composition over everything above it.
+  let push_wrapped = |lines: &mut Vec<Line<'static>>, segments: &[StyledSegment]| {
+    lines.extend(wrap_segments_with_indent(
+      segments,
+      max_width,
+      "",
+      Style::default(),
+      "",
+      Style::default(),
+    ));
+  };
 
-  lines.push(Line::from(Span::styled(
-    "Please report any bugs or missing features to https://github.com/LargeModGames/spotatui",
-    Style::default().fg(theme.hint),
-  )));
+  push_wrapped(
+    &mut lines,
+    &[StyledSegment {
+      text: format!(
+        "Log located in /tmp/spotatui_logs/spotatuilog{}",
+        std::process::id()
+      ),
+      style: Style::default().fg(theme.hint),
+    }],
+  );
+
+  push_wrapped(
+    &mut lines,
+    &[StyledSegment {
+      text:
+        "Please report any bugs or missing features to https://github.com/LargeModGames/spotatui"
+          .to_string(),
+      style: Style::default().fg(theme.hint),
+    }],
+  );
   lines.push(Line::from(""));
 
   for line in changelog.lines() {
@@ -479,27 +572,30 @@ fn build_changelog_lines(
       continue;
     }
 
-    let styled_line = if line.starts_with("# ") {
-      Line::from(Span::styled(
-        line.trim_start_matches("# ").to_string(),
-        Style::default()
-          .fg(theme.banner)
-          .add_modifier(Modifier::BOLD),
-      ))
+    if line.starts_with("# ") {
+      push_wrapped(
+        &mut lines,
+        &[StyledSegment {
+          text: line.trim_start_matches("# ").to_string(),
+          style: Style::default()
+            .fg(theme.banner)
+            .add_modifier(Modifier::BOLD),
+        }],
+      );
     } else if line.starts_with("## [") {
-      Line::from(Span::styled(
-        format!("═══ {} ═══", line.trim_start_matches("## ")),
-        Style::default()
-          .fg(theme.active)
-          .add_modifier(Modifier::BOLD),
-      ))
+      push_wrapped(
+        &mut lines,
+        &[StyledSegment {
+          text: format!("═══ {} ═══", line.trim_start_matches("## ")),
+          style: Style::default()
+            .fg(theme.active)
+            .add_modifier(Modifier::BOLD),
+        }],
+      );
     } else {
       let segments = parse_markdown_inline(line, Style::default().fg(theme.text));
-      let line_spans = segments_to_spans(segments);
-      Line::from(line_spans)
-    };
-
-    lines.push(styled_line);
+      push_wrapped(&mut lines, &segments);
+    }
   }
 
   lines

--- a/src/tui/ui/home.rs
+++ b/src/tui/ui/home.rs
@@ -8,7 +8,7 @@ use ratatui::{
   widgets::{Block, BorderType, Borders, Paragraph, Wrap},
   Frame,
 };
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use unicode_width::UnicodeWidthStr;
 
 use super::util::get_color;
@@ -38,7 +38,7 @@ impl ChangelogCacheKey {
 
 struct ChangelogCache {
   key: ChangelogCacheKey,
-  changelog_lines: Vec<Line<'static>>,
+  changelog_lines: Arc<Vec<Line<'static>>>,
 }
 
 static CHANGELOG_CACHE: OnceLock<Mutex<ChangelogCache>> = OnceLock::new();
@@ -124,7 +124,7 @@ pub fn draw_home(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     counter_style,
   )]));
   changelog_lines.push(Line::from(""));
-  changelog_lines.extend(base_changelog_lines);
+  changelog_lines.extend(base_changelog_lines.iter().map(borrow_line));
 
   // CHANGELOG
   let bottom_text = Paragraph::new(Text::from(changelog_lines))
@@ -151,12 +151,12 @@ fn get_clean_changelog() -> &'static str {
 fn get_changelog_cache(
   theme: &crate::core::user_config::Theme,
   changelog_width: u16,
-) -> Vec<Line<'static>> {
+) -> Arc<Vec<Line<'static>>> {
   let cache = CHANGELOG_CACHE.get_or_init(|| {
     let changelog = get_clean_changelog();
     let key = ChangelogCacheKey::from_theme(theme, changelog_width);
     Mutex::new(ChangelogCache {
-      changelog_lines: build_changelog_lines(changelog, theme, changelog_width),
+      changelog_lines: Arc::new(build_changelog_lines(changelog, theme, changelog_width)),
       key,
     })
   });
@@ -164,16 +164,33 @@ fn get_changelog_cache(
   let key = ChangelogCacheKey::from_theme(theme, changelog_width);
   if cache.key != key {
     let changelog = get_clean_changelog();
-    cache.changelog_lines = build_changelog_lines(changelog, theme, changelog_width);
+    cache.changelog_lines = Arc::new(build_changelog_lines(changelog, theme, changelog_width));
     cache.key = key;
   }
-  cache.changelog_lines.clone()
+  Arc::clone(&cache.changelog_lines)
 }
 
-fn build_banner_gradient_lines(
-  theme: &crate::core::user_config::Theme,
-  animation_tick: u64,
-) -> Vec<Line<'static>> {
+/// Re-spans a cached line borrowing its span content instead of cloning the
+/// Strings. Cached changelog lines carry span-level styling only, so copying
+/// the spans is lossless.
+fn borrow_line<'a>(line: &'a Line<'static>) -> Line<'a> {
+  Line::from(
+    line
+      .spans
+      .iter()
+      .map(|span| Span::styled(span.content.as_ref(), span.style))
+      .collect::<Vec<Span<'a>>>(),
+  )
+}
+
+struct BannerGradientCache {
+  key: (Color, Color, Color),
+  gradient: colorgrad::LinearGradient,
+}
+
+static BANNER_GRADIENT_CACHE: OnceLock<Mutex<BannerGradientCache>> = OnceLock::new();
+
+fn build_banner_gradient(theme: &crate::core::user_config::Theme) -> colorgrad::LinearGradient {
   fn to_rgba(color: ratatui::style::Color) -> (u8, u8, u8, u8) {
     match color {
       ratatui::style::Color::Rgb(r, g, b) => (r, g, b, 255),
@@ -203,7 +220,7 @@ fn build_banner_gradient_lines(
 
   // Build a looping gradient: banner → hovered → active → banner
   // This ensures a smooth wrap-around for continuous animation
-  let grad = colorgrad::GradientBuilder::new()
+  colorgrad::GradientBuilder::new()
     .colors(&[
       colorgrad::Color::from_rgba8(c1.0, c1.1, c1.2, c1.3),
       colorgrad::Color::from_rgba8(c2.0, c2.1, c2.2, c2.3),
@@ -211,7 +228,28 @@ fn build_banner_gradient_lines(
       colorgrad::Color::from_rgba8(c1.0, c1.1, c1.2, c1.3),
     ])
     .build::<colorgrad::LinearGradient>()
-    .unwrap();
+    .unwrap()
+}
+
+fn build_banner_gradient_lines(
+  theme: &crate::core::user_config::Theme,
+  animation_tick: u64,
+) -> Vec<Line<'static>> {
+  // Only the phase changes per frame; the gradient itself depends solely on
+  // the three theme colors, so rebuild it only when those change.
+  let key = (theme.banner, theme.hovered, theme.active);
+  let cache = BANNER_GRADIENT_CACHE.get_or_init(|| {
+    Mutex::new(BannerGradientCache {
+      key,
+      gradient: build_banner_gradient(theme),
+    })
+  });
+  let mut cache = cache.lock().expect("banner gradient cache lock failed");
+  if cache.key != key {
+    cache.gradient = build_banner_gradient(theme);
+    cache.key = key;
+  }
+  let grad = &cache.gradient;
 
   // Phase offset scrolls the gradient over time (~4 seconds per full cycle at 62 FPS)
   let phase = animation_tick as f64 * 0.004;
@@ -220,17 +258,17 @@ fn build_banner_gradient_lines(
     .lines()
     .enumerate()
     .map(|(row, line)| {
-      let chars: Vec<char> = line.chars().collect();
-      let line_len = chars.len().max(1);
-      let spans: Vec<Span<'static>> = chars
-        .into_iter()
+      let line_len = line.chars().count().max(1);
+      let spans: Vec<Span<'static>> = line
+        .char_indices()
         .enumerate()
-        .map(|(col, ch)| {
+        .map(|(col, (byte_idx, ch))| {
           // Diagonal gradient: combine column position and row offset
           let t = ((col as f64 / line_len as f64) + (row as f64 * 0.08) + phase) % 1.0;
           let [r, g, b, _] = grad.at(t as f32).to_rgba8();
           Span::styled(
-            ch.to_string(),
+            // Slice of the static banner text: no String allocation per glyph
+            &line[byte_idx..byte_idx + ch.len_utf8()],
             Style::default().fg(ratatui::style::Color::Rgb(r, g, b)),
           )
         })

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -12,15 +12,23 @@ use ratatui::{
 
 use super::help::get_help_docs;
 
-pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
-  let [area] = f
-    .area()
-    .layout(&Layout::vertical([Constraint::Percentage(100)]).margin(2));
+/// Formatted help rows are static per session except for terminal width and
+/// keybinding changes, so cache them instead of rebuilding ~80 owned Strings
+/// (plus per-cell char-count truncation) on every redraw while help is open.
+struct HelpMenuCache {
+  width: usize,
+  keys: crate::core::user_config::KeyBindings,
+  header: String,
+  rows: Vec<String>,
+}
 
+static HELP_MENU_CACHE: std::sync::OnceLock<std::sync::Mutex<Option<HelpMenuCache>>> =
+  std::sync::OnceLock::new();
+
+fn build_help_rows(app: &App, total_width: usize) -> (String, Vec<String>) {
   // Create a one-column table to avoid flickering due to non-determinism when
   // resolving constraints on widths of table columns.
   // Calculate column widths based on available terminal width
-  let total_width = area.width as usize;
   let col1_width = (total_width as f32 * 0.40) as usize;
   let col2_width = (total_width as f32 * 0.30) as usize;
   let col3_width = total_width.saturating_sub(col1_width + col2_width + 2);
@@ -37,8 +45,8 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
     }
   };
 
-  let format_row = |r: Vec<String>| -> Vec<String> {
-    vec![format!(
+  let format_row = |r: Vec<String>| -> String {
+    format!(
       "{:<w1$}  {:<w2$}  {:<w3$}",
       truncate(&r[0], col1_width),
       truncate(&r[1], col2_width),
@@ -46,26 +54,50 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
       w1 = col1_width,
       w2 = col2_width,
       w3 = col3_width,
-    )]
+    )
   };
 
-  let help_menu_style = app.user_config.theme.base_style();
   let header = ["Description", "Event", "Context"];
   let header = format_row(header.iter().map(|s| s.to_string()).collect());
+  let rows = get_help_docs(app).into_iter().map(format_row).collect();
+  (header, rows)
+}
 
-  let help_docs = get_help_docs(app);
-  let help_docs = help_docs
-    .into_iter()
-    .map(format_row)
-    .collect::<Vec<Vec<String>>>();
-  let help_docs = &help_docs[app.help_menu_offset as usize..];
+pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
+  let [area] = f
+    .area()
+    .layout(&Layout::vertical([Constraint::Percentage(100)]).margin(2));
+
+  let total_width = area.width as usize;
+
+  let cache_slot = HELP_MENU_CACHE.get_or_init(|| std::sync::Mutex::new(None));
+  let mut cache = cache_slot.lock().unwrap();
+  let stale = cache
+    .as_ref()
+    .is_none_or(|c| c.width != total_width || c.keys != app.user_config.keys);
+  if stale {
+    let (header, rows) = build_help_rows(app, total_width);
+    *cache = Some(HelpMenuCache {
+      width: total_width,
+      keys: app.user_config.keys.clone(),
+      header,
+      rows,
+    });
+  }
+  let cache = cache.as_ref().expect("help cache populated above");
+
+  let help_menu_style = app.user_config.theme.base_style();
+  let header = &cache.header;
+  let help_docs = &cache.rows[app.help_menu_offset as usize..];
+  // Only the rows that fit the area can render; don't build Rows for the rest.
+  let help_docs = &help_docs[..help_docs.len().min(area.height as usize)];
 
   let rows = help_docs
     .iter()
-    .map(|item| Row::new(item.clone()).style(help_menu_style));
+    .map(|item| Row::new([item.as_str()]).style(help_menu_style));
 
   let help_menu = Table::new(rows, &[Constraint::Percentage(100)])
-    .header(Row::new(header))
+    .header(Row::new([header.as_str()]))
     .block(
       Block::default()
         .borders(Borders::ALL)

--- a/src/tui/ui/tables.rs
+++ b/src/tui/ui/tables.rs
@@ -62,6 +62,81 @@ struct AlbumUi {
   selected_index: usize,
   items: Vec<TableItem>,
   title: String,
+  offset: usize,
+}
+
+fn table_visible_rows(app: &App, layout_chunk: Rect) -> usize {
+  // Clamp the configured padding to half the table height so an oversized
+  // value can never zero out the visible-row count (which would pin the
+  // scroll offset to 0 and make off-screen rows unreachable).
+  let padding = app
+    .user_config
+    .behavior
+    .table_scroll_padding
+    .min(layout_chunk.height / 2);
+  layout_chunk
+    .height
+    .checked_sub(padding)
+    .map(|height| height as usize)
+    .unwrap_or(0)
+}
+
+fn window_at<T>(offset: usize, layout_chunk: Rect, items: &[T]) -> (usize, &[T]) {
+  // The scroll offset math works with fewer rows than the drawable area (that
+  // gap is the scroll padding below the selection), but the table still
+  // renders rows into it, so slice a full chunk-height of rows to fill every
+  // line.
+  let offset = offset.min(items.len());
+  let end = items
+    .len()
+    .min(offset.saturating_add(layout_chunk.height as usize));
+  (offset, &items[offset..end])
+}
+
+/// Slice a backing collection down to the rows that can be visible in this
+/// layout, so callers only format the viewport instead of the whole
+/// collection. Returns the scroll offset and the visible slice; the offset
+/// math must stay in sync with what `draw_table` expects.
+fn visible_window<'a, T>(
+  app: &App,
+  layout_chunk: Rect,
+  selected_index: usize,
+  items: &'a [T],
+) -> (usize, &'a [T]) {
+  let visible_rows = table_visible_rows(app, layout_chunk);
+  window_at(
+    table_scroll_offset(selected_index, visible_rows),
+    layout_chunk,
+    items,
+  )
+}
+
+/// Like `visible_window`, but anchored to a persisted scroll offset: the
+/// cursor moves within the visible rows without moving the view, and the view
+/// scrolls only when the cursor reaches the top visible row (going up) or the
+/// padded bottom row (going down). The updated offset is written back to
+/// `scroll_offset` so the next frame and the mouse handler see it.
+fn visible_window_anchored<'a, T>(
+  app: &App,
+  layout_chunk: Rect,
+  selected_index: usize,
+  scroll_offset: &std::cell::Cell<usize>,
+  items: &'a [T],
+) -> (usize, &'a [T]) {
+  let visible_rows = table_visible_rows(app, layout_chunk);
+  let max_cursor_row = visible_rows.saturating_sub(1);
+
+  let anchor = scroll_offset.get().min(items.len().saturating_sub(1));
+  let offset = if selected_index < anchor {
+    selected_index
+  } else if selected_index > anchor.saturating_add(max_cursor_row) {
+    selected_index - max_cursor_row
+  } else {
+    anchor
+  };
+  scroll_offset.set(offset);
+
+  window_at(offset, layout_chunk, items)
 }
 
 fn table_columns(app: &App, table: TableColumnSet, layout_width: u16) -> Vec<ResolvedColumn> {
@@ -237,8 +312,13 @@ pub fn draw_artist_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   );
 
   if let Some(saved_artists) = app.library.saved_artists.get_results(None) {
-    let items = saved_artists
-      .items
+    let (offset, visible) = visible_window(
+      app,
+      layout_chunk,
+      app.artists_list_index,
+      &saved_artists.items,
+    );
+    let items = visible
       .iter()
       .map(|item| TableItem {
         id: item.id.clone().unwrap_or_default(),
@@ -253,6 +333,7 @@ pub fn draw_artist_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       ("Artists", &header),
       &items,
       app.artists_list_index,
+      offset,
       highlight_state,
     )
   } else {
@@ -263,6 +344,7 @@ pub fn draw_artist_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       ("Artists", &header),
       &[],
       app.artists_list_index,
+      0,
       highlight_state,
     )
   }
@@ -280,8 +362,9 @@ pub fn draw_podcast_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   );
 
   if let Some(saved_shows) = app.library.saved_shows.get_results(None) {
-    let items = saved_shows
-      .items
+    let (offset, visible) =
+      visible_window(app, layout_chunk, app.shows_list_index, &saved_shows.items);
+    let items = visible
       .iter()
       .map(|show| podcast_table_item(show, &columns))
       .collect::<Vec<TableItem>>();
@@ -293,6 +376,7 @@ pub fn draw_podcast_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       ("Podcasts", &header),
       &items,
       app.shows_list_index,
+      offset,
       highlight_state,
     )
   };
@@ -313,26 +397,37 @@ pub fn draw_album_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       app
         .selected_album_simplified
         .as_ref()
-        .map(|selected_album_simplified| AlbumUi {
-          items: selected_album_simplified
-            .tracks
-            .items
-            .iter()
-            .map(|item| track_table_item(item, &columns))
-            .collect::<Vec<TableItem>>(),
-          title: format!(
-            "{} by {}",
-            selected_album_simplified.album.name,
-            join_artist_names(&selected_album_simplified.album.artists)
-          ),
-          selected_index: selected_album_simplified.selected_index,
+        .map(|selected_album_simplified| {
+          let (offset, visible) = visible_window(
+            app,
+            layout_chunk,
+            selected_album_simplified.selected_index,
+            &selected_album_simplified.tracks.items,
+          );
+          AlbumUi {
+            items: visible
+              .iter()
+              .map(|item| track_table_item(item, &columns))
+              .collect::<Vec<TableItem>>(),
+            title: format!(
+              "{} by {}",
+              selected_album_simplified.album.name,
+              join_artist_names(&selected_album_simplified.album.artists)
+            ),
+            selected_index: selected_album_simplified.selected_index,
+            offset,
+          }
         })
     }
-    AlbumTableContext::Full => match app.selected_album_full.clone() {
-      Some(selected_album) => Some(AlbumUi {
-        items: selected_album
-          .album
-          .tracks
+    AlbumTableContext::Full => app.selected_album_full.as_ref().map(|selected_album| {
+      let (offset, visible) = visible_window(
+        app,
+        layout_chunk,
+        app.saved_album_tracks_index,
+        &selected_album.album.tracks,
+      );
+      AlbumUi {
+        items: visible
           .iter()
           .map(|item| track_table_item(item, &columns))
           .collect::<Vec<TableItem>>(),
@@ -342,9 +437,9 @@ pub fn draw_album_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
           join_artist_names(&selected_album.album.artists)
         ),
         selected_index: app.saved_album_tracks_index,
-      }),
-      None => None,
-    },
+        offset,
+      }
+    }),
   };
 
   if let Some(album_ui) = album_ui {
@@ -355,6 +450,7 @@ pub fn draw_album_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       (&album_ui.title, &header),
       &album_ui.items,
       album_ui.selected_index,
+      album_ui.offset,
       highlight_state,
     );
   };
@@ -370,9 +466,14 @@ pub fn draw_recommendations_table(f: &mut Frame<'_>, app: &App, layout_chunk: Re
     current_route.hovered_block == ActiveBlock::TrackTable,
   );
 
-  let items = app
-    .track_table
-    .tracks
+  let (offset, visible) = visible_window_anchored(
+    app,
+    layout_chunk,
+    app.track_table.selected_index,
+    &app.track_table.scroll_offset,
+    &app.track_table.tracks,
+  );
+  let items = visible
     .iter()
     .map(|item| track_table_item(item, &columns))
     .collect::<Vec<TableItem>>();
@@ -395,6 +496,7 @@ pub fn draw_recommendations_table(f: &mut Frame<'_>, app: &App, layout_chunk: Re
     (&recommendations_ui[..], &header),
     &items,
     app.track_table.selected_index,
+    offset,
     highlight_state,
   )
 }
@@ -409,9 +511,14 @@ pub fn draw_song_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     current_route.hovered_block == ActiveBlock::TrackTable,
   );
 
-  let items = app
-    .track_table
-    .tracks
+  let (offset, visible) = visible_window_anchored(
+    app,
+    layout_chunk,
+    app.track_table.selected_index,
+    &app.track_table.scroll_offset,
+    &app.track_table.tracks,
+  );
+  let items = visible
     .iter()
     .map(|item| track_table_item(item, &columns))
     .collect::<Vec<TableItem>>();
@@ -437,6 +544,7 @@ pub fn draw_song_table(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
     (&title, &header),
     &items,
     app.track_table.selected_index,
+    offset,
     highlight_state,
   )
 }
@@ -455,8 +563,9 @@ pub fn draw_album_list(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   let selected_song_index = app.album_list_index;
 
   if let Some(saved_albums) = app.library.saved_albums.get_results(None) {
-    let items = saved_albums
-      .items
+    let (offset, visible) =
+      visible_window(app, layout_chunk, selected_song_index, &saved_albums.items);
+    let items = visible
       .iter()
       .map(|saved_album| album_table_item(saved_album, &columns, app))
       .collect::<Vec<TableItem>>();
@@ -468,6 +577,7 @@ pub fn draw_album_list(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       ("Saved Albums", &header),
       &items,
       selected_song_index,
+      offset,
       highlight_state,
     )
   };
@@ -485,8 +595,9 @@ pub fn draw_show_episodes(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   );
 
   if let Some(episodes) = app.library.show_episodes.get_results(None) {
-    let items = episodes
-      .items
+    let (offset, visible) =
+      visible_window(app, layout_chunk, app.episode_list_index, &episodes.items);
+    let items = visible
       .iter()
       .map(|episode| episode_table_item(episode, &columns, app))
       .collect::<Vec<TableItem>>();
@@ -519,6 +630,7 @@ pub fn draw_show_episodes(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       (&title, &header),
       &items,
       app.episode_list_index,
+      offset,
       highlight_state,
     );
   };
@@ -538,8 +650,13 @@ pub fn draw_recently_played_table(f: &mut Frame<'_>, app: &App, layout_chunk: Re
 
     let selected_song_index = app.recently_played.index;
 
-    let items = recently_played
-      .items
+    let (offset, visible) = visible_window(
+      app,
+      layout_chunk,
+      selected_song_index,
+      &recently_played.items,
+    );
+    let items = visible
       .iter()
       .map(|item| track_table_item(item, &columns))
       .collect::<Vec<TableItem>>();
@@ -551,27 +668,30 @@ pub fn draw_recently_played_table(f: &mut Frame<'_>, app: &App, layout_chunk: Re
       ("Recently Played Tracks", &header),
       &items,
       selected_song_index,
+      offset,
       highlight_state,
     )
   };
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_table(
   f: &mut Frame<'_>,
   app: &App,
   layout_chunk: Rect,
   table_layout: (&str, &TableHeader), // (title, header colums)
-  items: &[TableItem], // The nested vector must have the same length as the `header_columns`
+  items: &[TableItem], // Visible window only (see `visible_window`); same length as `header_columns`
   selected_index: usize,
+  offset: usize, // Index of `items[0]` within the full backing collection
   highlight_state: (bool, bool),
 ) {
   let selected_style = get_color(highlight_state, app.user_config.theme)
     .add_modifier(Modifier::BOLD | Modifier::REVERSED);
 
-  let track_playing_index = app.current_playback_context.to_owned().and_then(|ctx| {
-    ctx.item.and_then(|item| match item {
+  let track_playing_index = app.current_playback_context.as_ref().and_then(|ctx| {
+    ctx.item.as_ref().and_then(|item| match item {
       PlayableItem::Track(track) => {
-        let track_id_str = track.id.map(|id| id.id().to_string());
+        let track_id_str = track.id.as_ref().map(|id| id.id().to_string());
         items.iter().position(|item| {
           track_id_str
             .as_ref()
@@ -589,25 +709,7 @@ fn draw_table(
 
   let (title, header) = table_layout;
 
-  // Make sure that the selected item is visible on the page. Need to add some rows of padding
-  // to chunk height for header and header space to get a true table height
-  // Clamp the configured padding to half the table height so an oversized
-  // value can never zero out the visible-row count (which would pin the
-  // scroll offset to 0 and make off-screen rows unreachable).
-  let padding = app
-    .user_config
-    .behavior
-    .table_scroll_padding
-    .min(layout_chunk.height / 2);
-  let visible_rows = layout_chunk
-    .height
-    .checked_sub(padding)
-    .map(|height| height as usize)
-    .unwrap_or(0);
-
-  let offset = table_scroll_offset(selected_index, visible_rows);
-
-  let rows = items.iter().skip(offset).enumerate().map(|(i, item)| {
+  let rows = items.iter().enumerate().map(|(i, item)| {
     let mut formatted_row = item.format.clone();
     let mut style = app.user_config.theme.base_style(); // default styling
 
@@ -617,18 +719,14 @@ fn draw_table(
         // First check if the song should be highlighted because it is currently playing.
         // The marker goes on the title cell, falling back to the first cell when the
         // user's column config omits `title` so the playing row is never unmarked.
-        if let Some(track_playing_offset_index) =
-          track_playing_index.and_then(|idx| idx.checked_sub(offset))
-        {
-          if i == track_playing_offset_index {
-            let title_idx = header.get_index(ColumnId::Title).unwrap_or(0);
-            if let Some(cell) = formatted_row.get_mut(title_idx) {
-              cell.insert_str(0, &app.user_config.padded_playing_icon());
-            }
-            style = Style::default()
-              .fg(app.user_config.theme.active)
-              .add_modifier(app.user_config.behavior.emphasis(Modifier::BOLD));
+        if track_playing_index == Some(i) {
+          let title_idx = header.get_index(ColumnId::Title).unwrap_or(0);
+          if let Some(cell) = formatted_row.get_mut(title_idx) {
+            cell.insert_str(0, &app.user_config.padded_playing_icon());
           }
+          style = Style::default()
+            .fg(app.user_config.theme.active)
+            .add_modifier(app.user_config.behavior.emphasis(Modifier::BOLD));
         }
 
         // Show this the liked icon if the song is liked
@@ -638,20 +736,14 @@ fn draw_table(
           }
         }
       }
-      TableId::PodcastEpisodes => {
-        if let Some(track_playing_offset_index) =
-          track_playing_index.and_then(|idx| idx.checked_sub(offset))
-        {
-          if i == track_playing_offset_index {
-            let name_idx = header.get_index(ColumnId::Title).unwrap_or(0);
-            if let Some(cell) = formatted_row.get_mut(name_idx) {
-              cell.insert_str(0, &app.user_config.padded_playing_icon());
-            }
-            style = Style::default()
-              .fg(app.user_config.theme.active)
-              .add_modifier(app.user_config.behavior.emphasis(Modifier::BOLD));
-          }
+      TableId::PodcastEpisodes if track_playing_index == Some(i) => {
+        let name_idx = header.get_index(ColumnId::Title).unwrap_or(0);
+        if let Some(cell) = formatted_row.get_mut(name_idx) {
+          cell.insert_str(0, &app.user_config.padded_playing_icon());
         }
+        style = Style::default()
+          .fg(app.user_config.theme.active)
+          .add_modifier(app.user_config.behavior.emphasis(Modifier::BOLD));
       }
       _ => {}
     }
@@ -726,6 +818,103 @@ mod tests {
       public: None,
       image_url: None,
     }
+  }
+
+  fn track(i: u32) -> TrackInfo {
+    TrackInfo {
+      uri: Some(format!("spotify:track:{i:022}")),
+      name: format!("Track {i}"),
+      artists: vec![format!("Artist {i}")],
+      album: format!("Album {i}"),
+      duration_ms: 180_000,
+      id: Some(format!("{i:022}")),
+      album_id: None,
+      artist_refs: Vec::new(),
+      is_playable: true,
+      is_local: false,
+      track_number: i + 1,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  #[test]
+  fn song_table_fills_rows_below_scroll_padding() {
+    let mut app = App::default();
+    app.track_table.tracks = (0..30).map(track).collect();
+    app.track_table.selected_index = 15;
+
+    // Height 12 with the default scroll padding of 5: the scroll offset math
+    // treats 7 rows as visible, but the drawable area holds 9 data rows
+    // (12 minus 2 borders and 1 header). The rows past the padding window
+    // must still be filled with the following tracks, not left blank.
+    let area = Rect::new(0, 0, 80, 12);
+    let mut terminal = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
+    terminal.draw(|f| draw_song_table(f, &app, area)).unwrap();
+    let buffer = terminal.backend().buffer();
+    let content: String = (0..area.height)
+      .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+      .filter_map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().to_string()))
+      .collect();
+
+    for i in [15, 16, 17] {
+      assert!(
+        content.contains(&format!("Track {i}")),
+        "row for track {i} should be rendered: {content}"
+      );
+    }
+    assert!(
+      !content.contains("Track 18"),
+      "track 18 is below the drawable area and should not be rendered: {content}"
+    );
+  }
+
+  #[test]
+  fn song_table_view_stays_anchored_until_cursor_hits_top() {
+    let mut app = App::default();
+    app.track_table.tracks = (0..30).map(track).collect();
+
+    let area = Rect::new(0, 0, 80, 12);
+    let mut terminal = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
+    let first_data_row = |terminal: &Terminal<TestBackend>| -> String {
+      let buffer = terminal.backend().buffer();
+      (0..area.width)
+        .filter_map(|x| buffer.cell((x, 2)).map(|c| c.symbol().to_string()))
+        .collect()
+    };
+
+    // Scroll down to row 15: with height 12 and default padding 5 the offset
+    // math treats 7 rows as visible, so the view lands at offset 9.
+    app.track_table.selected_index = 15;
+    terminal.draw(|f| draw_song_table(f, &app, area)).unwrap();
+    assert!(
+      first_data_row(&terminal).contains("Track 9"),
+      "view should scroll to offset 9"
+    );
+
+    // Moving the cursor back up within the window must NOT move the view.
+    app.track_table.selected_index = 12;
+    terminal.draw(|f| draw_song_table(f, &app, area)).unwrap();
+    assert!(
+      first_data_row(&terminal).contains("Track 9"),
+      "view should stay anchored while the cursor moves inside the window"
+    );
+
+    // At the top visible row the view still holds...
+    app.track_table.selected_index = 9;
+    terminal.draw(|f| draw_song_table(f, &app, area)).unwrap();
+    assert!(
+      first_data_row(&terminal).contains("Track 9"),
+      "cursor on the top visible row should not scroll yet"
+    );
+
+    // ...and only going past it scrolls the view up.
+    app.track_table.selected_index = 8;
+    terminal.draw(|f| draw_song_table(f, &app, area)).unwrap();
+    assert!(
+      first_data_row(&terminal).contains("Track 8"),
+      "going above the top visible row should scroll the view up"
+    );
   }
 
   #[test]


### PR DESCRIPTION
A performance pass over startup, rendering, and the network/event architecture, plus the login fixes found along the way.

## Performance measurements

Measured with headless probes on Windows 11, debug profile (absolute values are inflated vs release, but before/after comparisons on the same profile are valid; the pacing probe is sleep-dominated and profile-independent).

| Scenario | Before | After | Change |
|---|---:|---:|---|
| Search fan-out pacing delay (5 concurrent API calls) | 1.04 s | 0.02-0.12 ms | ~1 s of artificial delay removed from every search, ~250 ms from every artist page |
| Frame draw, 10k-track table | 60.1 ms | 2.5 ms | ~24x; frame cost now scales with the viewport, not library size |
| Frame draw, 10k-track table scrolled to row 9500 | n/a | 2.6 ms | deep scroll costs the same as top-of-list |
| Home screen frame (60 fps animation tick) | 6.0 ms | 2.8 ms | ~2x |
| Home screen frame, scrolled deep into the changelog | 16.0 ms | 2.7 ms | ~6x; scroll depth no longer affects frame cost |
| Session-persistence check per tick (5k-track queue) | 2.16 ms | 9 ns | full snapshot now built only when the 3 s save throttle is due |
| Config saves while holding volume/resize keys | 2.08 ms disk write per key repeat | 0 per repeat | debounced to one save 500 ms after the last change |
| Redraws per keypress | 2 | 1 | tick events sent only when due |
| Sustained API rate (regression check) | 1 per 250 ms | 1 per 250 ms | unchanged; only bursts of up to 5 start immediately |

`opt-level = 3` was also measured against the current `"s"`: 19-37% faster frames but +33% binary size on costs already down to 0.06-0.4 ms release, so `"s"` stays.

## What changed

**Startup**
- The TUI shows immediately: the update check runs concurrently with auth, and the account probe + librespot session handshake (up to 45 s worst case) moved to a background task behind a live UI.
- One `/me` round trip instead of three; playlists publish page 1 right away and fetch the rest (plus rootlist folders) in the background; the Lua VM is only constructed when user scripts exist.

**Rendering**
- All table draws format only the visible rows instead of the whole backing collection every frame; the track table gains anchored scrolling.
- Home caches the changelog (pre-wrapped, sliced by scroll) and the banner gradient instead of rebuilding both per frame. This also un-froze the banner animation, which had been gated on a focus condition that almost never held.

**Network / event loop**
- Non-Spotify work (lyrics, cover art, Subsonic/radio/local, telemetry, friends) runs on a concurrent service lane so slow Spotify calls no longer head-of-line-block it; the pump's poll loop is replaced with a blocking bridge thread.
- API pacing reserves slots without holding the lock across the sleep and allows bursts of 5 (sized to the search fan-out); artist/album metadata gets a small TTL cache; Subsonic/radio/announcement HTTP clients are reused instead of rebuilt per action.
- Playlists open on Enter immediately with a loading state, and repeated presses dedupe instead of stacking dispatches.

**Playback reliability**
- Play requests issued while native streaming is recovering (or still initializing at startup) are parked and replayed once the device is back, instead of being swallowed or routed to the full-screen Error; a load watchdog with an attempt cap tears down zombie sessions.
- Playlist refreshes preserve folder selection and never publish a truncated list on a partial pagination failure; cover-art and lyrics results are dropped unless they match the current track.

**Login fixes**
- First-run auth no longer hangs on a blocking callback server; the startup wizard now uses the same async server as the in-TUI login (fixes #364).
- First-run double login completes without a restart: the native-streaming consent now waits for the Web API login's callback server to release port 8989 before binding it.

## Verification

- `cargo fmt`, `cargo clippy -D warnings` (CI feature set, all-sources, and default features), full test suite green throughout (419 tests on the CI set at HEAD).
- Live-tested: fresh-profile first run (both OAuth consents complete in one run), startup behavior Play/Pause with deferred init, playlist opens during startup, queue playback.
