### PR TITLE
fix: Native streaming recovery reconnects but leaves playback paused after a...

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -2470,6 +2470,7 @@ impl App {
   /// TCP: `is_connected` true, Spirc commands silently dropped).
   #[cfg(feature = "streaming")]
   pub fn force_native_streaming_recovery(&mut self, reselect_device: bool) {
+    let resume_playback = self.native_is_playing == Some(true);
     if let Some(player) = self.streaming_player.take() {
       // Stop the old spirc before dropping our reference so the dead session
       // doesn't linger as a ghost Connect device (#297).
@@ -2496,7 +2497,10 @@ impl App {
     self.set_status_message("Native streaming disconnected; attempting recovery.", 8);
     if let Some(tx) = &self.streaming_recovery_tx {
       self.native_backend_pending = tx
-        .send(crate::infra::player::StreamingRecoveryRequest { reselect_device })
+        .send(crate::infra::player::StreamingRecoveryRequest {
+          reselect_device,
+          resume_playback,
+        })
         .is_ok();
     } else {
       self.native_backend_pending = false;

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -110,7 +110,7 @@ pub enum IoEvent {
   GetAlbum(String),
   TransferPlaybackToDevice(String, bool),
   #[allow(dead_code)]
-  AutoSelectStreamingDevice(String, bool), // Auto-select a device by name (used for native streaming)
+  AutoSelectStreamingDevice(String, bool, bool), // device name, persist ID, resume playback
   GetAlbumForTrack(String),
   CurrentUserSavedTracksContains(Vec<String>),
   GetCurrentUserSavedShows(Option<u32>),
@@ -681,9 +681,9 @@ impl Network {
           .await;
       }
       #[cfg(feature = "streaming")]
-      IoEvent::AutoSelectStreamingDevice(device_name, persist_device_id) => {
+      IoEvent::AutoSelectStreamingDevice(device_name, persist_device_id, resume_playback) => {
         self
-          .auto_select_streaming_device(device_name, persist_device_id)
+          .auto_select_streaming_device(device_name, persist_device_id, resume_playback)
           .await;
       }
       #[cfg(not(feature = "streaming"))]

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -54,7 +54,12 @@ pub trait PlaybackNetwork {
   async fn change_volume(&mut self, volume: u8);
   async fn transfert_playback_to_device(&mut self, device_id: String, persist_device_id: bool);
   #[cfg(feature = "streaming")]
-  async fn auto_select_streaming_device(&mut self, device_name: String, persist_device_id: bool);
+  async fn auto_select_streaming_device(
+    &mut self,
+    device_name: String,
+    persist_device_id: bool,
+    resume_playback: bool,
+  );
   async fn ensure_playback_continues(&mut self, previous_track_id: String);
   /// Resume a native-Spotify context suspended under the native queue, targeting
   /// the resume track via an offset URI. Falls back to playing just the track
@@ -1888,7 +1893,12 @@ impl PlaybackNetwork for Network {
   }
 
   #[cfg(feature = "streaming")]
-  async fn auto_select_streaming_device(&mut self, device_name: String, persist_device_id: bool) {
+  async fn auto_select_streaming_device(
+    &mut self,
+    device_name: String,
+    persist_device_id: bool,
+    resume_playback: bool,
+  ) {
     if let Some(player) = current_streaming_player(self).await {
       let activation_time = Instant::now();
       let native_device_id = player.device_id();
@@ -1925,6 +1935,9 @@ impl PlaybackNetwork for Network {
         let _ = player.transfer(None);
       }
       player.activate();
+      if resume_playback {
+        player.play();
+      }
       self
         .native_idle_recovery
         .settle_current_episode(activation_time);

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -16,6 +16,7 @@ use tokio::sync::Mutex;
 #[derive(Clone, Copy, Default)]
 pub struct StreamingRecoveryRequest {
   pub reselect_device: bool,
+  pub resume_playback: bool,
 }
 
 /// Bundled context for player event handling tasks.
@@ -60,14 +61,19 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
   while let Some(mut request) = ctx.recovery_rx.recv().await {
     while let Ok(next_request) = ctx.recovery_rx.try_recv() {
       request.reselect_device |= next_request.reselect_device;
+      request.resume_playback |= next_request.resume_playback;
     }
 
-    if active_streaming_player(&ctx.app).await.is_some() {
+    if let Some(player) = active_streaming_player(&ctx.app).await {
       // A live player already exists (e.g. a queued duplicate request): the
       // pending window is over, so replay anything parked against it.
       let mut app = ctx.app.lock().await;
       app.native_backend_pending = false;
+      let has_pending_start = app.pending_start_playback.is_some();
       app.replay_pending_start_playback();
+      if request.resume_playback && !has_pending_start {
+        player.play();
+      }
       continue;
     }
 
@@ -106,10 +112,12 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
           }
           app.streaming_player = Some(Arc::clone(&recovered_player));
           app.set_status_message("Native streaming recovered.", 6);
-          if request.reselect_device {
+          let resume_playback = request.resume_playback && app.pending_start_playback.is_none();
+          if request.reselect_device || resume_playback {
             app.dispatch(IoEvent::AutoSelectStreamingDevice(
               ctx.client_config.streaming_device_name.clone(),
               false,
+              resume_playback,
             ));
           }
           // Replay the request that triggered (or arrived during) recovery.
@@ -477,6 +485,12 @@ async fn handle_player_events(
         }
       }
       PlayerEvent::Stopped { .. } => {
+        // Spirc emits Stopped before its event channel closes when Spotify
+        // Connect transfers playback away. Clear this before recovery decides
+        // whether to resume, so we do not steal playback back (#254). An abrupt
+        // session drop has no Stopped event and preserves the playing state.
+        shared_is_playing.store(false, Ordering::Relaxed);
+
         #[cfg(all(feature = "mpris", target_os = "linux"))]
         if let Some(ref mpris) = mpris_manager {
           mpris.set_stopped();
@@ -748,7 +762,9 @@ async fn disconnect_streaming_player(
   // Spotify Connect sends SessionDisconnected when the user intentionally moves
   // playback to another device. At that point the API context can still be the
   // old native device, so only reselect native for non-Connect-disconnect paths.
-  let reselect_device = allow_reselect_device && current_playback_matches_native(&app_lock, player);
+  let playback_matches_native = current_playback_matches_native(&app_lock, player);
+  let reselect_device = allow_reselect_device && playback_matches_native;
+  let resume_playback = playback_matches_native && shared_is_playing.load(Ordering::Relaxed);
 
   app_lock.streaming_player = None;
   // Stop the old Connect session so it doesn't linger as a ghost device (#297).
@@ -773,5 +789,8 @@ async fn disconnect_streaming_player(
   shared_position.store(0, Ordering::Relaxed);
   shared_is_playing.store(false, Ordering::Relaxed);
 
-  Some(StreamingRecoveryRequest { reselect_device })
+  Some(StreamingRecoveryRequest {
+    reselect_device,
+    resume_playback,
+  })
 }

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -762,9 +762,8 @@ async fn disconnect_streaming_player(
   // Spotify Connect sends SessionDisconnected when the user intentionally moves
   // playback to another device. At that point the API context can still be the
   // old native device, so only reselect native for non-Connect-disconnect paths.
-  let playback_matches_native = current_playback_matches_native(&app_lock, player);
-  let reselect_device = allow_reselect_device && playback_matches_native;
-  let resume_playback = playback_matches_native && shared_is_playing.load(Ordering::Relaxed);
+  let reselect_device = allow_reselect_device && current_playback_matches_native(&app_lock, player);
+  let resume_playback = reselect_device && shared_is_playing.load(Ordering::Relaxed);
 
   app_lock.streaming_player = None;
   // Stop the old Connect session so it doesn't linger as a ghost device (#297).

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -326,7 +326,7 @@ impl StartupDeviceEvent {
       StartupDeviceEvent::AutoSelectStreaming {
         device_name,
         persist_device_id,
-      } => IoEvent::AutoSelectStreamingDevice(device_name, persist_device_id),
+      } => IoEvent::AutoSelectStreamingDevice(device_name, persist_device_id, false),
     }
   }
 }


### PR DESCRIPTION
Fixes #372.

## Summary

Native streaming recovery reconnects but leaves playback paused after a mid-song session drop

## Validation

- Mechanical gate: +47/-11, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming recovery to optionally resume playback automatically after reconnects or device switching.
  * Enhanced device re-selection logic to preserve and apply the intended resume/playback behavior during recovery.
  * Refined stopped-playback handling to clear playback state reliably before downstream processing.
  * Better coalescing of queued recovery actions to reduce cases where resume or device-selection steps could be skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->