### PR TITLE
fix: Song Quality Setting?

### DIFF
--- a/docs/native-streaming.md
+++ b/docs/native-streaming.md
@@ -17,6 +17,20 @@ The native streaming feature uses a separate authentication flow. On first run:
 - You can control playback from the TUI, your phone, or any other Spotify client
 - Audio plays directly on the computer running spotatui
 
+## Audio Quality
+
+Native streaming uses 320 kbps by default. To select a different quality, set
+`streaming_bitrate` in `client.yml` and restart spotatui:
+
+```yaml
+streaming_bitrate: 320 # 96, 160, or 320 kbps
+```
+
+`client.yml` is in the same app config directory as `config.yml` (for example,
+`~/.config/spotatui/client.yml` on Linux and macOS). This setting controls the
+librespot native player directly; the Spotify app may still describe a Connect
+device's quality as "Automatic".
+
 ## Notes
 
 - Native streaming is **enabled by default** when built with the `streaming` feature


### PR DESCRIPTION
## Summary

Song Quality Setting?

## Validation

- Mechanical gate: +14/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring native Spotify Connect streaming audio quality.
  * Documented supported bitrates, the 320 kbps default, configuration location, and restart requirements.
  * Clarified that Spotify may display the device quality as “Automatic” despite the configured bitrate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->