### PR TITLE
fix: keep the streaming OAuth callback alive through browser noise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "aes",
  "bytes",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "aes",
  "base64",
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "log",
  "oauth2",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "alsa 0.10.0",
  "cpal 0.16.0",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=514061e4df71f5827105611eab1b2b92a87c430a#514061e4df71f5827105611eab1b2b92a87c430a"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "aes",
  "bytes",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "futures-util",
  "librespot-core",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "aes",
  "base64",
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "librespot-oauth"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "log",
  "oauth2",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "alsa 0.10.0",
  "cpal 0.16.0",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=4e9e5c72f079ffe79743ba5245b894c0ab20ce5a#4e9e5c72f079ffe79743ba5245b894c0ab20ce5a"
+source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=00b77b271f3fb7baa16a750a179700daac77857a#00b77b271f3fb7baa16a750a179700daac77857a"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,10 +235,10 @@ pkg-fmt = "zip"
 # as the `spotatui` branch advances. Note: crates.io publishes ignore [patch], so `cargo install`
 # users need the upstream release.
 [patch.crates-io]
-librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
-librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }
+librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "514061e4df71f5827105611eab1b2b92a87c430a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,16 +226,19 @@ pkg-fmt = "zip"
 # Native streaming fixes: librespot 0.8.0 + backport of upstream PR #1722 (fall back to the
 # next CDN URL when one returns a non-206 status, e.g. HTTP 530) + port of upstream PR #1692
 # (dealer reconnects handled in place without restarting spirc; prompt spirc-task exit with
-# saved playback state on session TCP loss instead of hanging, enabling seamless recovery).
+# saved playback state on session TCP loss instead of hanging, enabling seamless recovery)
+# + cherry-pick of upstream PR #1706 and follow-up hardening of the OAuth callback listener,
+# which used to accept one connection and give up if it was not the redirect, closing port
+# 8989 before the real callback arrived (issue #414, upstream issue #1705).
 # Pinned to our maintained fork (spotatui-librespot) until a fixed librespot is published to
 # crates.io. Pinned by immutable `rev` (not a branch) so release builds stay reproducible even
 # as the `spotatui` branch advances. Note: crates.io publishes ignore [patch], so `cargo install`
 # users need the upstream release.
 [patch.crates-io]
-librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
-librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "4e9e5c72f079ffe79743ba5245b894c0ab20ce5a" }
+librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }
+librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "00b77b271f3fb7baa16a750a179700daac77857a" }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Machine-managed runtime state lives separately in `$XDG_STATE_HOME/spotatui/stat
 
 ## Safe by default
 
-A typo in `config.yml` never prevents the app from starting. Structural mistakes (an unknown sort field, a bad template placeholder, an invalid column id, an icon that is too wide) are logged as warnings and the affected value falls back to its built-in default. Warnings go to the log file whose path is printed at startup (`spotatui_logs/spotatuilog<pid>` inside your system temp directory: `/tmp` on Linux and macOS, `%TEMP%` on Windows).
+A typo in `config.yml` never prevents the app from starting. Structural mistakes (an unknown sort field, a bad template placeholder, an invalid column id, an icon that is too wide) are logged as warnings and the affected value falls back to its built-in default. Warnings go to the log file whose path is printed at startup, a `spotatui_logs/spotatuilog<pid>` file inside your system temp directory (`%TEMP%` on Windows, `$TMPDIR` where set, otherwise `/tmp`). The startup line reports the resolved path, so copy it from there rather than guessing.
 
 Only two kinds of errors are fatal: YAML syntax errors (the file cannot be parsed at all) and a handful of out-of-range numeric values that bypass the warn-and-fallback policy: `volume_increment` outside 0–100, a tick rate (or animation tick rate) outside 1–999ms, an unparseable `auto_update_delay`, `playback_poll_seconds` below 1, and `like_animation_frames` below 1.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Machine-managed runtime state lives separately in `$XDG_STATE_HOME/spotatui/stat
 
 ## Safe by default
 
-A typo in `config.yml` never prevents the app from starting. Structural mistakes — an unknown sort field, a bad template placeholder, an invalid column id, an icon that is too wide — are logged as warnings and the affected value falls back to its built-in default. Warnings go to the log file whose path is printed at startup (`/tmp/spotatui_logs/spotatuilog<pid>`).
+A typo in `config.yml` never prevents the app from starting. Structural mistakes (an unknown sort field, a bad template placeholder, an invalid column id, an icon that is too wide) are logged as warnings and the affected value falls back to its built-in default. Warnings go to the log file whose path is printed at startup (`spotatui_logs/spotatuilog<pid>` inside your system temp directory: `/tmp` on Linux and macOS, `%TEMP%` on Windows).
 
 Only two kinds of errors are fatal: YAML syntax errors (the file cannot be parsed at all) and a handful of out-of-range numeric values that bypass the warn-and-fallback policy: `volume_increment` outside 0–100, a tick rate (or animation tick rate) outside 1–999ms, an unparseable `auto_update_delay`, `playback_poll_seconds` below 1, and `like_animation_frames` below 1.
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,9 @@
             pkgs.apple-sdk
             pkgs.portaudio
           ];
-        librespotOutputHash = "sha256-F1pAhVgxYsbmLXOcbOEU6mGYZO1n94EWCXn5yjhPxv0=";
+        # Update alongside the [patch.crates-io] rev in Cargo.toml; the Nix build
+        # fails with a hash mismatch that reports the correct value otherwise.
+        librespotOutputHash = "sha256-N/ImWrtEyhKyjvZd8zVCelKtsAV1kHoFHMwCoe5ddI0=";
       in
       {
         # Build dependencies for rust

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1884,6 +1884,9 @@ pub struct App {
   pub plugin_popup: Option<crate::core::plugin_api::PluginPopup>,
   /// Scroll offset for the plugin popup.
   pub plugin_popup_scroll: u16,
+  /// Where this run's log file is being written, resolved once here so draw
+  /// code can show it without doing the environment lookup every frame.
+  pub log_path: String,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -2176,6 +2179,7 @@ impl Default for App {
       plugin_playbar_segments: std::collections::BTreeMap::new(),
       plugin_popup: None,
       plugin_popup_scroll: 0,
+      log_path: crate::core::paths::app_log_path().display().to_string(),
     }
   }
 }

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -51,6 +51,25 @@ pub(crate) fn app_state_dir() -> Option<PathBuf> {
   )
 }
 
+/// Directory holding this run's log file.
+///
+/// The OS temp directory rather than the state dir: a log file is written per
+/// process id, so they accumulate, and temp is the one location the platform
+/// clears on its own. Resolved through `std::env::temp_dir` so Windows lands in
+/// `%TEMP%` instead of the literal `/tmp` this used to hard-code, which is
+/// drive-relative there and left Windows users looking for a path the app
+/// reported but their shell could not find.
+pub(crate) fn app_log_dir() -> PathBuf {
+  std::env::temp_dir().join("spotatui_logs")
+}
+
+/// Path of this process's log file. Callers on both the writing side
+/// (`setup_logging`) and the reporting side (the help screen) use this so the
+/// path shown to a user is always the path actually written.
+pub(crate) fn app_log_path() -> PathBuf {
+  app_log_dir().join(format!("spotatuilog{}", std::process::id()))
+}
+
 /// Ensure a directory that stores credentials or other private app data exists
 /// and is owner-only where supported.
 pub(crate) fn ensure_private_dir(dir: &Path) -> Result<()> {

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -520,26 +520,27 @@ const SPOTIFY_PLAYER_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 /// spotify-player's redirect_uri - must match what's registered with their client_id
 const SPOTIFY_PLAYER_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
 
-fn wait_for_oauth_callback_port(
-  address: &str,
-  max_wait: Duration,
-  retry_delay: Duration,
-) -> Result<()> {
+/// Wait until `address` looks bindable, so the streaming consent is not opened
+/// while the Web API callback server still holds the port.
+///
+/// Advisory only, and deliberately so. librespot binds the port itself, so the
+/// most this can do is probe and release; between that release and librespot's
+/// own bind the port is unowned, which no amount of retrying can close. Returns
+/// whether the port came free rather than `Result`, because the caller must not
+/// treat "still busy" as fatal: librespot's bind is the authority and reports a
+/// far better error than this probe can.
+fn wait_for_oauth_callback_port(address: &str, max_wait: Duration, retry_delay: Duration) -> bool {
   let deadline = Instant::now() + max_wait;
   loop {
     match std::net::TcpListener::bind(address) {
       Ok(listener) => {
         drop(listener);
-        return Ok(());
+        return true;
       }
       Err(_) if Instant::now() < deadline => {
         std::thread::sleep(retry_delay.min(deadline.saturating_duration_since(Instant::now())));
       }
-      Err(error) => {
-        return Err(anyhow!(
-          "OAuth callback port {address} did not become available: {error}"
-        ));
-      }
+      Err(_) => return false,
     }
   }
 }
@@ -548,11 +549,15 @@ fn request_streaming_oauth_credentials() -> Result<Credentials> {
   // The Web API and streaming OAuth clients both use port 8989. On a fresh
   // profile their callback servers run back-to-back, so wait for the first
   // listener to be fully released before librespot opens the second consent.
-  wait_for_oauth_callback_port(
+  // Advisory: if it is still busy we go ahead anyway and let librespot's own
+  // bind produce the real error, rather than refusing to try at all.
+  if !wait_for_oauth_callback_port(
     "127.0.0.1:8989",
     Duration::from_secs(5),
     Duration::from_millis(50),
-  )?;
+  ) {
+    warn!("OAuth callback port 127.0.0.1:8989 still busy; attempting the streaming login anyway");
+  }
 
   let client_builder = OAuthClientBuilder::new(
     SPOTIFY_PLAYER_CLIENT_ID,
@@ -1412,11 +1417,32 @@ mod tests {
       drop(listener);
     });
 
-    wait_for_oauth_callback_port(&address, Duration::from_secs(1), Duration::from_millis(10))
-      .expect("callback port should become available after the first listener exits");
+    assert!(
+      wait_for_oauth_callback_port(&address, Duration::from_secs(1), Duration::from_millis(10)),
+      "callback port should become available after the first listener exits"
+    );
     release.join().unwrap();
 
     std::net::TcpListener::bind(address).expect("callback port should remain available");
+  }
+
+  /// A port that never frees is reported, not fatal: the caller logs and lets
+  /// librespot's own bind produce the authoritative error.
+  #[test]
+  fn oauth_callback_port_reports_a_port_that_stays_busy() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap().to_string();
+
+    assert!(
+      !wait_for_oauth_callback_port(
+        &address,
+        Duration::from_millis(50),
+        Duration::from_millis(10)
+      ),
+      "a port held for the whole wait should report as unavailable"
+    );
+
+    drop(listener);
   }
 
   #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -564,14 +564,23 @@ async fn handle_self_update_command(_matches: &ArgMatches) -> Result<bool> {
   Ok(false)
 }
 
+/// Run the auto-update check, returning the new version when one was installed.
+///
+/// Deliberately does NOT restart here. This runs concurrently with
+/// authentication, and restarting mid-authentication deadlocks startup: the
+/// re-exec blocks this task in `Command::status()`, which stops the joined
+/// authentication future from being polled while it still owns the OAuth
+/// callback port, so the child cannot bind that port and the parent never
+/// releases it. See `restart_after_update`, which the caller invokes once
+/// authentication has finished.
 #[cfg(feature = "self-update")]
-async fn run_auto_update(matches: &ArgMatches, user_config: &UserConfig) {
+async fn run_auto_update(matches: &ArgMatches, user_config: &UserConfig) -> Option<String> {
   if matches.subcommand_name().is_some()
     || std::env::var_os("SPOTATUI_SKIP_UPDATE").is_some()
     || matches.get_flag("no-update")
     || user_config.behavior.disable_auto_update
   {
-    return;
+    return None;
   }
 
   println!("Checking for updates...");
@@ -594,24 +603,7 @@ async fn run_auto_update(matches: &ArgMatches, user_config: &UserConfig) {
     };
 
   match update_result {
-    Some(cli::UpdateOutcome::Installed(new_version)) => {
-      println!("Updated to v{}! Restarting...", new_version);
-      // Re-exec the current binary with the same args, skipping the update check.
-      let exe = std::env::current_exe().expect("failed to get current executable path");
-      let args: Vec<String> = std::env::args().skip(1).collect();
-      let status = std::process::Command::new(&exe)
-        .args(&args)
-        .env("SPOTATUI_SKIP_UPDATE", "1")
-        .status();
-      match status {
-        Ok(exit_status) => std::process::exit(exit_status.code().unwrap_or(0)),
-        Err(e) => {
-          eprintln!("Failed to restart after update: {}", e);
-          eprintln!("Please restart spotatui manually.");
-          std::process::exit(1);
-        }
-      }
-    }
+    Some(cli::UpdateOutcome::Installed(new_version)) => Some(new_version),
     Some(cli::UpdateOutcome::Pending {
       version,
       secs_remaining,
@@ -621,14 +613,48 @@ async fn run_auto_update(matches: &ArgMatches, user_config: &UserConfig) {
         version,
         crate::core::user_config::format_update_delay_secs(secs_remaining)
       );
+      None
     }
     // Up-to-date, check failed, or no update — continue normally.
-    _ => {}
+    _ => None,
   }
 }
 
 #[cfg(not(feature = "self-update"))]
-async fn run_auto_update(_matches: &ArgMatches, _user_config: &UserConfig) {}
+async fn run_auto_update(_matches: &ArgMatches, _user_config: &UserConfig) -> Option<String> {
+  None
+}
+
+/// Re-exec into the freshly installed binary. Never returns when an update was
+/// installed.
+///
+/// Must be called only once startup is no longer holding resources the child
+/// will need. The child repeats startup from scratch, so anything this process
+/// still owns (the OAuth callback port on 8989, stdin, the terminal) it would
+/// contend with. Authentication persists its token before returning, so the
+/// child reuses it rather than opening a second browser login.
+fn restart_after_update(new_version: Option<String>) {
+  let Some(new_version) = new_version else {
+    return;
+  };
+
+  println!("Updated to v{}! Restarting...", new_version);
+  // Re-exec the current binary with the same args, skipping the update check.
+  let exe = std::env::current_exe().expect("failed to get current executable path");
+  let args: Vec<String> = std::env::args().skip(1).collect();
+  let status = std::process::Command::new(&exe)
+    .args(&args)
+    .env("SPOTATUI_SKIP_UPDATE", "1")
+    .status();
+  match status {
+    Ok(exit_status) => std::process::exit(exit_status.code().unwrap_or(0)),
+    Err(e) => {
+      eprintln!("Failed to restart after update: {}", e);
+      eprintln!("Please restart spotatui manually.");
+      std::process::exit(1);
+    }
+  }
+}
 
 /// Everything native streaming needs that used to gate the first frame:
 /// account probe, librespot session handshake, player event handler, and the
@@ -1303,7 +1329,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   // network round trips and neither depends on the other, so the check no
   // longer adds its own latency to startup. (An update that actually installs
   // still restarts the process, exactly as before.)
-  let (authenticated, _) = tokio::join!(
+  let (authenticated, installed_update) = tokio::join!(
     async {
       if spotify_required {
         auth::authenticate_with_fallback(&mut client_config, &config_paths)
@@ -1315,6 +1341,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     },
     run_auto_update(&matches, &user_config)
   );
+
+  // Only now that authentication has released the OAuth callback port and the
+  // terminal. Runs before the `?` below so a broken auth state is still allowed
+  // to restart into the newer build, which may be what fixes it.
+  restart_after_update(installed_update);
+
   let authenticated: Option<auth::AuthenticatedClient> = authenticated?;
 
   // Which Spotify app the session actually authenticated as, when the user would

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -51,7 +51,7 @@ use crate::infra::network::{IoEvent, Network};
 use crate::infra::player;
 use crate::tui::banner::BANNER;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use backtrace::Backtrace;
 use clap::{Arg, ArgMatches, Command as ClapApp};
 use clap_complete::{generate, Shell};
@@ -434,16 +434,16 @@ fn setup_logging() -> anyhow::Result<()> {
   let log_dir = crate::core::paths::app_log_dir();
   let log_path = crate::core::paths::app_log_path();
 
-  // Ensure the directory exists. If not, create.
-  if !log_dir.exists() {
-    std::fs::create_dir_all(&log_dir).map_err(|e| {
-      anyhow::anyhow!(
-        "Failed to create log directory {}: {}",
-        log_dir.display(),
-        e
-      )
-    })?;
-  }
+  // Owner-only, not plain create_dir_all: this sits in the shared OS temp
+  // directory under a predictable name, so the default mode would leave the
+  // logs readable by every other local user.
+  crate::core::paths::ensure_private_dir(&log_dir).map_err(|e| {
+    anyhow::anyhow!(
+      "Failed to create log directory {}: {}",
+      log_dir.display(),
+      e
+    )
+  })?;
   // define format of log messages.
   fern::Dispatch::new()
     .format(|out, message, record| {
@@ -633,14 +633,18 @@ async fn run_auto_update(_matches: &ArgMatches, _user_config: &UserConfig) -> Op
 /// still owns (the OAuth callback port on 8989, stdin, the terminal) it would
 /// contend with. Authentication persists its token before returning, so the
 /// child reuses it rather than opening a second browser login.
-fn restart_after_update(new_version: Option<String>) {
+fn restart_after_update(new_version: Option<String>) -> Result<()> {
   let Some(new_version) = new_version else {
-    return;
+    return Ok(());
   };
 
   println!("Updated to v{}! Restarting...", new_version);
   // Re-exec the current binary with the same args, skipping the update check.
-  let exe = std::env::current_exe().expect("failed to get current executable path");
+  // Reported rather than panicked: the update is already installed by now, so
+  // an unreadable executable path should surface as an error the user can act
+  // on, not a backtrace.
+  let exe = std::env::current_exe()
+    .context("failed to get current executable path while restarting after an update")?;
   let args: Vec<String> = std::env::args().skip(1).collect();
   let status = std::process::Command::new(&exe)
     .args(&args)
@@ -1345,7 +1349,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   // Only now that authentication has released the OAuth callback port and the
   // terminal. Runs before the `?` below so a broken auth state is still allowed
   // to restart into the newer build, which may be what fixes it.
-  restart_after_update(installed_update);
+  restart_after_update(installed_update)?;
 
   let authenticated: Option<auth::AuthenticatedClient> = authenticated?;
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -431,17 +431,18 @@ fn init_audio_backend() {
 fn init_audio_backend() {}
 
 fn setup_logging() -> anyhow::Result<()> {
-  // Get the current Process ID
-  let pid = std::process::id();
-
-  // Construct the log file path using the PID
-  let log_dir = "/tmp/spotatui_logs/";
-  let log_path = format!("{}spotatuilog{}", log_dir, pid);
+  let log_dir = crate::core::paths::app_log_dir();
+  let log_path = crate::core::paths::app_log_path();
 
   // Ensure the directory exists. If not, create.
-  if !std::path::Path::new(log_dir).exists() {
-    std::fs::create_dir_all(log_dir)
-      .map_err(|e| anyhow::anyhow!("Failed to create log directory {}: {}", log_dir, e))?;
+  if !log_dir.exists() {
+    std::fs::create_dir_all(&log_dir).map_err(|e| {
+      anyhow::anyhow!(
+        "Failed to create log directory {}: {}",
+        log_dir.display(),
+        e
+      )
+    })?;
   }
   // define format of log messages.
   fern::Dispatch::new()
@@ -460,7 +461,7 @@ fn setup_logging() -> anyhow::Result<()> {
     .map_err(|e| anyhow::anyhow!("Failed to initialize logger: {}", e))?;
 
   // Print the location of log for user reference.
-  println!("Logging to: {}", log_path);
+  println!("Logging to: {}", log_path.display());
 
   Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1431,8 +1431,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
             .unwrap_or_else(|e| Err(anyhow::anyhow!("credential caching task panicked: {e}")));
           if let Err(error) = cached {
             warn!("native streaming authentication unavailable: {error}");
+            // Name the actual failure. The generic message left issue #414's
+            // reporter with a browser "unable to connect" page, a login that
+            // repeated every launch, and nothing on screen or in reach that
+            // said which half of startup had failed or why.
             app.lock().await.set_status_message(
-              "Native streaming authentication failed; using Spotify Connect.",
+              format!("Native streaming authentication failed ({error}); using Spotify Connect."),
               10,
             );
           }

--- a/src/tui/ui/home.rs
+++ b/src/tui/ui/home.rs
@@ -76,7 +76,8 @@ pub fn draw_home(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   } else {
     Text::styled(BANNER, Style::default().fg(app.user_config.theme.banner))
   };
-  let base_changelog_lines = get_changelog_cache(&app.user_config.theme, changelog_area.width);
+  let base_changelog_lines =
+    get_changelog_cache(&app.user_config.theme, changelog_area.width, &app.log_path);
 
   // Contains the banner
   let top_text = Paragraph::new(banner_text)
@@ -179,12 +180,18 @@ fn get_clean_changelog() -> &'static str {
 fn get_changelog_cache(
   theme: &crate::core::user_config::Theme,
   changelog_width: u16,
+  log_path: &str,
 ) -> Arc<Vec<Line<'static>>> {
   let cache = CHANGELOG_CACHE.get_or_init(|| {
     let changelog = get_clean_changelog();
     let key = ChangelogCacheKey::from_theme(theme, changelog_width);
     Mutex::new(ChangelogCache {
-      changelog_lines: Arc::new(build_changelog_lines(changelog, theme, changelog_width)),
+      changelog_lines: Arc::new(build_changelog_lines(
+        changelog,
+        theme,
+        changelog_width,
+        log_path,
+      )),
       key,
     })
   });
@@ -192,7 +199,12 @@ fn get_changelog_cache(
   let key = ChangelogCacheKey::from_theme(theme, changelog_width);
   if cache.key != key {
     let changelog = get_clean_changelog();
-    cache.changelog_lines = Arc::new(build_changelog_lines(changelog, theme, changelog_width));
+    cache.changelog_lines = Arc::new(build_changelog_lines(
+      changelog,
+      theme,
+      changelog_width,
+      log_path,
+    ));
     cache.key = key;
   }
   Arc::clone(&cache.changelog_lines)
@@ -559,6 +571,7 @@ fn build_changelog_lines(
   changelog: &str,
   theme: &crate::core::user_config::Theme,
   max_width: u16,
+  log_path: &str,
 ) -> Vec<Line<'static>> {
   let mut lines: Vec<Line<'static>> = vec![];
   let max_width = usize::from(max_width);
@@ -580,10 +593,7 @@ fn build_changelog_lines(
   push_wrapped(
     &mut lines,
     &[StyledSegment {
-      text: format!(
-        "Log located in {}",
-        crate::core::paths::app_log_path().display()
-      ),
+      text: format!("Log located in {}", log_path),
       style: Style::default().fg(theme.hint),
     }],
   );

--- a/src/tui/ui/home.rs
+++ b/src/tui/ui/home.rs
@@ -581,8 +581,8 @@ fn build_changelog_lines(
     &mut lines,
     &[StyledSegment {
       text: format!(
-        "Log located in /tmp/spotatui_logs/spotatuilog{}",
-        std::process::id()
+        "Log located in {}",
+        crate::core::paths::app_log_path().display()
       ),
       style: Style::default().fg(theme.hint),
     }],


### PR DESCRIPTION
# Summary

Fixes #414. The streaming login hands port 8989 to librespot, whose callback server accepted exactly one connection and gave up if it was not the redirect, dropping the listener and closing the port. Some browsers, LibreWolf in particular, send a bare CRLF or open a connection without writing to it before the real callback arrives. librespot consumed that, failed to parse it, and closed the port, so the redirect carrying the code hit a dead port. The user is left on a browser "unable to connect" page, and because the flow errors before `save_credentials` it repeats on every launch, which is the "streaming cookie does not get cached" the reporter described.

Not Windows specific. Three independent reports line up: upstream [librespot#1705](https://github.com/librespot-org/librespot/issues/1705) (LibreWolf + ncspot on Fedora, with a debug trace showing the empty line and vanilla Firefox working as a control), #234 (LibreWolf on Gentoo, same "web API login works, streaming fails" split), and #364 (a commenter with `AuthCodeListenerParse` in their log who confirmed Chrome works). The common variable is the browser.

spotatui's own callback server never had this problem: `extract_callback_url` runs `split_whitespace()` over the whole buffer, which steps over a leading CRLF, and it answers unrelated requests with a 400 and keeps waiting. `read_line` stops at the first `\n`. Only the librespot half was fragile, which is why the web API login succeeded and the streaming one did not.

Fixed in our librespot fork rather than here, since that is where the defective listener lives. The fork cherry-picks upstream PR [#1706](https://github.com/librespot-org/librespot/pull/1706) with its original attribution, then hardens it: #1706 skips to the next *connection* on a blank line, which is correct only if the blank line arrives on its own connection and hangs if it is a leading CRLF on the same one. This PR bumps the `[patch.crates-io]` rev to pick that up.

Three unrelated startup bugs found while tracing this are fixed in their own commits:

- **Auto-update deadlock.** `run_auto_update` ran concurrently with authentication in a `tokio::join!` and re-exec'd immediately on a successful install. The re-exec blocks the task in `Command::status()`, so the joined authentication future stops being polled while it still owns the callback port, and the child, which repeats startup from scratch, cannot bind that port. The parent waits on the child, the child waits on a port the parent will never release. The check still runs concurrently; only the restart moves to after the join.
- **Log path.** `setup_logging` hard-coded `/tmp/spotatui_logs/`, which on Windows is drive-relative, so the app printed a location the user's shell could not resolve directly above the line inviting them to report bugs. Now resolved through `std::env::temp_dir`.
- **OAuth port probe.** `wait_for_oauth_callback_port` refused to start the login when its probe timed out, so we never even attempted and reported something vaguer than the bind error librespot would have produced. It now warns and proceeds.

# Testing

- `cargo fmt --all` (and `--check`, clean)
- `cargo clippy --no-default-features --features telemetry -- -D warnings` (clean)
- `cargo clippy -- -D warnings` (clean, default features)
- `cargo test --no-default-features --features telemetry` (544 passed)
- `cargo test` (809 passed)

In the fork, `cargo test -p librespot-oauth` (14 passed) and `cargo clippy -p librespot-oauth --all-targets -- -D warnings` (clean). The listener tests cover both shapes of librespot#1705 (blank line on the same connection, and on a separate one), a `/favicon.ico` request before the callback, a code surviving a browser that hangs up before the success page is written, and a peer dribbling bytes being cut off at the deadline. They run behind a watchdog so a regression fails the suite instead of hanging it.

Reviewed across five rounds with the Codex CLI, which caught four real defects: a captured authorization code being discarded when the success page failed to write, the accept loop having no overall deadline, HTTP header lines being read as if each were a request, and the deadline not covering an in-flight read.

# Additional notes

Not verified against a live LibreWolf on Windows. I am on Linux and cannot reproduce the reporter's setup, so this rests on code reading plus the three corroborating reports above rather than an observed repro.

A fork fix reaches everyone who installs today: GitHub releases, winget, Homebrew, both AUR packages, and `install.sh`/`install.ps1` all build with `[patch]` active. The one gap is `cargo install spotatui` from crates.io, which is stuck at 0.40.2 because the v0.40.3 publish job fails to compile against upstream librespot (`unresolved import librespot_connect::SavedPlaybackState`). Worth fixing separately; those users cannot get 0.40.3+ by any route today.

Workaround for anyone hitting this before the next release: set `enable_streaming: false` in `client.yml`. That stops the every-launch browser flow and leaves Spotify Connect working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Log files now use a platform-appropriate temporary directory and include the process ID.
  - The changelog displays the actual log-file location.
  - Automatic updates restart after authentication resources are released.

- **Bug Fixes**
  - Improved OAuth callback handling when the callback port is unavailable.
  - Streaming authentication errors now include more actionable details.
  - Updated playback and connection reliability fixes.

- **Documentation**
  - Updated safe-by-default guidance to explain how to find the log-file location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->