### PR TITLE
fix: Crashes when audio backend fails instead of failing softly

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -5303,12 +5303,14 @@ impl App {
   /// Pause native streaming playback with the full bookkeeping the pause
   /// branch of [`toggle_playback`](Self::toggle_playback) does: clear any
   /// parked StartPlayback and the load watchdog (either would resume or force
-  /// recovery against a backend we just gave up on), pause the player, and
-  /// flip the UI playing state.
+  /// recovery against a backend we just gave up on), mark the playback intent
+  /// as paused (so a recovery snapshot doesn't resume into that backend
+  /// either), pause the player, and flip the UI playing state.
   #[cfg(feature = "streaming")]
   pub fn pause_native_playback(&mut self) {
     self.pending_start_playback = None;
     self.native_load_watchdog = None;
+    self.set_native_playback_intent(false);
     if let Some(player) = &self.streaming_player {
       player.pause();
     }
@@ -5417,15 +5419,7 @@ impl App {
           if is_playing { "paused" } else { "playing" }
         );
         if is_playing {
-          self.pending_start_playback = None;
-          self.native_load_watchdog = None;
-          self.set_native_playback_intent(false);
-          player.pause();
-          // Update UI state immediately
-          if let Some(ctx) = &mut self.current_playback_context {
-            ctx.is_playing = false;
-          }
-          self.native_is_playing = Some(false);
+          self.pause_native_playback();
         } else {
           self.set_native_playback_intent(true);
           player.play();

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -5300,6 +5300,24 @@ impl App {
     None
   }
 
+  /// Pause native streaming playback with the full bookkeeping the pause
+  /// branch of [`toggle_playback`](Self::toggle_playback) does: clear any
+  /// parked StartPlayback and the load watchdog (either would resume or force
+  /// recovery against a backend we just gave up on), pause the player, and
+  /// flip the UI playing state.
+  #[cfg(feature = "streaming")]
+  pub fn pause_native_playback(&mut self) {
+    self.pending_start_playback = None;
+    self.native_load_watchdog = None;
+    if let Some(player) = &self.streaming_player {
+      player.pause();
+    }
+    if let Some(ctx) = &mut self.current_playback_context {
+      ctx.is_playing = false;
+    }
+    self.native_is_playing = Some(false);
+  }
+
   pub fn toggle_playback(&mut self) {
     // The native queue slot owns the sink: toggle its player directly (covers the
     // idle-app case where no per-source context is set).

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -453,9 +453,16 @@ impl RecoveringSink {
 impl audio_backend::Sink for RecoveringSink {
   fn start(&mut self) -> audio_backend::SinkResult<()> {
     self.failed = false;
-    if let Err(err) = self.with_inner("start", |sink| sink.start()) {
-      *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(err.to_string());
-      self.failed = true;
+    match self.with_inner("start", |sink| sink.start()) {
+      Ok(()) => {
+        // A working sink supersedes any stale error recorded before there was
+        // a player to surface it; leaving it would report a live failure later.
+        *self.error.lock().unwrap_or_else(|e| e.into_inner()) = None;
+      }
+      Err(err) => {
+        *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(err.to_string());
+        self.failed = true;
+      }
     }
     // A sink error must not invalidate librespot's player thread. Keep consuming
     // packets silently so the TUI can surface the failure and remain usable.
@@ -1318,9 +1325,76 @@ fn new_device_id_string() -> String {
 mod tests {
   use super::{
     get_or_create_device_id, new_device_id_string, should_retry_with_fresh_credentials,
-    wait_for_oauth_callback_port, StreamingConnectionState,
+    wait_for_oauth_callback_port, RecoveringSink, StreamingConnectionState,
   };
+  use librespot_playback::{audio_backend, convert::Converter, decoder::AudioPacket};
+  use std::sync::Arc;
   use std::time::Duration;
+
+  struct StubSink {
+    start_result: fn() -> audio_backend::SinkResult<()>,
+  }
+
+  impl audio_backend::Sink for StubSink {
+    fn start(&mut self) -> audio_backend::SinkResult<()> {
+      (self.start_result)()
+    }
+
+    fn stop(&mut self) -> audio_backend::SinkResult<()> {
+      Ok(())
+    }
+
+    fn write(
+      &mut self,
+      _packet: AudioPacket,
+      _converter: &mut Converter,
+    ) -> audio_backend::SinkResult<()> {
+      Ok(())
+    }
+  }
+
+  fn failing_start() -> audio_backend::SinkResult<()> {
+    Err(audio_backend::SinkError::StateChange(
+      "stub backend failure".to_string(),
+    ))
+  }
+
+  fn stub_recovering_sink(
+    start_result: fn() -> audio_backend::SinkResult<()>,
+  ) -> (RecoveringSink, Arc<std::sync::Mutex<Option<String>>>) {
+    let error = Arc::new(std::sync::Mutex::new(None));
+    let sink = RecoveringSink::new(
+      move || Box::new(StubSink { start_result }) as Box<dyn audio_backend::Sink>,
+      Arc::clone(&error),
+    );
+    (sink, error)
+  }
+
+  #[test]
+  fn failing_backend_start_returns_ok_and_records_error() {
+    use audio_backend::Sink;
+
+    let (mut sink, error) = stub_recovering_sink(failing_start);
+
+    // The regression guard for #384: a failing backend must not propagate the
+    // error into librespot's player thread.
+    sink.start().expect("start() must fail softly");
+    assert!(sink.failed);
+    let recorded = error.lock().unwrap().take();
+    assert!(recorded.unwrap().contains("stub backend failure"));
+  }
+
+  #[test]
+  fn successful_start_clears_stale_backend_error() {
+    use audio_backend::Sink;
+
+    let (mut sink, error) = stub_recovering_sink(|| Ok(()));
+    *error.lock().unwrap() = Some("stale error from a previous sink".to_string());
+
+    sink.start().expect("start() should succeed");
+    assert!(!sink.failed);
+    assert!(error.lock().unwrap().is_none());
+  }
 
   #[test]
   fn oauth_callback_port_waits_for_previous_listener_to_release() {

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -367,16 +367,20 @@ async fn run_spirc_supervisor(mut ctx: SpircSupervisorContext) {
 struct RecoveringSink {
   inner: Option<Box<dyn audio_backend::Sink>>,
   make_sink: Box<dyn Fn() -> Box<dyn audio_backend::Sink>>,
+  error: Arc<std::sync::Mutex<Option<String>>>,
+  failed: bool,
 }
 
 impl RecoveringSink {
-  fn new<F>(make_sink: F) -> Self
+  fn new<F>(make_sink: F, error: Arc<std::sync::Mutex<Option<String>>>) -> Self
   where
     F: Fn() -> Box<dyn audio_backend::Sink> + 'static,
   {
     Self {
       inner: None,
       make_sink: Box::new(make_sink),
+      error,
+      failed: false,
     }
   }
 
@@ -448,7 +452,14 @@ impl RecoveringSink {
 
 impl audio_backend::Sink for RecoveringSink {
   fn start(&mut self) -> audio_backend::SinkResult<()> {
-    self.with_inner("start", |sink| sink.start())
+    self.failed = false;
+    if let Err(err) = self.with_inner("start", |sink| sink.start()) {
+      *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(err.to_string());
+      self.failed = true;
+    }
+    // A sink error must not invalidate librespot's player thread. Keep consuming
+    // packets silently so the TUI can surface the failure and remain usable.
+    Ok(())
   }
 
   fn stop(&mut self) -> audio_backend::SinkResult<()> {
@@ -467,7 +478,14 @@ impl audio_backend::Sink for RecoveringSink {
     packet: AudioPacket,
     converter: &mut Converter,
   ) -> audio_backend::SinkResult<()> {
-    self.with_inner("write", |sink| sink.write(packet, converter))
+    if self.failed {
+      return Ok(());
+    }
+    if let Err(err) = self.with_inner("write", |sink| sink.write(packet, converter)) {
+      *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(err.to_string());
+      self.failed = true;
+    }
+    Ok(())
   }
 }
 
@@ -676,6 +694,7 @@ pub struct StreamingPlayer {
   shutdown_tx: tokio::sync::watch::Sender<bool>,
   connection_state_tx: tokio::sync::watch::Sender<StreamingConnectionState>,
   connection_state_rx: tokio::sync::watch::Receiver<StreamingConnectionState>,
+  audio_backend_error: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 #[allow(dead_code)]
@@ -789,14 +808,17 @@ impl StreamingPlayer {
       })?;
 
     // Create player
+    let audio_backend_error = Arc::new(std::sync::Mutex::new(None));
+    let sink_error = Arc::clone(&audio_backend_error);
     let player = Player::new(
       player_config,
       session.clone(),
       mixer.get_soft_volume(),
       move || {
-        Box::new(RecoveringSink::new(move || {
-          backend(requested_device.clone(), AudioFormat::default())
-        }))
+        Box::new(RecoveringSink::new(
+          move || backend(requested_device.clone(), AudioFormat::default()),
+          Arc::clone(&sink_error),
+        ))
       },
     );
 
@@ -915,6 +937,7 @@ impl StreamingPlayer {
       shutdown_tx,
       connection_state_tx,
       connection_state_rx,
+      audio_backend_error,
     })
   }
 
@@ -983,6 +1006,14 @@ impl StreamingPlayer {
 
   pub fn connection_state(&self) -> StreamingConnectionState {
     *self.connection_state_rx.borrow()
+  }
+
+  pub fn take_audio_backend_error(&self) -> Option<String> {
+    self
+      .audio_backend_error
+      .lock()
+      .unwrap_or_else(|e| e.into_inner())
+      .take()
   }
 
   /// Play a track by its Spotify URI (e.g., "spotify:track:xxxx")

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -478,12 +478,18 @@ impl audio_backend::Sink for RecoveringSink {
     packet: AudioPacket,
     converter: &mut Converter,
   ) -> audio_backend::SinkResult<()> {
+    // Unlike start(), write errors must propagate: a blocking sink.write() is
+    // librespot's only backpressure, and its packet-error path pauses playback
+    // without exiting the process.
     if self.failed {
-      return Ok(());
+      return Err(audio_backend::SinkError::NotConnected(
+        "Audio sink unavailable".to_string(),
+      ));
     }
     if let Err(err) = self.with_inner("write", |sink| sink.write(packet, converter)) {
       *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(err.to_string());
       self.failed = true;
+      return Err(err);
     }
     Ok(())
   }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -674,6 +674,15 @@ pub async fn start_ui(
     let title_update = {
       let mut app = app.lock().await;
 
+      #[cfg(feature = "streaming")]
+      if let Some(player) = app.streaming_player.clone() {
+        if let Some(error) = player.take_audio_backend_error() {
+          player.pause();
+          app.native_is_playing = Some(false);
+          app.set_status_message(format!("Audio backend failed: {error}"), 15);
+        }
+      }
+
       #[cfg(all(feature = "mpris", target_os = "linux"))]
       {
         let current_is_streaming_active = app.is_streaming_active;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -677,8 +677,7 @@ pub async fn start_ui(
       #[cfg(feature = "streaming")]
       if let Some(player) = app.streaming_player.clone() {
         if let Some(error) = player.take_audio_backend_error() {
-          player.pause();
-          app.native_is_playing = Some(false);
+          app.pause_native_playback();
           app.set_status_message(format!("Audio backend failed: {error}"), 15);
         }
       }


### PR DESCRIPTION
Fixes #384.

## Summary

Crashes when audio backend fails instead of failing softly

## Validation

- Mechanical gate: +46/-6, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In streaming mode, audio-backend startup and streaming errors are now captured and made available to the UI instead of being silently ignored.
  * When an audio-backend error is detected, native playback is paused to prevent repeated failure loops.
  * The UI shows **“Audio backend failed: {error}”** for a short time, then clears the message and resumes normal status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->