### PR TITLE
fix: Play/Pause on the queue slot's playbar resumes Spotify instead of pausin...

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -4593,9 +4593,13 @@ impl App {
     }
 
     // Spotify queue playback has no item in `current_playback_context`; route
-    // the intended transport action using the librespot state instead.
+    // the intended transport action using the librespot state instead. Flip the
+    // state optimistically so rapid toggles alternate instead of both reading
+    // the stale pre-router value and dispatching the same action twice.
     if self.queue_now_is_spotify() {
-      if self.native_is_playing.unwrap_or(false) {
+      let is_playing = self.native_is_playing.unwrap_or(false);
+      self.native_is_playing = Some(!is_playing);
+      if is_playing {
         self.dispatch(IoEvent::PausePlayback);
       } else {
         self.dispatch(IoEvent::StartPlayback(None, None, None));
@@ -7978,6 +7982,17 @@ mod tests {
 
     assert!(app.queue_now_is_spotify());
     assert!(matches!(rx.recv().unwrap(), IoEvent::PausePlayback));
+    assert_eq!(app.native_is_playing, Some(false));
+
+    // A second toggle before the router echoes back the new state must read
+    // the optimistically flipped value and dispatch the opposite action.
+    app.toggle_playback();
+
+    assert!(matches!(
+      rx.recv().unwrap(),
+      IoEvent::StartPlayback(None, None, None)
+    ));
+    assert_eq!(app.native_is_playing, Some(true));
   }
 
   #[cfg(feature = "streaming")]

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -4592,58 +4592,63 @@ impl App {
       return;
     }
 
-    // A queued Spotify track owns the sink via librespot: skip the per-source
-    // arms (any still-`Some` `*_playback` is a suspended context whose paused
-    // player must not be resumed on top of librespot) and fall through to the
-    // native-streaming control below.
-    if !self.queue_now_is_spotify() {
-      // Local-file playback owns the session: toggle the local sink directly. The
-      // playbar reads pause state live from the player, so nothing else to update.
-      #[cfg(feature = "local-files")]
-      if let Some(local) = &self.local_playback {
-        if local.player.is_paused() {
-          local.player.resume();
-        } else {
-          local.player.pause();
-        }
-        return;
+    // Spotify queue playback has no item in `current_playback_context`; route
+    // the intended transport action using the librespot state instead.
+    if self.queue_now_is_spotify() {
+      if self.native_is_playing.unwrap_or(false) {
+        self.dispatch(IoEvent::PausePlayback);
+      } else {
+        self.dispatch(IoEvent::StartPlayback(None, None, None));
       }
+      return;
+    }
 
-      // Subsonic playback owns the session the same way: toggle its sink directly.
-      #[cfg(feature = "subsonic")]
-      if let Some(subsonic) = &self.subsonic_playback {
-        if subsonic.player.is_paused() {
-          subsonic.player.resume();
-        } else {
-          subsonic.player.pause();
-        }
-        return;
+    // Local-file playback owns the session: toggle the local sink directly. The
+    // playbar reads pause state live from the player, so nothing else to update.
+    #[cfg(feature = "local-files")]
+    if let Some(local) = &self.local_playback {
+      if local.player.is_paused() {
+        local.player.resume();
+      } else {
+        local.player.pause();
       }
+      return;
+    }
 
-      // YouTube playback owns the session the same way: toggle its sink directly.
-      #[cfg(feature = "youtube")]
-      if let Some(youtube) = &self.youtube_playback {
-        if youtube.player.is_paused() {
-          youtube.player.resume();
-        } else {
-          youtube.player.pause();
-        }
-        return;
+    // Subsonic playback owns the session the same way: toggle its sink directly.
+    #[cfg(feature = "subsonic")]
+    if let Some(subsonic) = &self.subsonic_playback {
+      if subsonic.player.is_paused() {
+        subsonic.player.resume();
+      } else {
+        subsonic.player.pause();
       }
+      return;
+    }
 
-      // Internet-radio playback owns the session the same way: toggle its sink
-      // directly. Without this branch radio falls through to the streaming path,
-      // which only ever emits a bare resume — so Play/Pause could resume radio but
-      // never pause it.
-      #[cfg(feature = "internet-radio")]
-      if let Some(radio) = &self.radio_playback {
-        if radio.player.is_paused() {
-          radio.player.resume();
-        } else {
-          radio.player.pause();
-        }
-        return;
+    // YouTube playback owns the session the same way: toggle its sink directly.
+    #[cfg(feature = "youtube")]
+    if let Some(youtube) = &self.youtube_playback {
+      if youtube.player.is_paused() {
+        youtube.player.resume();
+      } else {
+        youtube.player.pause();
       }
+      return;
+    }
+
+    // Internet-radio playback owns the session the same way: toggle its sink
+    // directly. Without this branch radio falls through to the streaming path,
+    // which only ever emits a bare resume — so Play/Pause could resume radio but
+    // never pause it.
+    #[cfg(feature = "internet-radio")]
+    if let Some(radio) = &self.radio_playback {
+      if radio.player.is_paused() {
+        radio.player.resume();
+      } else {
+        radio.player.pause();
+      }
+      return;
     }
 
     // Use native streaming player for instant control (bypasses event channel latency)
@@ -7962,15 +7967,17 @@ mod tests {
   #[test]
   fn toggle_playback_with_spotify_queue_slot_does_not_panic() {
     use crate::infra::queue::QueueNowPlaying;
-    let (tx, _rx) = channel();
+    let (tx, rx) = channel();
     let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
     app.queue_now = Some(QueueNowPlaying::Spotify {
       track: queue_track(Some("spotify:track:queued"), "Queued"),
     });
+    app.native_is_playing = Some(true);
 
     app.toggle_playback();
 
     assert!(app.queue_now_is_spotify());
+    assert!(matches!(rx.recv().unwrap(), IoEvent::PausePlayback));
   }
 
   #[cfg(feature = "streaming")]

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -120,6 +120,20 @@ async fn route_spotify_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -
     return None;
   }
   match event {
+    IoEvent::PausePlayback => {
+      if let Some(player) = { app.lock().await.streaming_player.clone() } {
+        player.pause();
+      }
+      app.lock().await.native_is_playing = Some(false);
+      Some(true)
+    }
+    IoEvent::StartPlayback(None, None, None) => {
+      if let Some(player) = { app.lock().await.streaming_player.clone() } {
+        player.play();
+      }
+      app.lock().await.native_is_playing = Some(true);
+      Some(true)
+    }
     IoEvent::NextTrack => {
       advance_native_queue(app).await;
       Some(true)
@@ -995,7 +1009,7 @@ mod tests {
 
   #[cfg(feature = "streaming")]
   #[tokio::test]
-  async fn bare_resume_does_not_clear_spotify_queue_slot() {
+  async fn spotify_queue_slot_consumes_transport_controls() {
     use crate::core::queue::SuspendedContext;
     use crate::infra::queue::QueueNowPlaying;
     let app = test_app();
@@ -1010,11 +1024,13 @@ mod tests {
       });
     }
 
-    assert!(!route_queue_event(&app, &IoEvent::StartPlayback(None, None, None)).await);
+    assert!(route_queue_event(&app, &IoEvent::PausePlayback).await);
+    assert!(route_queue_event(&app, &IoEvent::StartPlayback(None, None, None)).await);
 
     let guard = app.lock().await;
     assert!(guard.queue_now_is_spotify());
     assert!(guard.queue_suspended.is_some());
+    assert_eq!(guard.native_is_playing, Some(true));
   }
 
   #[cfg(feature = "streaming")]


### PR DESCRIPTION
Fixes #374.

## Summary

Play/Pause on the queue slot's playbar resumes Spotify instead of pausing the queued track

## Validation

- Mechanical gate: +71/-48, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved play/pause handling for the Spotify native queue-slot, including correct pause vs “bare resume” behavior.
  - Prevented incorrect fallthrough into decoded-source toggling paths during Spotify queue-slot transport controls.
  - Ensured Internet Radio transport controls don’t trigger unintended streaming resume logic.
  - Preserved the Spotify queue context while consuming transport controls and updating playback state.
- **Tests**
  - Expanded coverage for Spotify queue-slot transport control dispatch and playback-state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->