### PR TITLE
ci: add nix flake check and build job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,61 @@
+# Nix packaging is only exercised when the inputs that can break it change,
+# because `nix build` compiles the whole crate and is far too slow to run on
+# every PR. Keep this list in sync with anything the flake reads.
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/nix.yml"
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/nix.yml"
+
+name: Nix
+
+permissions:
+  contents: read
+
+jobs:
+  flake:
+    name: Flake
+    runs-on: ubuntu-latest
+    # A cold `nix build` of the full default feature set (librespot included)
+    # is the long pole here.
+    timeout-minutes: 60
+    if: |
+      !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[skip ci]')
+    steps:
+      - uses: actions/checkout@master
+      - uses: cachix/install-nix-action@v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Catches outputs declared under the wrong attribute path. `devShells` and
+      # `apps` nested inside `packages` evaluated fine but were invisible to Nix,
+      # so `nix run` had no target and `nix develop` silently fell back to the
+      # package derivation (#401). Evaluation only, no builds.
+      - name: Check flake outputs
+        run: nix flake check --all-systems --no-build
+
+      # Direct regression guard for the above: the dev shell has to be reachable
+      # *and* actually carry the Rust toolchain.
+      - name: Dev shell provides the Rust toolchain
+        run: nix develop --command cargo --version
+
+      # The `librespot-*` entries in `cargoLock.outputHashes` pin the content of
+      # the spotatui-librespot checkout, while the rev they correspond to lives
+      # in Cargo.toml's [patch] block. Nothing links the two, so bumping the fork
+      # without regenerating the hash breaks `nix build` for every Nix user, with
+      # a fixed-output hash mismatch that never mentions the rev. Building here is
+      # what catches that drift before it reaches main.
+      - name: Build the package
+        run: nix build --no-link --print-build-logs .#default

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,8 +33,17 @@ jobs:
     if: |
       !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[skip ci]')
     steps:
-      - uses: actions/checkout@master
-      - uses: cachix/install-nix-action@v31.11.0
+      # Pinned to commit SHAs rather than tags or branches: a tag can be
+      # retargeted, and this job runs `nix build`, so a compromised action would
+      # be executing arbitrary code against the build. Dependabot already tracks
+      # the `github-actions` ecosystem and reads the trailing version comment, so
+      # these still get update PRs.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The job only reads the repo, so leaving GITHUB_TOKEN behind in the
+          # local git config buys nothing.
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
# Summary

Adds a Nix leg that the Rust matrix cannot cover. Three steps, cheapest first:

- `nix flake check --all-systems --no-build` catches outputs declared under the wrong attribute path. This is the #401 class of bug: `devShells` and `apps` nested inside `packages` evaluated fine but were invisible to Nix, so `nix run` had no target and `nix develop` silently fell back to the package derivation. That had been the case since v0.37.0.
- `nix develop --command cargo --version` guards the dev shell directly: reachable, and actually carrying the toolchain.
- `nix build --no-link .#default` catches drift between the `librespot-*` entries in `cargoLock.outputHashes` and the fork rev in `Cargo.toml`'s `[patch]` block. Nothing links the two, so bumping the fork without regenerating the hash breaks `nix build` for every Nix user, with a fixed-output hash mismatch that never names the rev. Only an actual build realizes the vendor derivation, so only a build catches it.

Separate workflow rather than a job in `ci.yml` because GitHub filters `paths:` at the workflow level only, and the build step compiles the full default feature set.

# Testing

Nix is not installed on my machine, so none of the three steps ran locally. The workflow triggers on changes to itself, so this PR's own run is the real verification.

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nix.yml'))"` parses clean
- `git ls-files flake.lock` confirms the lock is tracked, so the job will not go red merely because `nixos-unstable` moved
- `gh api repos/cachix/install-nix-action/tags` to pin `v31.11.0`; that repo publishes no moving major tag

# Additional notes

- Not suitable as a required check. With `paths:` filters it does not run on most PRs, and a required check that never runs leaves them blocked pending forever.
- Expect the build step to run long whenever it fires. A hermetic `nix build` gets no benefit from the existing `Swatinem/rust-cache`. That is inherent to catching hash drift by building; the path filter is the mitigation.
- If step 1 fails on a darwin attribute rather than on output layout, drop `--all-systems`. It cross-evaluates the darwin outputs (including `pkgs.apple-sdk`) from a Linux runner, and the layout bug it guards reproduces on the Linux system alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Nix-based CI workflow that runs on relevant changes to Nix/Rust or the workflow itself, and on pushes to the main branch.
  * Validates the Nix flake across all systems (without building) and confirms the development shell provides Rust tooling.
  * Builds the flake’s default output and includes protections like limited permissions, a 60-minute timeout, and support for `[skip ci]`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->