### PR TITLE
fix: load lyrics for multi-artist tracks (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Help search highlights its matches**: While filtering the Help menu (search key, `/` by default), every occurrence of your search terms is now highlighted in the visible rows, so you can see at a glance which part of a row matched. Highlighting follows the same smart-case rule as the filter itself ([#408](https://github.com/LargeModGames/spotatui/issues/408)).
 
+### Fixed
+
+- **Lyrics now load for collaborations**: A track credited to more than one artist (e.g. "Take Me Back" by Kygo and Max McNown) showed "No lyrics for this track" even when LRCLIB clearly had it. LRCLIB indexes each track under a single artist string, almost always the primary one, but spotatui sent the full joined credit ("Kygo, Max McNown") to both the exact `/api/get` and the fuzzy `/api/search` endpoint, so every collaboration missed. The playback snapshot now carries the artist names as a structured list instead of one pre-joined string (which also makes MPRIS `xesam:artist` a real array), and the LRCLIB lookup falls back to the primary artist alone when the full credit finds nothing ([#410](https://github.com/LargeModGames/spotatui/issues/410)).
+
 ## [v0.40.3] 2026-07-27
 
 ### Added

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -978,7 +978,11 @@ pub(crate) fn shuffle_advance_index(
 #[derive(Clone, Debug, Default)]
 pub struct NativeTrackInfo {
   pub name: String,
-  pub artists_display: String,
+  /// Individual credited artist names, in order. Kept structured (not a
+  /// pre-joined display string) so the LRCLIB lookup can fall back to the
+  /// primary artist alone for collaborations (#410). Join with `", "` for
+  /// display.
+  pub artists: Vec<String>,
   #[allow(dead_code)]
   pub album: String, // Reserved for future use (e.g., displaying album in playbar)
   pub duration_ms: u32,

--- a/src/infra/media_metadata.rs
+++ b/src/infra/media_metadata.rs
@@ -9,7 +9,6 @@
 )]
 
 use crate::core::app::{App, NativePlaybackOrigin, NativeTrackKind};
-use crate::tui::ui::util::create_artist_string;
 use rspotify::model::{PlayableItem, RepeatState};
 use rspotify::prelude::Id;
 
@@ -91,7 +90,7 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
     (
       PlaybackMetadata {
         title: native_info.name.clone(),
-        artists: vec![native_info.artists_display.clone()],
+        artists: native_info.artists.clone(),
         album: native_info.album.clone(),
         // Prefer the art librespot handed us with this very track. The polled
         // context is a per-track race: after a skip it still holds the previous
@@ -364,7 +363,7 @@ fn metadata_and_identity_from_context_item(
       Some((
         PlaybackMetadata {
           title: track.name.clone(),
-          artists: vec![create_artist_string(&track.artists)],
+          artists: track.artists.iter().map(|a| a.name.clone()).collect(),
           album: track.album.name.clone(),
           image_url: track.album.images.first().map(|image| image.url.clone()),
           duration_ms: track.duration.num_milliseconds() as u32,
@@ -607,7 +606,7 @@ mod tests {
     app.native_is_playing = Some(true);
     app.native_track_info = Some(NativeTrackInfo {
       name: "Native Track".to_string(),
-      artists_display: "Native Artist".to_string(),
+      artists: vec!["Native Artist".to_string()],
       album: "Native Album".to_string(),
       duration_ms: 123_000,
       kind: NativeTrackKind::Track,
@@ -627,6 +626,31 @@ mod tests {
     assert!(snapshot.is_playing);
   }
 
+  /// #410: a native collaboration must reach the snapshot as a *structured*
+  /// artist list, not a single joined string, so the LRCLIB lookup can fall back
+  /// to the primary artist. `primary_artist()` still joins it for display, so the
+  /// playbar/window title are unchanged.
+  #[test]
+  fn native_collaboration_keeps_structured_artist_list() {
+    let mut app = app();
+    app.is_streaming_active = true;
+    app.native_is_playing = Some(true);
+    app.native_track_info = Some(NativeTrackInfo {
+      name: "Take Me Back".to_string(),
+      artists: vec!["Kygo".to_string(), "Max McNown".to_string()],
+      album: "Take Me Back".to_string(),
+      duration_ms: 201_000,
+      kind: NativeTrackKind::Track,
+      image_url: None,
+    });
+    app.native_playback_origin = Some(NativePlaybackOrigin::RawList);
+
+    let snapshot = current_playback_snapshot(&app).unwrap();
+
+    assert_eq!(snapshot.metadata.artists, vec!["Kygo", "Max McNown"]);
+    assert_eq!(snapshot.primary_artist(), "Kygo, Max McNown");
+  }
+
   /// #402: after a skip (and for the whole of a natively queued track) the
   /// polled context still holds the *previous* item, so its cover art belongs to
   /// the previous album. librespot's own `TrackChanged` art must win.
@@ -636,7 +660,7 @@ mod tests {
     app.is_streaming_active = true;
     app.native_track_info = Some(NativeTrackInfo {
       name: "Native Track".to_string(),
-      artists_display: "Native Artist".to_string(),
+      artists: vec!["Native Artist".to_string()],
       album: "Native Album".to_string(),
       duration_ms: 123_000,
       kind: NativeTrackKind::Track,
@@ -665,7 +689,7 @@ mod tests {
     app.is_streaming_active = true;
     app.native_track_info = Some(NativeTrackInfo {
       name: "Track".to_string(),
-      artists_display: "Artist".to_string(),
+      artists: vec!["Artist".to_string()],
       album: "Album".to_string(),
       duration_ms: 123_000,
       kind: NativeTrackKind::Track,
@@ -721,7 +745,7 @@ mod tests {
     app.native_is_playing = Some(false);
     app.native_track_info = Some(NativeTrackInfo {
       name: "Native Track".to_string(),
-      artists_display: "Native Artist".to_string(),
+      artists: vec!["Native Artist".to_string()],
       album: "Native Album".to_string(),
       duration_ms: 123_000,
       kind: NativeTrackKind::Track,

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -166,7 +166,7 @@ pub enum IoEvent {
   IncrementGlobalSongCount,
   FetchGlobalSongCount,
   FetchAnnouncements,
-  GetLyrics(String, String, f64),
+  GetLyrics(String, Vec<String>, f64),
   /// Get user's top tracks for Discover feature (with time range)
   GetUserTopTracks(crate::core::app::DiscoverTimeRange),
   /// Get Top Artists Mix - fetches top artists and their top tracks
@@ -799,8 +799,8 @@ impl Network {
       IoEvent::FetchAnnouncements => {
         self.fetch_announcements().await;
       }
-      IoEvent::GetLyrics(track, artist, duration) => {
-        self.get_lyrics(track, artist, duration).await;
+      IoEvent::GetLyrics(track, artists, duration) => {
+        self.get_lyrics(track, artists, duration).await;
       }
       #[cfg(feature = "cover-art")]
       IoEvent::FetchCoverArt(request) => {
@@ -1603,7 +1603,7 @@ mod tests {
       IoEvent::FetchGlobalSongCount,
       IoEvent::IncrementGlobalSongCount,
       IoEvent::FetchAnnouncements,
-      IoEvent::GetLyrics(String::new(), String::new(), 0.0),
+      IoEvent::GetLyrics(String::new(), Vec::new(), 0.0),
       IoEvent::GetFriendCode,
       IoEvent::GetFriends,
       IoEvent::AddFriendByCode(String::new()),

--- a/src/infra/network/utils.rs
+++ b/src/infra/network/utils.rs
@@ -74,15 +74,18 @@ struct AnnouncementRecord {
 }
 
 pub trait UtilsNetwork {
-  async fn get_lyrics(&mut self, track: String, artist: String, duration: f64);
+  async fn get_lyrics(&mut self, track: String, artists: Vec<String>, duration: f64);
   async fn increment_global_song_count(&mut self);
   async fn fetch_global_song_count(&mut self);
   async fn fetch_announcements(&mut self);
 }
 
 impl UtilsNetwork for Network {
-  async fn get_lyrics(&mut self, track: String, artist: String, duration: f64) {
-    let request_identity = (track.clone(), artist.clone());
+  async fn get_lyrics(&mut self, track: String, artists: Vec<String>, duration: f64) {
+    // The identity latch and the plugin-facing `lyrics_state_is_current` gate
+    // both key on the joined display credit (`primary_artist()`), so build the
+    // identity from the same join here.
+    let request_identity = (track.clone(), artists.join(", "));
     let client = super::requests::shared_http_client();
 
     // Update state to loading
@@ -96,7 +99,7 @@ impl UtilsNetwork for Network {
       app.lyrics_synced = false;
     }
 
-    let lrc_resp = fetch_lrclib_lyrics(client, &track, &artist, duration).await;
+    let lrc_resp = fetch_lrclib_lyrics(client, &track, &artists, duration).await;
 
     let mut app = self.app.lock().await;
     if app.desired_lyrics_identity.as_ref() != Some(&request_identity) {
@@ -323,39 +326,97 @@ impl UtilsNetwork for Network {
 /// seconds), so it 404s on small metadata differences even when LRCLIB has the
 /// song. When it misses, fall back to the fuzzy `/api/search` endpoint and pick
 /// the best-matching result.
+///
+/// Both endpoints are tried across every artist candidate (see
+/// [`artist_query_candidates`]): all `/api/get` candidates first, then all
+/// `/api/search` candidates, so an exact hit on the primary artist always beats
+/// a fuzzy hit on the full multi-artist credit.
 async fn fetch_lrclib_lyrics(
+  client: &reqwest::Client,
+  track: &str,
+  artists: &[String],
+  duration: f64,
+) -> Option<LrcResponse> {
+  let candidates = artist_query_candidates(artists);
+
+  for artist in &candidates {
+    if let Some(lrc_resp) = lrclib_get(client, track, artist, duration).await {
+      return Some(lrc_resp);
+    }
+  }
+
+  for artist in &candidates {
+    if let Some(lrc_resp) = lrclib_search(client, track, artist, duration).await {
+      return Some(lrc_resp);
+    }
+  }
+
+  None
+}
+
+/// The LRCLIB artist strings to try, in order. LRCLIB indexes each track under a
+/// single artist string, almost always the primary (first) credited artist. A
+/// collaboration reaches here as the joined `"A, B"` credit that
+/// `primary_artist()` builds for display, which matches neither `/api/get`
+/// (exact) nor `/api/search`, so those tracks find no lyrics even when LRCLIB
+/// has them (issue #410). Try the full credit first (correct for solo tracks and
+/// acts whose own name contains a comma, e.g. "Earth, Wind & Fire"), then the
+/// first credited artist alone. The first artist is taken from the structured
+/// list, never by splitting the joined string, so a comma inside an artist name
+/// is preserved.
+fn artist_query_candidates(artists: &[String]) -> Vec<String> {
+  let joined = artists.join(", ");
+  let mut candidates = vec![joined.clone()];
+  if let Some(first) = artists.first() {
+    let first = first.trim();
+    if !first.is_empty() && first != joined {
+      candidates.push(first.to_string());
+    }
+  }
+  candidates
+}
+
+/// Exact `/api/get` lookup for one artist string. Returns the record only when
+/// the request succeeds and it actually carries lyrics.
+async fn lrclib_get(
   client: &reqwest::Client,
   track: &str,
   artist: &str,
   duration: f64,
 ) -> Option<LrcResponse> {
-  let get_query = [
+  let query = [
     ("track_name", track.to_string()),
     ("artist_name", artist.to_string()),
     ("duration", (duration.round() as u64).to_string()),
   ];
-  if let Ok(resp) = client
+  let resp = client
     .get("https://lrclib.net/api/get")
-    .query(&get_query)
+    .query(&query)
     .send()
     .await
-  {
-    if resp.status().is_success() {
-      if let Ok(lrc_resp) = resp.json::<LrcResponse>().await {
-        if lrc_resp.has_lyrics() {
-          return Some(lrc_resp);
-        }
-      }
-    }
+    .ok()?;
+  if !resp.status().is_success() {
+    return None;
   }
+  let lrc_resp = resp.json::<LrcResponse>().await.ok()?;
+  lrc_resp.has_lyrics().then_some(lrc_resp)
+}
 
-  let search_query = [
+/// Fuzzy `/api/search` lookup for one artist string, reduced to the best hit via
+/// [`pick_search_result`].
+async fn lrclib_search(
+  client: &reqwest::Client,
+  track: &str,
+  artist: &str,
+  duration: f64,
+) -> Option<LrcResponse> {
+  let query = [
     ("track_name", track.to_string()),
     ("artist_name", artist.to_string()),
   ];
   let resp = client
     .get("https://lrclib.net/api/search")
-    .query(&search_query)
+    .query(&query)
     .send()
     .await
     .ok()?;
@@ -475,7 +536,48 @@ fn parse_announcement_level(level: Option<&str>) -> AnnouncementLevel {
 
 #[cfg(test)]
 mod tests {
-  use super::{parse_synced_lyrics, pick_search_result, synthesize_plain_lyrics, LrcResponse};
+  use super::{
+    artist_query_candidates, parse_synced_lyrics, pick_search_result, synthesize_plain_lyrics,
+    LrcResponse,
+  };
+
+  #[test]
+  fn artist_candidates_single_artist_has_no_fallback() {
+    // A solo track queries once; nothing extra to try.
+    assert_eq!(
+      artist_query_candidates(&["Kygo".to_string()]),
+      vec!["Kygo".to_string()]
+    );
+  }
+
+  #[test]
+  fn artist_candidates_add_primary_artist_for_collaborations() {
+    // LRCLIB stores "Take Me Back" under "Kygo" alone, so the joined credit must
+    // fall back to the first artist (issue #410).
+    assert_eq!(
+      artist_query_candidates(&["Kygo".to_string(), "Max McNown".to_string()]),
+      vec!["Kygo, Max McNown".to_string(), "Kygo".to_string()]
+    );
+  }
+
+  #[test]
+  fn artist_candidates_preserve_comma_inside_artist_name() {
+    // Splitting the joined display string on ", " would corrupt an act whose own
+    // name contains a comma; the primary artist must come from the structured
+    // list instead.
+    assert_eq!(
+      artist_query_candidates(&["Earth, Wind & Fire".to_string(), "Guest".to_string()]),
+      vec![
+        "Earth, Wind & Fire, Guest".to_string(),
+        "Earth, Wind & Fire".to_string(),
+      ]
+    );
+  }
+
+  #[test]
+  fn artist_candidates_empty_list_yields_single_empty_query() {
+    assert_eq!(artist_query_candidates(&[]), vec![String::new()]);
+  }
 
   #[test]
   fn parses_timestamped_lyric_lines_and_drops_untimed_ones() {

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -681,7 +681,7 @@ async fn handle_player_events(
         app.native_backend_pending = false;
         app.native_track_info = Some(app::NativeTrackInfo {
           name: audio_item.name.clone(),
-          artists_display: artists.join(", "),
+          artists: artists.clone(),
           album: album.clone(),
           duration_ms: audio_item.duration_ms,
           kind,

--- a/src/infra/scripting/tests.rs
+++ b/src/infra/scripting/tests.rs
@@ -1886,7 +1886,7 @@ mod data_read_tests {
       app.is_streaming_active = true;
       app.native_track_info = Some(NativeTrackInfo {
         name: name.to_string(),
-        artists_display: "The Artist".to_string(),
+        artists: vec!["The Artist".to_string()],
         album: "The Album".to_string(),
         duration_ms: 180_000,
         kind: NativeTrackKind::Track,
@@ -1947,7 +1947,7 @@ mod data_read_tests {
     app.is_streaming_active = true;
     app.native_track_info = Some(NativeTrackInfo {
       name: "Track A".to_string(),
-      artists_display: "The Artist".to_string(),
+      artists: vec!["The Artist".to_string()],
       album: "The Album".to_string(),
       duration_ms: 180_000,
       kind: NativeTrackKind::Track,

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -308,7 +308,7 @@ mod tests {
     app.is_streaming_active = true;
     app.native_track_info = Some(NativeTrackInfo {
       name: "The Track".to_string(),
-      artists_display: "The Artist".to_string(),
+      artists: vec!["The Artist".to_string()],
       album: "The Album".to_string(),
       duration_ms: 180_000,
       kind: crate::core::app::NativeTrackKind::Track,
@@ -324,7 +324,7 @@ mod tests {
     app.is_streaming_active = true;
     app.native_track_info = Some(NativeTrackInfo {
       name: "The\x1b]2;Bad\x07 Track".to_string(),
-      artists_display: "The\nArtist".to_string(),
+      artists: vec!["The\nArtist".to_string()],
       album: "The Album".to_string(),
       duration_ms: 180_000,
       kind: crate::core::app::NativeTrackKind::Track,
@@ -946,11 +946,14 @@ pub async fn start_ui(
                 // not-found message rather than stale lyrics.
                 if snapshot.item_kind == PlaybackItemKind::Track {
                   let title = snapshot.metadata.title.clone();
-                  let artist = snapshot.primary_artist();
-                  app.desired_lyrics_identity = Some((title.clone(), artist.clone()));
+                  // The identity latch keys on the joined display credit, but the
+                  // LRCLIB lookup needs the structured artist list so it can fall
+                  // back to the primary artist alone for collaborations (#410).
+                  let artists = snapshot.metadata.artists.clone();
+                  app.desired_lyrics_identity = Some((title.clone(), artists.join(", ")));
                   app.dispatch(IoEvent::GetLyrics(
                     title,
-                    artist,
+                    artists,
                     snapshot.metadata.duration_ms as f64 / 1000.0,
                   ));
                 } else {

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -1331,7 +1331,7 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
         if let Some(ref native_info) = app.native_track_info {
           (
             native_info.name.clone(),
-            native_info.artists_display.clone(),
+            native_info.artists.join(", "),
             native_info.duration_ms as u64,
           )
         } else {


### PR DESCRIPTION
# Summary

Fixes #410. Lyrics never appeared for tracks credited to more than one artist (e.g. "Take Me Back" by Kygo and Max McNown), even when LRCLIB clearly had the track.

Root cause: LRCLIB indexes each track under a single artist string (almost always the primary credit), but spotatui sent the full **joined** credit (`"Kygo, Max McNown"`) to both the exact `/api/get` and the fuzzy `/api/search` endpoints, so every collaboration missed. The `PlaybackMetadata.artists` field was typed `Vec<String>` but in practice always held one pre-joined display string, so there was no way to recover the individual artists downstream.

The fix threads the real per-artist list through instead of a display string:

- The playback snapshot now carries individual artist names as a structured list (both the native-streaming and Spotify-context paths). `NativeTrackInfo.artists_display: String` became `artists: Vec<String>`, populated from the structured list already present at the player-event boundary.
- The LRCLIB lookup (`network/utils.rs`) now tries a candidate ladder: all `/api/get` candidates first, then all `/api/search`, where candidates are `[full joined credit, primary artist alone]`. The primary artist comes from the structured list (never a `", "` split), so an act whose own name contains a comma (e.g. "Earth, Wind & Fire") plus a guest is not corrupted.

Side effect: MPRIS `xesam:artist` is now a genuine array instead of a single joined element. Display is unchanged (`primary_artist()` still joins the list), and the friends-widget backend already joins the artists array with `", "`, so there is no wire-format change.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry -- -D warnings` (clean)
- `cargo clippy -- -D warnings` (default, clean)
- `cargo clippy --features all-sources -- -D warnings` (clean)
- `cargo test --no-default-features --features telemetry` (510 passed)
- `cargo test` (default, 771 passed)
- `cargo test --features all-sources` (843 passed)
- Added unit tests for the artist candidate ladder and a snapshot regression test for a multi-artist native track.
- Live: played "Take Me Back" (Kygo, Max McNown) on the native device and the synced lyrics now render.

# Additional notes

The earlier fix for this issue (#411) added the `/api/get` -> `/api/search` fallback but still passed the joined multi-artist string to both endpoints, so collaborations stayed broken; this addresses the underlying data shape. Local-files (single lofty artist string) and internet radio (no track duration, so no lyrics) are intentionally left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Lyrics now load correctly for collaboration tracks.
  - Lookup tries the complete artist credits first, then falls back to the primary artist.
  - Artist names containing commas are handled correctly.
  - Artist display formatting remains unchanged in the player interface.

- **Tests**
  - Added coverage for solo artists, collaborations, fallback lookups, and empty artist lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->