### PR TITLE
ci: add DeepSeek-powered issue triage bot

### DIFF
--- a/.github/scripts/triage.mjs
+++ b/.github/scripts/triage.mjs
@@ -1,0 +1,145 @@
+// Issue triage for spotatui, powered by DeepSeek V4-Flash.
+//
+// Two modes:
+//   node triage.mjs            -> calls the model, prints a validated triage
+//                                 JSON object to stdout (redirect to triage.json)
+//   node triage.mjs --render   -> reads triage.json and prints a Markdown block
+//                                 (used for both the run summary and the bot comment)
+//
+// No dependencies: Node 20+ built-in fetch and fs only. Untrusted issue text is
+// read from files (issue.json / open-issues.json) written by `gh`, never passed
+// through shell interpolation.
+
+import { readFileSync } from "node:fs";
+
+// Rename here if DeepSeek changes the model string. Endpoint is OpenAI-compatible.
+const MODEL = "deepseek-v4-flash";
+const API_URL = "https://api.deepseek.com/v1/chat/completions";
+
+// Labels the bot may APPLY. Deliberately excludes `duplicate` (on this repo that
+// means "closed as a dup" — a human decision) and judgement labels like
+// `good first issue` / `help wanted`. Dedup results go in the comment, not a label.
+const ALLOWED_LABELS = ["bug", "enhancement", "question", "documentation"];
+
+// ---- render mode -----------------------------------------------------------
+if (process.argv.includes("--render")) {
+  const r = JSON.parse(readFileSync("triage.json", "utf8"));
+  const lines = [];
+  lines.push("### 🎧 spotatui triage");
+  lines.push("");
+  lines.push("_Auto-generated with DeepSeek V4-Flash._");
+  lines.push("");
+  lines.push(`**Suggested label:** ${r.labels.length ? r.labels.map((l) => `\`${l}\``).join(", ") : "_none_"}`);
+  lines.push(`**Summary:** ${r.summary || "_n/a_"}`);
+  lines.push("");
+  if (r.dup_candidates.length) {
+    lines.push("**Possible duplicates:**");
+    for (const d of r.dup_candidates) lines.push(`- #${d.number} (${d.confidence}) — ${d.reason}`);
+  } else {
+    lines.push("**Possible duplicates:** none found");
+  }
+  lines.push("");
+  lines.push(`<sub>Compared against the ${r.compared} most recently updated open issues.</sub>`);
+  console.log(lines.join("\n"));
+  process.exit(0);
+}
+
+// ---- triage mode -----------------------------------------------------------
+const apiKey = process.env.DEEPSEEK_API_KEY;
+if (!apiKey) {
+  console.error("DEEPSEEK_API_KEY is not set");
+  process.exit(1);
+}
+
+const issue = JSON.parse(readFileSync("issue.json", "utf8"));
+let openIssues = [];
+try {
+  openIssues = JSON.parse(readFileSync("open-issues.json", "utf8"));
+} catch {
+  openIssues = [];
+}
+// Never compare an issue against itself.
+openIssues = openIssues.filter((i) => i.number !== issue.number);
+const compared = openIssues.length;
+
+const system = `You triage GitHub issues for "spotatui", a Rust terminal UI Spotify client.
+Return ONLY a JSON object — no prose, no Markdown fences — with this exact shape:
+{
+  "category": one of ${JSON.stringify(ALLOWED_LABELS)} or null,
+  "summary": "one plain sentence describing what the issue is about",
+  "dup_candidates": [ { "number": <int taken from the provided open-issue list>, "confidence": "high"|"medium"|"low", "reason": "short" } ]
+}
+Rules:
+- "category" is your single best classification, or null if none fit.
+- "dup_candidates": only issues from the provided list that plausibly describe the SAME underlying bug/request. Empty array if none. Never invent numbers.
+- Be conservative: prefer a null category and an empty dup list over guessing.`;
+
+const user = `NEW ISSUE #${issue.number}
+Title: ${issue.title}
+Body:
+${(issue.body || "").slice(0, 8000)}
+
+OPEN ISSUES (${compared} most recently updated; compare for duplicates):
+${openIssues.map((i) => `#${i.number}: ${i.title}`).join("\n") || "(none)"}`;
+
+const resp = await fetch(API_URL, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+  body: JSON.stringify({
+    model: MODEL,
+    temperature: 0,
+    // If the API ever rejects this field, drop it — the parser below already
+    // tolerates a model that wraps its JSON in a Markdown fence.
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+  }),
+});
+
+if (!resp.ok) {
+  console.error(`DeepSeek API error ${resp.status}: ${await resp.text()}`);
+  process.exit(1);
+}
+
+const raw = (await resp.json()).choices?.[0]?.message?.content ?? "";
+
+// Flash models occasionally wrap JSON in a ```json fence even with
+// response_format set; strip it before parsing.
+function parseModelJson(s) {
+  const fenced = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return JSON.parse((fenced ? fenced[1] : s).trim());
+}
+
+let triage;
+try {
+  triage = parseModelJson(raw);
+} catch (e) {
+  console.error(`Could not parse model output as JSON: ${e.message}\n---\n${raw}`);
+  process.exit(1);
+}
+
+// Hard-filter everything the model returned against reality.
+const openNumbers = new Set(openIssues.map((i) => i.number));
+const category = ALLOWED_LABELS.includes(triage.category) ? triage.category : null;
+const dupCandidates = Array.isArray(triage.dup_candidates)
+  ? triage.dup_candidates
+      .filter((d) => openNumbers.has(d.number))
+      .map((d) => ({
+        number: d.number,
+        confidence: ["high", "medium", "low"].includes(d.confidence) ? d.confidence : "low",
+        reason: String(d.reason || "").slice(0, 200),
+      }))
+  : [];
+
+console.log(
+  JSON.stringify({
+    issue: issue.number,
+    category,
+    labels: category ? [category] : [],
+    summary: String(triage.summary || "").slice(0, 300),
+    dup_candidates: dupCandidates,
+    compared,
+  }),
+);

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,111 @@
+name: Issue Triage
+
+# Drafts a triage (label + summary + possible duplicates) for every opened issue
+# using DeepSeek V4-Flash, then waits for a maintainer to approve it by adding the
+# `triage-ok` label before anything is posted publicly. See .github/scripts/triage.mjs.
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to (re)draft a triage for"
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: triage-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  # Draft the triage into the run summary. Runs on untrusted, user-opened issues,
+  # so it holds NO write permission and NO GitHub App key — only the DeepSeek key.
+  suggest:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Resolve issue number
+        id: n
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+        run: echo "number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Gather issue + open issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          N: ${{ steps.n.outputs.number }}
+        run: |
+          gh issue view "$N" --repo "$REPO" --json number,title,body > issue.json
+          gh issue list --repo "$REPO" --state open --limit 100 --json number,title > open-issues.json
+      - name: Draft triage with DeepSeek
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: node .github/scripts/triage.mjs > triage.json
+      - name: Write draft to run summary
+        env:
+          N: ${{ steps.n.outputs.number }}
+        run: |
+          node .github/scripts/triage.mjs --render >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "---"
+            echo "**To apply:** add the \`triage-ok\` label to issue #${N}."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Approved by a maintainer adding `triage-ok` (only write/triage access can add
+  # labels). This is the only job that holds the App key and writes to the repo.
+  apply:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'triage-ok'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Mint spotatui[bot] token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SPOTATUI_APP_ID }}
+          private-key: ${{ secrets.SPOTATUI_APP_KEY }}
+      - name: Gather issue + open issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          N: ${{ github.event.issue.number }}
+        run: |
+          gh issue view "$N" --repo "$REPO" --json number,title,body > issue.json
+          gh issue list --repo "$REPO" --state open --limit 100 --json number,title > open-issues.json
+      - name: Re-run triage with DeepSeek
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: node .github/scripts/triage.mjs > triage.json
+      - name: Post comment + apply labels as spotatui[bot]
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          N: ${{ github.event.issue.number }}
+        run: |
+          node .github/scripts/triage.mjs --render > comment.md
+          gh issue comment "$N" --repo "$REPO" --body-file comment.md
+          labels=$(node -e 'process.stdout.write(require("./triage.json").labels.join(","))')
+          if [ -n "$labels" ]; then
+            gh issue edit "$N" --repo "$REPO" --add-label "$labels"
+          fi
+          gh issue edit "$N" --repo "$REPO" --remove-label "triage-ok"


### PR DESCRIPTION
# Summary

An Issue Triage GitHub Action that uses DeepSeek V4-Flash to draft, for each opened issue, a suggested label (from the existing label set), a one-line summary, and possible-duplicate candidates. The draft is written to the workflow run summary only. Nothing is posted publicly until a maintainer approves by adding the `triage-ok` label, which triggers the apply job to post the comment and apply labels as `spotatui[bot]`.

Design notes:
- The `suggest` job runs on arbitrary user-opened issues, so it has read-only permission and no GitHub App key; only the approval-gated `apply` job holds the key and writes.
- Model output is hard-filtered in code against the real label set, invented issue numbers are dropped, and `duplicate` is never applied as a label (dedup goes in the comment body).
- Requires repo secrets `DEEPSEEK_API_KEY`, `SPOTATUI_APP_ID`, `SPOTATUI_APP_KEY`, and the `triage-ok` label (already created).

# Testing
- `node --check .github/scripts/triage.mjs` (syntax)
- Rendered the Markdown output for both a populated triage and the empty/no-findings case
- End-to-end dry run pending via `workflow_dispatch` after merge (Actions only run from the default branch)

# Additional notes
- Cost is roughly $0.001 to $0.002 per issue.
- First live run will confirm the `deepseek-v4-flash` model string and `response_format: json_object` support; both are one-line fixes at the top of the script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated issue triage that drafts summaries, suggested labels, and potential duplicate issues.
  * Added review-based approval before publishing triage results, applying labels, and posting comments.
  * Added protections to handle failed requests, invalid results, missing credentials, and overlapping triage runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->