### PR TITLE
feat: search help rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Searchable Help menu**: Press the configured search key (`/` by default) while viewing Help to filter keybinding rows across descriptions, keys, and contexts. Multiple terms are matched together using smart-case matching; press `Enter` to apply the filter and `Esc` to clear it.
+
 - **Lyrics view: smooth scrolling, browsing, and a timing nudge**: The lyrics view now glides between lines with a short eased animation instead of snapping. Scroll with `↑`/`↓` (or the mouse wheel) to read ahead or behind: auto-follow pauses while you browse (the browsed line is highlighted and a hint row appears) and resumes with `f`, `Esc`, or automatically after 8 seconds without input. `Ctrl+d`/`Ctrl+u` page five lines at a time and `Ctrl+a`/`Ctrl+e` jump to the first/last line. For LRC files whose timestamps do not line up with your audio, `→`/`←` nudge the lyric timing half a second earlier/later per press; the current offset is shown in the block title and resets on track change. The title also notes "(timing estimated)" when LRCLIB only had plain lyrics, so synthesized line timings are no longer presented as real ones.
 
 - **Banner Gradient toggle**: A new setting (Settings → Theme → Banner Gradient, or `behavior.banner_gradient` in `config.yml`) turns off the home banner's animated RGB gradient and draws it in the theme's banner color instead. The Terminal (ANSI) preset defaults the gradient off so the banner follows the terminal palette out of the box — tools like pywal recolor it live along with the rest of the UI; an explicit `banner_gradient:` in the config overrides the preset default either way ([#336](https://github.com/LargeModGames/spotatui/issues/336)).

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1345,6 +1345,10 @@ pub struct App {
   pub help_menu_page: u32,
   pub help_menu_max_lines: u32,
   pub help_menu_offset: u32,
+  /// Text filter applied to the rows in the Help menu.
+  pub help_filter: String,
+  /// Whether typed keys are currently editing [`Self::help_filter`].
+  pub help_filter_editing: bool,
   pub is_loading: bool,
   io_tx: Option<Sender<IoEvent>>,
   pub is_fetching_current_playback: bool,
@@ -1776,6 +1780,8 @@ impl Default for App {
       help_menu_page: 0,
       help_menu_max_lines: 0,
       help_menu_offset: 0,
+      help_filter: String::new(),
+      help_filter_editing: false,
       is_loading: false,
       io_tx: None,
       is_fetching_current_playback: false,
@@ -5923,15 +5929,15 @@ impl App {
   }
 
   pub fn calculate_help_menu_offset(&mut self) {
-    let old_offset = self.help_menu_offset;
+    if self.help_menu_max_lines == 0 || self.help_docs_size == 0 {
+      self.help_menu_page = 0;
+      self.help_menu_offset = 0;
+      return;
+    }
 
-    if self.help_menu_max_lines < self.help_docs_size {
-      self.help_menu_offset = self.help_menu_page * self.help_menu_max_lines;
-    }
-    if self.help_menu_offset > self.help_docs_size {
-      self.help_menu_offset = old_offset;
-      self.help_menu_page -= 1;
-    }
+    let last_page = self.help_docs_size.saturating_sub(1) / self.help_menu_max_lines;
+    self.help_menu_page = self.help_menu_page.min(last_page);
+    self.help_menu_offset = self.help_menu_page * self.help_menu_max_lines;
   }
 
   /// Load settings for the current category into settings_items

--- a/src/tui/handlers/help_menu.rs
+++ b/src/tui/handlers/help_menu.rs
@@ -1,5 +1,8 @@
 use super::common_key_events;
-use crate::{core::app::App, tui::event::Key};
+use crate::{
+  core::app::{ActiveBlock, App, RouteId},
+  tui::{event::Key, ui::help::get_filtered_help_docs},
+};
 
 #[derive(PartialEq)]
 enum Direction {
@@ -7,8 +10,26 @@ enum Direction {
   Down,
 }
 
+pub(super) fn open(app: &mut App) {
+  clear_filter(app);
+  app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+}
+
+pub(super) fn clear_filter(app: &mut App) {
+  app.help_filter.clear();
+  app.help_filter_editing = false;
+  refresh_filtered_rows(app);
+}
+
 pub fn handler(key: Key, app: &mut App) {
+  if app.help_filter_editing {
+    handle_filter_input(key, app);
+    return;
+  }
+
   match key {
+    k if k == app.user_config.keys.search => begin_filter(app),
+    Key::Esc if !app.help_filter.is_empty() => clear_filter(app),
     k if common_key_events::down_event(k, &app.user_config.keys) => {
       move_page(Direction::Down, app);
     }
@@ -25,13 +46,70 @@ pub fn handler(key: Key, app: &mut App) {
   };
 }
 
+fn begin_filter(app: &mut App) {
+  app.help_filter.clear();
+  app.help_filter_editing = true;
+  refresh_filtered_rows(app);
+}
+
+fn handle_filter_input(key: Key, app: &mut App) {
+  match key {
+    Key::Esc => clear_filter(app),
+    Key::Enter => {
+      if app.help_filter.split_whitespace().next().is_none() {
+        clear_filter(app);
+      } else {
+        app.help_filter_editing = false;
+        reset_page(app);
+      }
+    }
+    Key::Backspace | Key::Ctrl('h') => {
+      app.help_filter.pop();
+      refresh_filtered_rows(app);
+    }
+    Key::Ctrl('u') | Key::Ctrl('l') => {
+      app.help_filter.clear();
+      refresh_filtered_rows(app);
+    }
+    Key::Ctrl('w') => {
+      while app.help_filter.ends_with(char::is_whitespace) {
+        app.help_filter.pop();
+      }
+      while app
+        .help_filter
+        .chars()
+        .next_back()
+        .is_some_and(|c| !c.is_whitespace())
+      {
+        app.help_filter.pop();
+      }
+      refresh_filtered_rows(app);
+    }
+    Key::Char(c) => {
+      app.help_filter.push(c);
+      refresh_filtered_rows(app);
+    }
+    _ => {}
+  }
+}
+
+fn refresh_filtered_rows(app: &mut App) {
+  app.help_docs_size = get_filtered_help_docs(app).len() as u32;
+  reset_page(app);
+}
+
+fn reset_page(app: &mut App) {
+  app.help_menu_page = 0;
+  app.help_menu_offset = 0;
+}
+
 fn move_page(direction: Direction, app: &mut App) {
   if direction == Direction::Up {
     if app.help_menu_page > 0 {
       app.help_menu_page -= 1;
     }
   } else if direction == Direction::Down {
-    app.help_menu_page += 1;
+    app.help_menu_page = app.help_menu_page.saturating_add(1);
   }
   app.calculate_help_menu_offset();
 }
@@ -39,8 +117,10 @@ fn move_page(direction: Direction, app: &mut App) {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::core::app::{ActiveBlock, RouteId};
-  use crate::tui::handlers::handle_app;
+  use crate::{
+    core::source::Source,
+    tui::{handlers::handle_app, ui::help::get_help_docs},
+  };
 
   #[test]
   fn test_help_menu_pagination() {
@@ -76,6 +156,20 @@ mod tests {
   }
 
   #[test]
+  fn pagination_does_not_open_an_empty_last_page() {
+    let mut app = App::default();
+    app.help_docs_size = 20;
+    app.help_menu_max_lines = 10;
+    app.help_menu_page = 1;
+    app.calculate_help_menu_offset();
+
+    handler(Key::Down, &mut app);
+
+    assert_eq!(app.help_menu_page, 1);
+    assert_eq!(app.help_menu_offset, 10);
+  }
+
+  #[test]
   fn test_help_menu_navigation_stack() {
     let mut app = App::default();
     // Start at Home
@@ -96,12 +190,68 @@ mod tests {
     handle_app(Key::Char('?'), &mut app);
     assert_eq!(app.get_current_route().id, RouteId::HelpMenu);
 
-    // Close help menu with 'q' (simulating the back key handling in main.rs)
+    // Close help menu with 'q' (simulating the back key handling in the runner)
     let back_key = app.user_config.keys.back;
     assert_eq!(back_key, Key::Char('q'));
 
     let pop_result = app.pop_navigation_stack();
     assert!(pop_result.is_some());
     assert_eq!(app.get_current_route().id, RouteId::Home);
+  }
+
+  #[test]
+  fn search_key_starts_a_local_help_filter_and_captures_global_keys() {
+    let mut app = App::default();
+    app.active_source = Source::Local;
+    handle_app(app.user_config.keys.help, &mut app);
+
+    handle_app(app.user_config.keys.search, &mut app);
+    handle_app(Key::Char('d'), &mut app);
+    handle_app(Key::Char('q'), &mut app);
+
+    assert_eq!(app.get_current_route().id, RouteId::HelpMenu);
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::HelpMenu);
+    assert!(app.help_filter_editing);
+    assert_eq!(app.help_filter, "dq");
+  }
+
+  #[test]
+  fn confirmed_filter_stays_applied_until_escape_clears_it() {
+    let mut app = App::default();
+    handle_app(app.user_config.keys.help, &mut app);
+    let unfiltered_size = get_help_docs(&app).len() as u32;
+
+    handle_app(app.user_config.keys.search, &mut app);
+    for c in "volume".chars() {
+      handle_app(Key::Char(c), &mut app);
+    }
+
+    assert!(app.help_filter_editing);
+    assert!(app.help_docs_size > 0);
+    assert!(app.help_docs_size < unfiltered_size);
+
+    handle_app(Key::Enter, &mut app);
+    assert!(!app.help_filter_editing);
+    assert_eq!(app.help_filter, "volume");
+
+    handle_app(Key::Esc, &mut app);
+    assert_eq!(app.get_current_route().id, RouteId::HelpMenu);
+    assert!(app.help_filter.is_empty());
+    assert_eq!(app.help_docs_size, unfiltered_size);
+
+    handle_app(Key::Esc, &mut app);
+    assert_eq!(app.get_current_route().id, RouteId::Home);
+  }
+
+  #[test]
+  fn help_filter_uses_the_configured_search_binding() {
+    let mut app = App::default();
+    app.user_config.keys.search = Key::Char('f');
+    handle_app(app.user_config.keys.help, &mut app);
+
+    handle_app(Key::Char('f'), &mut app);
+
+    assert!(app.help_filter_editing);
+    assert!(app.help_filter.is_empty());
   }
 }

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -123,6 +123,15 @@ pub fn handle_app(key: Key, app: &mut App) {
     return;
   }
 
+  // Help filtering is an inline modal input. Give it priority over global
+  // bindings so queries can contain keys such as d, n, p, q, or ?.
+  if app.get_current_route().active_block == ActiveBlock::HelpMenu
+    && (app.help_filter_editing || key == app.user_config.keys.search)
+  {
+    help_menu::handler(key, app);
+    return;
+  }
+
   if app.get_current_route().active_block == ActiveBlock::Settings
     && (app.settings_unsaved_prompt_visible || app.settings_edit_mode)
   {
@@ -233,7 +242,7 @@ pub fn handle_app(key: Key, app: &mut App) {
       app.force_previous_track();
     }
     _ if key == app.user_config.keys.help => {
-      app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+      help_menu::open(app);
     }
     _ if key == app.user_config.keys.show_queue => {
       app.dispatch(IoEvent::GetQueue);
@@ -540,7 +549,11 @@ fn handle_escape(app: &mut App) {
       app.clear_dialog_state();
     }
     ActiveBlock::HelpMenu => {
-      app.pop_navigation_stack();
+      if app.help_filter_editing || !app.help_filter.is_empty() {
+        help_menu::clear_filter(app);
+      } else {
+        app.pop_navigation_stack();
+      }
     }
     ActiveBlock::Queue => {
       app.pop_navigation_stack();

--- a/src/tui/handlers/mouse.rs
+++ b/src/tui/handlers/mouse.rs
@@ -201,7 +201,7 @@ fn handle_input_mouse(mouse: MouseEvent, input_area: Rect, app: &mut App) {
 
 fn handle_help_mouse(mouse: MouseEvent, app: &mut App) {
   if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
-    app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+    super::help_menu::open(app);
   }
 }
 

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -275,6 +275,17 @@ fn back_key_clears_playlist_filter(app: &mut App, active_block: ActiveBlock) -> 
   }
 }
 
+/// The runner normally handles the configurable back key before `handle_app`.
+/// Help's inline filter must get first chance while it is being edited (so `q`
+/// can be query text), when opening the filter, and when Esc should clear a
+/// confirmed filter rather than close Help.
+fn help_menu_captures_key_before_back(app: &App, key: Key) -> bool {
+  app.get_current_route().active_block == ActiveBlock::HelpMenu
+    && (app.help_filter_editing
+      || key == app.user_config.keys.search
+      || (key == Key::Esc && !app.help_filter.is_empty()))
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -362,6 +373,31 @@ mod tests {
 
     assert!(app.active_playlist_track_filter.is_none());
     assert_eq!(app.get_current_route().id, RouteId::TrackTable);
+  }
+
+  #[test]
+  fn help_filter_captures_back_key_while_editing() {
+    let mut app = app();
+    app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+    app.help_filter_editing = true;
+
+    assert!(help_menu_captures_key_before_back(
+      &app,
+      app.user_config.keys.back
+    ));
+  }
+
+  #[test]
+  fn confirmed_help_filter_captures_escape_but_not_normal_back_key() {
+    let mut app = app();
+    app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+    app.help_filter = "volume".to_string();
+
+    assert!(help_menu_captures_key_before_back(&app, Key::Esc));
+    assert!(!help_menu_captures_key_before_back(
+      &app,
+      app.user_config.keys.back
+    ));
   }
 }
 
@@ -792,6 +828,8 @@ pub async fn start_ui(
           }
         } else if current_active_block == ActiveBlock::Input {
           handlers::input_handler(key, &mut app);
+        } else if help_menu_captures_key_before_back(&app, key) {
+          handlers::handle_app(key, &mut app);
         } else if key == app.user_config.keys.back {
           if !back_key_clears_playlist_filter(&mut app, current_active_block) {
             if current_active_block == ActiveBlock::Settings {

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -1,5 +1,36 @@
 use crate::core::app::App;
 
+/// Return Help rows matching the active filter.
+/// Whitespace-separated terms are ANDed and matching is case-insensitive unless
+/// a term contains an uppercase ASCII character.
+pub fn get_filtered_help_docs(app: &App) -> Vec<Vec<String>> {
+  filter_help_docs(get_help_docs(app), &app.help_filter)
+}
+
+fn filter_help_docs(rows: Vec<Vec<String>>, filter: &str) -> Vec<Vec<String>> {
+  let terms = filter.split_whitespace().collect::<Vec<_>>();
+  if terms.is_empty() {
+    return rows;
+  }
+
+  rows
+    .into_iter()
+    .filter(|row| {
+      terms
+        .iter()
+        .all(|term| row.iter().any(|field| help_field_contains(field, term)))
+    })
+    .collect()
+}
+
+fn help_field_contains(field: &str, term: &str) -> bool {
+  if term.chars().any(|c| c.is_ascii_uppercase()) {
+    field.contains(term)
+  } else {
+    field.to_lowercase().contains(&term.to_lowercase())
+  }
+}
+
 pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
   let key_bindings = &app.user_config.keys;
   vec![
@@ -132,6 +163,11 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("Enter input for search"),
       key_bindings.search.to_string(),
       String::from("General"),
+    ],
+    vec![
+      String::from("Filter help rows"),
+      key_bindings.search.to_string(),
+      String::from("Help menu"),
     ],
     vec![
       String::from("Pause/Resume playback"),
@@ -436,4 +472,51 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("General"),
     ],
   ]
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn rows() -> Vec<Vec<String>> {
+    vec![
+      vec![
+        "Increase volume by 10%".to_string(),
+        "+".to_string(),
+        "General".to_string(),
+      ],
+      vec![
+        "Search tracks in current playlist".to_string(),
+        "<Ctrl+f>".to_string(),
+        "Track table (playlist views)".to_string(),
+      ],
+      vec![
+        "Open settings".to_string(),
+        "<Alt+,>".to_string(),
+        "General".to_string(),
+      ],
+    ]
+  }
+
+  #[test]
+  fn help_filter_matches_terms_across_columns() {
+    let filtered = filter_help_docs(rows(), "ctrl playlist");
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0][0], "Search tracks in current playlist");
+  }
+
+  #[test]
+  fn help_filter_uses_smart_case() {
+    assert_eq!(filter_help_docs(rows(), "VOLUME").len(), 0);
+    assert_eq!(filter_help_docs(rows(), "volume").len(), 1);
+    assert_eq!(filter_help_docs(rows(), "Increase").len(), 1);
+  }
+
+  #[test]
+  fn empty_help_filter_preserves_all_rows_and_order() {
+    let rows = rows();
+
+    assert_eq!(filter_help_docs(rows.clone(), "   "), rows);
+  }
 }

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -81,7 +81,9 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
   let total_width = table_area.width as usize;
 
   let cache_slot = HELP_MENU_CACHE.get_or_init(|| std::sync::Mutex::new(None));
-  let mut cache = cache_slot.lock().unwrap();
+  let mut cache = cache_slot
+    .lock()
+    .unwrap_or_else(|poisoned| poisoned.into_inner());
   let stale = cache.as_ref().is_none_or(|c| {
     c.width != total_width || c.keys != app.user_config.keys || c.filter != app.help_filter
   });

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -10,14 +10,15 @@ use ratatui::{
   Frame,
 };
 
-use super::help::get_help_docs;
+use super::help::get_filtered_help_docs;
 
-/// Formatted help rows are static per session except for terminal width and
-/// keybinding changes, so cache them instead of rebuilding ~80 owned Strings
-/// (plus per-cell char-count truncation) on every redraw while help is open.
+/// Formatted help rows are static between terminal-width, keybinding, or filter
+/// changes, so cache them instead of rebuilding ~80 owned Strings (plus
+/// per-cell char-count truncation) on every redraw while Help is open.
 struct HelpMenuCache {
   width: usize,
   keys: crate::core::user_config::KeyBindings,
+  filter: String,
   header: String,
   rows: Vec<String>,
 }
@@ -28,7 +29,7 @@ static HELP_MENU_CACHE: std::sync::OnceLock<std::sync::Mutex<Option<HelpMenuCach
 fn build_help_rows(app: &App, total_width: usize) -> (String, Vec<String>) {
   // Create a one-column table to avoid flickering due to non-determinism when
   // resolving constraints on widths of table columns.
-  // Calculate column widths based on available terminal width
+  // Calculate column widths based on available terminal width.
   let col1_width = (total_width as f32 * 0.40) as usize;
   let col2_width = (total_width as f32 * 0.30) as usize;
   let col3_width = total_width.saturating_sub(col1_width + col2_width + 2);
@@ -59,7 +60,12 @@ fn build_help_rows(app: &App, total_width: usize) -> (String, Vec<String>) {
 
   let header = ["Description", "Event", "Context"];
   let header = format_row(header.iter().map(|s| s.to_string()).collect());
-  let rows = get_help_docs(app).into_iter().map(format_row).collect();
+  // Filter before formatting/truncating so narrow terminals do not make hidden
+  // parts of descriptions or contexts unsearchable.
+  let rows = get_filtered_help_docs(app)
+    .into_iter()
+    .map(format_row)
+    .collect();
   (header, rows)
 }
 
@@ -67,19 +73,24 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
   let [area] = f
     .area()
     .layout(&Layout::vertical([Constraint::Percentage(100)]).margin(2));
+  let [table_area, filter_area] = area.layout(&Layout::vertical([
+    Constraint::Min(0),
+    Constraint::Length(1),
+  ]));
 
-  let total_width = area.width as usize;
+  let total_width = table_area.width as usize;
 
   let cache_slot = HELP_MENU_CACHE.get_or_init(|| std::sync::Mutex::new(None));
   let mut cache = cache_slot.lock().unwrap();
-  let stale = cache
-    .as_ref()
-    .is_none_or(|c| c.width != total_width || c.keys != app.user_config.keys);
+  let stale = cache.as_ref().is_none_or(|c| {
+    c.width != total_width || c.keys != app.user_config.keys || c.filter != app.help_filter
+  });
   if stale {
     let (header, rows) = build_help_rows(app, total_width);
     *cache = Some(HelpMenuCache {
       width: total_width,
       keys: app.user_config.keys.clone(),
+      filter: app.help_filter.clone(),
       header,
       rows,
     });
@@ -88,13 +99,24 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
 
   let help_menu_style = app.user_config.theme.base_style();
   let header = &cache.header;
-  let help_docs = &cache.rows[app.help_menu_offset as usize..];
-  // Only the rows that fit the area can render; don't build Rows for the rest.
-  let help_docs = &help_docs[..help_docs.len().min(area.height as usize)];
+  let start = (app.help_menu_offset as usize).min(cache.rows.len());
+  // Two border rows plus the table header leave this many data rows. This is
+  // also the value used by the runner for page-size calculations.
+  let visible_count = table_area.height.saturating_sub(3) as usize;
+  let end = start.saturating_add(visible_count).min(cache.rows.len());
+  let help_docs = &cache.rows[start..end];
 
-  let rows = help_docs
-    .iter()
-    .map(|item| Row::new([item.as_str()]).style(help_menu_style));
+  let rows: Vec<Row<'_>> = if cache.rows.is_empty() && !app.help_filter.is_empty() {
+    vec![
+      Row::new([format!("No help rows match '{}'", app.help_filter)])
+        .style(Style::default().fg(app.user_config.theme.inactive)),
+    ]
+  } else {
+    help_docs
+      .iter()
+      .map(|item| Row::new([item.as_str()]).style(help_menu_style))
+      .collect()
+  };
 
   let help_menu = Table::new(rows, &[Constraint::Percentage(100)])
     .header(Row::new([header.as_str()]))
@@ -102,14 +124,107 @@ pub fn draw_help_menu(f: &mut Frame<'_>, app: &App) {
       Block::default()
         .borders(Borders::ALL)
         .style(help_menu_style)
-        .title(Span::styled(
-          "Help (press <Esc> to go back)",
-          help_menu_style,
-        ))
+        .title(Span::styled("Help", help_menu_style))
         .border_style(help_menu_style),
     )
     .style(help_menu_style);
-  f.render_widget(help_menu, area);
+  f.render_widget(help_menu, table_area);
+
+  let theme = app.user_config.theme;
+  let filter_line = if app.help_filter_editing {
+    Line::from(vec![
+      Span::styled("Filter: ", Style::default().fg(theme.active)),
+      Span::styled(app.help_filter.clone(), help_menu_style),
+      Span::styled("▏", Style::default().fg(theme.active)),
+      Span::styled(
+        "  <Enter>: apply  <Esc>: cancel search",
+        Style::default().fg(theme.inactive),
+      ),
+    ])
+  } else if !app.help_filter.is_empty() {
+    Line::from(vec![
+      Span::styled(
+        format!("matches for '{}'", app.help_filter),
+        Style::default().fg(theme.active),
+      ),
+      Span::styled(
+        format!(" ({})  <Esc>: clear filter", cache.rows.len()),
+        Style::default().fg(theme.inactive),
+      ),
+    ])
+  } else {
+    Line::from(vec![
+      Span::styled(
+        app.user_config.keys.search.to_string(),
+        Style::default().fg(theme.active),
+      ),
+      Span::styled(
+        ": filter rows  <Esc>: go back",
+        Style::default().fg(theme.inactive),
+      ),
+    ])
+  };
+  f.render_widget(
+    Paragraph::new(filter_line).style(help_menu_style),
+    filter_area,
+  );
+}
+
+#[cfg(test)]
+mod help_menu_tests {
+  use super::*;
+  use ratatui::{backend::TestBackend, Terminal};
+
+  fn rendered_help(app: &App) -> String {
+    let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+    terminal.draw(|f| draw_help_menu(f, app)).unwrap();
+    let buffer = terminal.backend().buffer();
+
+    (0..30)
+      .map(|y| {
+        (0..100)
+          .filter_map(|x| buffer.cell((x, y)).map(|cell| cell.symbol().to_string()))
+          .collect::<String>()
+      })
+      .collect::<Vec<_>>()
+      .join("\n")
+  }
+
+  #[test]
+  fn help_menu_renders_only_filtered_rows_and_live_prompt() {
+    let mut app = App::default();
+    app.help_filter = "volume".to_string();
+    app.help_filter_editing = true;
+
+    let rendered = rendered_help(&app);
+
+    assert!(rendered.contains("Increase volume by 10%"));
+    assert!(rendered.contains("Decrease volume by 10%"));
+    assert!(!rendered.contains("Jump to start of playlist"));
+    assert!(rendered.contains("Filter: volume▏"));
+    assert!(rendered.contains("<Enter>: apply  <Esc>: cancel search"));
+  }
+
+  #[test]
+  fn help_menu_shows_back_hint_when_filter_is_inactive() {
+    let rendered = rendered_help(&App::default());
+
+    assert!(rendered.contains("<Esc>: go back"));
+    assert!(!rendered.contains("press <Esc> to go back"));
+  }
+
+  #[test]
+  fn help_menu_renders_no_matches_and_clamps_a_stale_offset() {
+    let mut app = App::default();
+    app.help_filter = "not-a-real-help-row".to_string();
+    app.help_menu_offset = u32::MAX;
+
+    let rendered = rendered_help(&app);
+
+    assert!(rendered.contains("No help rows match 'not-a-real-help-row'"));
+    assert!(rendered.contains("matches for 'not-a-real-help-row' (0)"));
+    assert!(rendered.contains("<Esc>: clear filter"));
+  }
 }
 
 fn queue_item_line(item: &PlayableInfo) -> String {


### PR DESCRIPTION
# Summary

Search help menu rows.

🤖 AI-authored PR, operated by @felixzieger

# Testing

- cargo fmt --all
- cargo clippy --locked -- -D warnings
- cargo test --locked (477 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out)
- manual ui testing

# Additional notes

Hint at the bottom of help menu:
<img width="1348" height="841" alt="grafik" src="https://github.com/user-attachments/assets/7d828ce5-d62e-4d03-85a6-963596590922" />

Filter:
<img width="1348" height="841" alt="grafik" src="https://github.com/user-attachments/assets/c81afa64-7d79-41a8-930b-75966c4e8132" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added searchable Help menu using the configured search key (default `/`) to start filtering Help entries.
  - Supports multi-term filtering across descriptions, keys, and contexts with smart-case matching.
  - Live filter prompt inside the Help menu: `Enter` confirms (clears if empty), and `Esc` clears the filter (or exits Help when no filter is active).
  - Displays “no help rows match …” when there are no matches and shows only the matching rows.

- **Bug Fixes**
  - Improved Help menu pagination/offset clamping so navigation no longer lands on empty last pages and results stay aligned with the visible area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->