### PR TITLE
Remove redundant cfg split around Network::new

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1283,9 +1283,8 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     info!("running in cli mode with command: {}", cmd);
     // Safe, because we checked if the subcommand is present at runtime
     let m = matches.subcommand_matches(cmd).unwrap();
-    #[cfg(feature = "streaming")]
-    let network = Network::new(spotify, client_config, &app, final_token_cache_path); // CLI doesn't use streaming
-    #[cfg(not(feature = "streaming"))]
+    // Both `Network::new` variants share one signature, so the same call
+    // compiles with or without `streaming`. CLI mode never uses streaming.
     let network = Network::new(spotify, client_config, &app, final_token_cache_path);
     println!(
       "{}",
@@ -1647,9 +1646,6 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     let cloned_app = Arc::clone(&app);
     info!("spawning spotify network event handler");
     tokio::spawn(async move {
-      #[cfg(feature = "streaming")]
-      let mut network = Network::new(spotify, client_config, &app, final_token_cache_path);
-      #[cfg(not(feature = "streaming"))]
       let mut network = Network::new(spotify, client_config, &app, final_token_cache_path);
 
       // The saved-device startup decision moved into


### PR DESCRIPTION
# Summary

`runtime.rs:1287` and `1289` were byte-for-byte identical, so the `#[cfg(feature = "streaming")]` / `#[cfg(not(...))]` split around them did nothing (flagged in #419). The streaming and non-streaming `Network::new` constructors share one signature, so a single call compiles under both feature sets, as the unguarded call at `runtime.rs:1945` already shows. The split was a leftover from when the constructors took different arguments; a later refactor unified the signatures but left the dead branches. Collapses both occurrences to a single call and fixes the misplaced `// CLI doesn't use streaming` comment, which had been sitting on the streaming branch.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
- `cargo check --no-default-features --features telemetry`
- `cargo check --features all-sources`

# Additional notes

Closes #419. Reported by @istipisti113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified network initialization across CLI and background event handling.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->