### PR TITLE
Add one-line installers, cargo-binstall, and aarch64-Linux builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,11 @@ jobs:
             artifact_prefix: linux-x86_64 # most Linux distros
             binary_postfix: ""
             audio_features: "audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+          - os: ubuntu-24.04-arm # free native ARM64 runner for public repos
+            target: aarch64-unknown-linux-gnu
+            artifact_prefix: linux-aarch64 # Raspberry Pi 4/5, ARM servers, Asahi Linux
+            binary_postfix: ""
+            audio_features: "audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           - os: macos-15-intel # Intel runner for x86_64 (available until Aug 2027)
             target: x86_64-apple-darwin
             artifact_prefix: macos-x86_64
@@ -193,8 +198,11 @@ jobs:
 
             - On **Windows 10/11 (64-bit)** → `spotatui-windows-x86_64.zip`
             - On **Linux (Ubuntu, Arch, Fedora, etc.)** → `spotatui-linux-x86_64.tar.gz`
+            - On **Linux ARM64 (Raspberry Pi 4/5, ARM servers)** → `spotatui-linux-aarch64.tar.gz`
             - On **macOS with Intel CPU** → `spotatui-macos-x86_64.tar.gz`
             - On **macOS with Apple Silicon (M1/M2/M3)** → `spotatui-macos-aarch64.tar.gz`
+
+            Or just run the one-line installer: `curl -fsSL https://spotatui.com/install.sh | bash` (macOS/Linux) or `irm https://spotatui.com/install.ps1 | iex` (Windows).
 
             Checksums (`.sha256`) are optional and only needed if you want to verify the download.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,34 @@ suggests = "yt-dlp, ffmpeg"
 section = "utils"
 priority = "optional"
 
+# cargo-binstall: fetch the prebuilt release binaries instead of compiling.
+#   cargo binstall spotatui
+# Our release assets use friendly names (spotatui-<os>-<arch>) rather than the
+# Rust target triple, and the binary sits at the archive root, so every target
+# needs an explicit override with an archive-root bin-dir.
+[package.metadata.binstall]
+bin-dir = "{ bin }{ binary-ext }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/spotatui-linux-x86_64.tar.gz"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/spotatui-linux-aarch64.tar.gz"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/spotatui-macos-x86_64.tar.gz"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/spotatui-macos-aarch64.tar.gz"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/spotatui-windows-x86_64.zip"
+pkg-fmt = "zip"
+
 # Native streaming fixes: librespot 0.8.0 + backport of upstream PR #1722 (fall back to the
 # next CDN URL when one returns a non-206 status, e.g. HTTP 530) + port of upstream PR #1692
 # (dealer reconnects handled in place without restarting spirc; prompt spirc-task exit with

--- a/README.md
+++ b/README.md
@@ -76,25 +76,35 @@
 > **Spotify is optional.** On first launch spotatui asks which source you want to use. YouTube, Subsonic/Navidrome, Internet Radio, and Local Files all work with no Spotify account. Spotify Premium is only needed for the Spotify source; you can add it anytime from the `d` menu.
 
 ```bash
+# One-line installer — macOS, Linux, WSL. Grabs the prebuilt binary for your
+# system, verifies its checksum, and puts spotatui on your PATH. No Rust needed.
+curl -fsSL https://spotatui.com/install.sh | bash
+
 # Homebrew (macOS only)
 brew tap LargeModGames/spotatui
 brew install spotatui
 
-# Winget (Windows)
-winget install spotatui
-
-# Cargo
+# Cargo — compile from crates.io …
 cargo install --locked spotatui
+# … or fetch the prebuilt binary without compiling
+cargo binstall spotatui
 
-# Arch Linux (AUR) - pre-built binary (faster)
+# Arch Linux (AUR) — prebuilt binary (faster)
 yay -S spotatui-bin
-
-# Arch Linux (AUR) - build from source
+# …or build from source
 yay -S spotatui
 
-# Void Linux (Unofficial Repo)
+# Void Linux (unofficial repo)
 echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
 sudo xbps-install -S spotatui
+```
+
+```powershell
+# One-line installer — Windows PowerShell
+irm https://spotatui.com/install.ps1 | iex
+
+# …or via Winget
+winget install spotatui
 ```
 ```nix
 # NixOS (Flake)
@@ -117,6 +127,8 @@ inputs = {
 ```
 
 Or download pre-built binaries from [GitHub Releases](https://github.com/LargeModGames/spotatui/releases/latest).
+
+> **Which build has which sources?** The prebuilt Linux and Windows binaries (the one-line installer, GitHub Releases, and `cargo binstall`) include the extra music sources — Local Files, Subsonic, Internet Radio, and YouTube. macOS builds and a plain `cargo install --locked spotatui` do not; enable them with `--features local-files,subsonic,internet-radio,youtube`.
 
 See the [Installation Wiki](https://github.com/LargeModGames/spotatui/wiki/Installation) for platform-specific requirements and building from source.
 

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,7 @@
+@echo off
+REM spotatui installer for Windows CMD.
+REM
+REM   curl -fsSL https://spotatui.com/install.cmd -o install.cmd && install.cmd
+REM
+REM Delegates to the PowerShell installer so there is a single source of truth.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://spotatui.com/install.ps1 | iex"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+  spotatui installer for Windows.
+
+  irm https://spotatui.com/install.ps1 | iex
+
+  Environment overrides:
+    SPOTATUI_VERSION        install a specific tag (e.g. v0.40.3); default: latest
+    SPOTATUI_INSTALL_DIR    where to put the binary; default: %LOCALAPPDATA%\spotatui\bin
+    SPOTATUI_NO_MODIFY_PATH set to any value to skip updating your user PATH
+#>
+$ErrorActionPreference = 'Stop'
+
+$Repo   = 'LargeModGames/spotatui'
+$Binary = 'spotatui'
+$InstallDir = if ($env:SPOTATUI_INSTALL_DIR) { $env:SPOTATUI_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA 'spotatui\bin' }
+
+function Info($m) { Write-Host "· $m" -ForegroundColor DarkGray }
+function Ok($m)   { Write-Host "√ $m" -ForegroundColor Green }
+function Warn($m) { Write-Host "! $m" -ForegroundColor Yellow }
+function Fail($m) { Write-Host "x $m" -ForegroundColor Red; exit 1 }
+
+# --- detect arch -----------------------------------------------------------
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -ne 'AMD64') {
+  if ($arch -eq 'ARM64') {
+    Warn 'No native ARM64 Windows build yet; installing the x64 build (runs under emulation).'
+  } else {
+    Fail "Unsupported architecture '$arch'. Build from source instead: cargo install --locked spotatui"
+  }
+}
+$asset = "$Binary-windows-x86_64.zip"
+
+# --- resolve version / URL -------------------------------------------------
+if ($env:SPOTATUI_VERSION) {
+  $tag = 'v' + ($env:SPOTATUI_VERSION -replace '^v', '')
+  $base = "https://github.com/$Repo/releases/download/$tag"
+  $label = $tag
+} else {
+  $base = "https://github.com/$Repo/releases/latest/download"
+  $label = 'latest'
+}
+
+Info "installing spotatui ($label) for windows/x86_64"
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("spotatui-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+  $zip = Join-Path $tmp $asset
+  try {
+    Invoke-WebRequest -Uri "$base/$asset" -OutFile $zip -UseBasicParsing
+  } catch {
+    Fail "could not download $asset. That build may not exist yet for this release; try: cargo install --locked spotatui"
+  }
+
+  # --- verify checksum (best effort) --------------------------------------
+  try {
+    $sumFile = "$zip.sha256"
+    Invoke-WebRequest -Uri "$base/$asset.sha256" -OutFile $sumFile -UseBasicParsing
+    $expected = ((Get-Content $sumFile -Raw) -split '\s+' | Where-Object { $_ -match '^[0-9a-fA-F]{64}$' } | Select-Object -First 1)
+    $actual = (Get-FileHash -Algorithm SHA256 $zip).Hash
+    if ($expected -and $actual -and ($expected -ne $actual)) {
+      Fail "checksum mismatch (expected $expected, got $actual); aborting"
+    } elseif ($expected) {
+      Ok 'checksum verified'
+    } else {
+      Warn 'no published checksum; skipping verification'
+    }
+  } catch {
+    Warn 'no published checksum; skipping verification'
+  }
+
+  # --- extract & install --------------------------------------------------
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
+  $exe = Join-Path $tmp "$Binary.exe"
+  if (-not (Test-Path $exe)) { Fail "archive did not contain $Binary.exe" }
+
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  Copy-Item -Path $exe -Destination (Join-Path $InstallDir "$Binary.exe") -Force
+  Ok "installed to $InstallDir\$Binary.exe"
+
+  # --- add to user PATH ---------------------------------------------------
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  if (($userPath -split ';') -notcontains $InstallDir) {
+    if ($env:SPOTATUI_NO_MODIFY_PATH) {
+      Warn "$InstallDir is not on your PATH. Add it for this session with:"
+      Write-Host "    `$env:Path = `"$InstallDir;`$env:Path`""
+    } else {
+      [Environment]::SetEnvironmentVariable('Path', ((@($userPath, $InstallDir) | Where-Object { $_ }) -join ';'), 'User')
+      $env:Path = "$env:Path;$InstallDir"
+      Info "added $InstallDir to your user PATH (restart your terminal to pick it up)"
+    }
+  }
+} finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host "Done. Run $Binary to get started." -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# spotatui installer for macOS, Linux, and WSL.
+#
+#   curl -fsSL https://spotatui.com/install.sh | bash
+#
+# Environment overrides:
+#   SPOTATUI_VERSION      install a specific tag (e.g. v0.40.3); default: latest
+#   SPOTATUI_INSTALL_DIR  where to put the binary; default: $HOME/.local/bin
+set -euo pipefail
+
+REPO="LargeModGames/spotatui"
+BINARY="spotatui"
+INSTALL_DIR="${SPOTATUI_INSTALL_DIR:-$HOME/.local/bin}"
+
+# --- pretty output ---------------------------------------------------------
+if [ -t 2 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD="$(printf '\033[1m')"; DIM="$(printf '\033[2m')"; RED="$(printf '\033[31m')"
+  GREEN="$(printf '\033[32m')"; YELLOW="$(printf '\033[33m')"; RESET="$(printf '\033[0m')"
+else
+  BOLD=""; DIM=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+info()  { printf '%s\n' "${DIM}·${RESET} $*" >&2; }
+ok()    { printf '%s\n' "${GREEN}✓${RESET} $*" >&2; }
+warn()  { printf '%s\n' "${YELLOW}!${RESET} $*" >&2; }
+error() { printf '%s\n' "${RED}✗${RESET} $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+if command -v curl >/dev/null 2>&1; then
+  dl() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  dl() { wget -qO "$2" "$1"; }
+else
+  error "need curl or wget to download spotatui"
+fi
+
+sha256_of() { # print the sha256 of file $1 using whatever tool is available
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum   >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v openssl  >/dev/null 2>&1; then openssl dgst -sha256 "$1" | awk '{print $NF}'
+  else echo ""; fi
+}
+
+# --- detect platform -------------------------------------------------------
+os="$(uname -s)"; arch="$(uname -m)"
+case "$os" in
+  Linux)  platform_os="linux" ;;
+  Darwin) platform_os="macos" ;;
+  *) error "unsupported OS '$os'. Build from source instead: ${BOLD}cargo install --locked spotatui${RESET}" ;;
+esac
+case "$arch" in
+  x86_64|amd64)  platform_arch="x86_64" ;;
+  aarch64|arm64) platform_arch="aarch64" ;;
+  *) error "no prebuilt binary for '$arch'. Build from source instead: ${BOLD}cargo install --locked spotatui${RESET}" ;;
+esac
+asset="${BINARY}-${platform_os}-${platform_arch}.tar.gz"
+
+# --- resolve version / URL -------------------------------------------------
+if [ -n "${SPOTATUI_VERSION:-}" ]; then
+  tag="${SPOTATUI_VERSION#v}"; tag="v${tag}"
+  base="https://github.com/${REPO}/releases/download/${tag}"
+  label="$tag"
+else
+  base="https://github.com/${REPO}/releases/latest/download"
+  label="latest"
+fi
+
+info "installing ${BOLD}spotatui${RESET} (${label}) for ${platform_os}/${platform_arch}"
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+if ! dl "${base}/${asset}" "${tmp}/${asset}"; then
+  error "could not download ${asset}. That build may not exist yet for this release; try ${BOLD}cargo install --locked spotatui${RESET}"
+fi
+
+# --- verify checksum (best effort) -----------------------------------------
+if dl "${base}/${asset}.sha256" "${tmp}/${asset}.sha256" 2>/dev/null; then
+  expected="$(awk '{print $1}' "${tmp}/${asset}.sha256")"
+  actual="$(sha256_of "${tmp}/${asset}")"
+  if [ -z "$actual" ]; then
+    warn "no sha256 tool found; skipping checksum verification"
+  elif [ "$expected" != "$actual" ]; then
+    error "checksum mismatch (expected ${expected}, got ${actual}); aborting"
+  else
+    ok "checksum verified"
+  fi
+else
+  warn "no published checksum; skipping verification"
+fi
+
+# --- extract & install -----------------------------------------------------
+tar -xzf "${tmp}/${asset}" -C "$tmp"
+[ -f "${tmp}/${BINARY}" ] || error "archive did not contain '${BINARY}'"
+
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "${tmp}/${BINARY}" "${INSTALL_DIR}/${BINARY}" 2>/dev/null \
+  || { cp "${tmp}/${BINARY}" "${INSTALL_DIR}/${BINARY}" && chmod 0755 "${INSTALL_DIR}/${BINARY}"; }
+ok "installed to ${BOLD}${INSTALL_DIR}/${BINARY}${RESET}"
+
+# --- PATH management -------------------------------------------------------
+# Append the install dir to the right shell profile (idempotently) and set
+# PATH_RC to the file we touched. Returns non-zero only if it couldn't write.
+PATH_RC=""
+add_to_path() {
+  dir="$1"; disp="$1"
+  case "$dir" in "$HOME"/*) disp="\$HOME/${dir#"$HOME"/}" ;; esac
+  case "$(basename "${SHELL:-sh}")" in
+    zsh)  PATH_RC="${ZDOTDIR:-$HOME}/.zshrc";      line="export PATH=\"$disp:\$PATH\"" ;;
+    bash) PATH_RC="$HOME/.bashrc";                 line="export PATH=\"$disp:\$PATH\"" ;;
+    fish) PATH_RC="$HOME/.config/fish/config.fish"; line="fish_add_path $dir" ;;
+    *)    PATH_RC="$HOME/.profile";                line="export PATH=\"$disp:\$PATH\"" ;;
+  esac
+  [ -f "$PATH_RC" ] && grep -qF -- "$line" "$PATH_RC" 2>/dev/null && return 0  # already there
+  mkdir -p "$(dirname "$PATH_RC")" 2>/dev/null || true
+  { printf '\n# Added by spotatui installer\n'; printf '%s\n' "$line"; } >> "$PATH_RC" 2>/dev/null || return 1
+  return 0
+}
+
+manual_path_hint() {
+  warn "${INSTALL_DIR} is not on your PATH. Add it, e.g.:"
+  printf '%s\n' "    export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2
+}
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*)
+    : # already on PATH, nothing to do
+    ;;
+  *)
+    if [ -n "${SPOTATUI_NO_MODIFY_PATH:-}" ]; then
+      manual_path_hint
+    elif add_to_path "$INSTALL_DIR"; then
+      ok "added ${INSTALL_DIR} to your PATH in ${BOLD}${PATH_RC}${RESET}"
+      info "restart your terminal or run ${BOLD}source ${PATH_RC}${RESET} to use it now"
+    else
+      manual_path_hint
+    fi
+    ;;
+esac
+
+printf '\n%s\n' "${GREEN}Done.${RESET} Run ${BOLD}${BINARY}${RESET} to get started." >&2


### PR DESCRIPTION
# Summary

Adds several ways to install spotatui, all reusing the release assets `cd.yml` already builds:

- **One-line installers** served from `spotatui.com`: `install.sh` (macOS/Linux/WSL), `install.ps1` (Windows PowerShell), `install.cmd` (Windows CMD). Each detects OS/arch, downloads the matching release asset, verifies its `.sha256`, installs to PATH, and auto-configures the shell profile (opt out with `SPOTATUI_NO_MODIFY_PATH=1`). Canonical scripts live here on `main`; the website redirects `spotatui.com/install.*` to them (committed separately to the website repo's `main`).
- **`cargo binstall spotatui`** via `[package.metadata.binstall]`, which fetches prebuilt binaries instead of compiling (per-target overrides, since our assets use friendly names rather than target triples).
- **aarch64-Linux release builds** via a new `cd.yml` row on the free native `ubuntu-24.04-arm` runner (Raspberry Pi 4/5, ARM servers, Asahi). Produces `spotatui-linux-aarch64.tar.gz` plus an arm64 `.deb`.
- **README** install section regrouped with the new one-liners and a note on which builds include the extra music sources.

`.rpm` packaging is intentionally left as a follow-up (see #416); it needs its own Fedora dependency-resolution validation.

# Testing

- **aarch64-Linux build validated on a real `ubuntu-24.04-arm` runner** (throwaway workflow): full release build + tarball + `cargo-deb` + smoke-run in ~8 min. Output: `ELF 64-bit ... ARM aarch64`, `spotatui_0.40.3-1_arm64.deb`, and `spotatui --version` -> `spotatui 0.40.3`.
- **`install.sh` end-to-end** against the real v0.40.3 release: download + checksum verify + extract + install + run. Also tested the `latest` path and graceful failure on a missing asset (clean error, exit 1).
- **`install.sh` PATH management** with a fake `$HOME`: appends the correct line to `.bashrc`/`.zshrc` per `$SHELL`, idempotent on re-run; `SPOTATUI_NO_MODIFY_PATH=1` writes nothing.
- `bash -n install.sh` clean; `cargo metadata` confirms the binstall overrides parse; `cd.yml` YAML validated with the new arm64 row.
- **Not run:** `install.ps1` (no Windows/PowerShell available locally). Its logic mirrors the tested `install.sh`, but Windows-specific bits (registry PATH, `Expand-Archive`, `Get-FileHash`) are unverified. The `cargo binstall` metadata takes effect on the next crates.io publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * One-line installation commands now available for macOS, Linux, WSL, and Windows.
  * Added support for `cargo binstall` to quickly install prebuilt binaries.
  * Void Linux package option now available.
  * Optional music sources can be enabled when building from source.

* **Infrastructure**
  * Extended build pipeline with native ARM64 Linux support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->