### PR TITLE
fix: nix develop flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,15 @@
 
             cargoLock = {
               lockFile = ./Cargo.lock;
+              outputHashes = {
+                "librespot-audio-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-connect-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-core-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-metadata-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-oauth-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-playback-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-protocol-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+              };
             };
             inherit nativeBuildInputs buildInputs;
             meta = with pkgs.lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
             pkgs.apple-sdk
             pkgs.portaudio
           ];
+        librespotOutputHash = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
       in
       {
         # Build dependencies for rust
@@ -52,13 +53,13 @@
             cargoLock = {
               lockFile = ./Cargo.lock;
               outputHashes = {
-                "librespot-audio-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-connect-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-core-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-metadata-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-oauth-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-playback-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
-                "librespot-protocol-0.8.0" = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+                "librespot-audio-0.8.0" = librespotOutputHash;
+                "librespot-connect-0.8.0" = librespotOutputHash;
+                "librespot-core-0.8.0" = librespotOutputHash;
+                "librespot-metadata-0.8.0" = librespotOutputHash;
+                "librespot-oauth-0.8.0" = librespotOutputHash;
+                "librespot-playback-0.8.0" = librespotOutputHash;
+                "librespot-protocol-0.8.0" = librespotOutputHash;
               };
             };
             inherit nativeBuildInputs buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,28 @@
         };
         cargoVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
         commitHash = toString (self.shortRev or self.dirtyShortRev or self.lastModified or "dirty");
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          patchelf
+          llvmPackages.clang
+          llvmPackages.libclang
+        ];
+        buildInputs =
+          with pkgs;
+          [
+            openssl
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            alsa-lib
+            dbus
+            pipewire
+          ]
+          # Build inputs for nix-darwin
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # macOS specific dependencies - use latest supported Apple SDK
+            pkgs.apple-sdk
+            pkgs.portaudio
+          ];
       in
       {
         # Build dependencies for rust
@@ -30,28 +52,7 @@
             cargoLock = {
               lockFile = ./Cargo.lock;
             };
-            nativeBuildInputs = with pkgs; [
-              pkg-config
-              patchelf
-              llvmPackages.clang
-              llvmPackages.libclang
-            ];
-            buildInputs =
-              with pkgs;
-              [
-                openssl
-              ]
-              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                alsa-lib
-                dbus
-                pipewire
-              ]
-              # Build inputs for nix-darwin
-              ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-                # macOS specific dependencies - use latest supported Apple SDK
-                pkgs.apple-sdk
-                pkgs.portaudio
-              ];
+            inherit nativeBuildInputs buildInputs;
             meta = with pkgs.lib; {
               description = "A Spotify client for the terminal written in Rust, powered by Ratatui";
               homepage = "https://github.com/LargeModGames/spotatui";
@@ -61,25 +62,29 @@
           };
           # Alias to reference it with .spotatui instead of default
           spotatui = self.packages.${system}.default;
+        };
 
-          # Execute with `nix run github:LargeModGames/spotatui`
-          apps = {
-            default = {
-              type = "app";
-              program = "${self.packages.${system}.default}/bin/spotatui";
-            };
+        # Execute with `nix run github:LargeModGames/spotatui`
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/spotatui";
           };
+        };
 
-          # Devtools for nix develop
-          devShells.default = pkgs.mkShell {
-            buildInputs = with pkgs; [
+        # Devtools for nix develop
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs =
+            nativeBuildInputs
+            ++ (with pkgs; [
               rustc
               cargo
               rust-analyzer
               rustfmt
               clippy
-            ];
-          };
+            ]);
+          inherit buildInputs;
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         };
       }
     );


### PR DESCRIPTION
# Summary

- Fix the flake output layout so `nix develop` finds `devShells.default` instead of falling back to the package derivation.
- Move `apps.default` to the proper top-level per-system flake output.
- Share native/build inputs between the package derivation and dev shell.
- Add `LIBCLANG_PATH` for bindgen/libclang-backed dependencies.
- Add `cargoLock.outputHashes` for the patched `librespot` git dependencies so `nix build` can vendor them reproducibly.

# Testing

- `nix flake show --all-systems`
- `nix develop --command true`
- `nix develop --command cargo --version`
  - Output included: `cargo 1.93.0`
- `nix develop --command pkg-config --modversion openssl`
  - Output: `3.6.1`
- `nix develop --command printenv LIBCLANG_PATH`
  - Output pointed to the Nix `libclang` store path.
- `nix-prefetch-git` for `LargeModGames/spotatui-librespot`
  - Confirmed hash: `sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=`
- `nix build --no-link`
  - Confirmed the previous Cargo vendoring/hash failure is fixed.
  - Build reached the final `spotatui` derivation; full package build did not complete during the validation window.

# Additional notes

- The seven `librespot-*` output hash entries use the same hash because they all come from the same pinned git repo/revision.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Rust build dependencies in the build configuration for consistent behavior across builds and development shells.
  * Added/updated output hash mappings for bundled `librespot` crate versions to strengthen dependency integrity.
  * Refreshed the development environment setup, including native tooling and `LIBCLANG_PATH`, to improve local build reliability.
  * Reformatted the packaged application output definition for clearer attribute structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->