### PR TITLE
feat(dj): dj-core, the shared tool layer under both DJ front doors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
           # The exact feature set shipped for Linux by cd.yml, so every new
           # source subsystem (local-files, subsonic, internet-radio, youtube)
           # and cover-art is compiled and tested in CI.
+          # `dj-core` has no consumer of its own yet, so all-sources is where it
+          # gets exercised until its front doors land.
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,dj-core,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # Slim build used for fast local iteration (matches CLAUDE.md).
           - name: slim
             args: "--locked --no-default-features --features telemetry"
@@ -72,7 +74,7 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,dj-core,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           - name: slim
             args: "--locked --no-default-features --features telemetry"
     env:
@@ -123,7 +125,7 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,dj-core,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           - name: slim
             args: "--locked --no-default-features --features telemetry"
     env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,12 @@ Always check `app.user_config.keys.<action>` instead of hard-coding key literals
 - `--no-default-features --features telemetry` is the minimal build used for CI and fast iteration.
 - Platform-specific audio backends (ALSA, PipeWire, PortAudio, Rodio) are gated behind their own features.
 - `cover-art` feature enables album art rendering via `ratatui-image`.
+- `dj-core` is a shared implementation feature (taste brief, name→URI resolver,
+  library index, bulk enqueue) that exists to be pulled in by `mcp-server` and
+  `ai-dj`, the way `audio-decode` is pulled in by the media sources. Not in
+  `default`. Neither front door is built yet, so nothing consumes it and
+  everything under `src/infra/dj/` is dead code for now — that is what the
+  crate-level `#![allow(dead_code)]` in `src/infra/dj/mod.rs` is for.
 
 ### Native streaming playback
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,14 @@ internet-radio = ["audio-decode", "dep:stream-download", "dep:icy-metadata"]
 # LocalPlayer. Unofficial-fragile by design — see plan-multi-source.md.
 youtube = ["audio-decode", "dep:tempfile"]
 
+# --- AI DJ / MCP -------------------------------------------------------------
+# Shared tool layer behind both front doors: the taste brief built from the local
+# listening history, the name -> URI resolver, and the bulk enqueue. Pure logic,
+# no new crates (reqwest / tokio "full" / serde_json are already non-optional).
+# Pulled by `mcp-server` and `ai-dj` the same way `audio-decode` is pulled by the
+# media sources.
+dj-core = []
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1468,6 +1468,10 @@ pub struct App {
   /// keys are discarded.
   #[cfg(feature = "cover-art")]
   pub desired_cover_art_key: Option<String>,
+  /// AI DJ session state: transcript, auto-queue toggle, vibe, and the
+  /// generation counter that invalidates in-flight background work.
+  #[cfg(feature = "dj-core")]
+  pub dj: crate::infra::dj::DjState,
   // Inputs:
   // input is the string for input;
   // input_idx is the index of the cursor in terms of character;
@@ -2162,6 +2166,8 @@ impl Default for App {
       cover_art_status: CoverArtStatus::default(),
       #[cfg(feature = "cover-art")]
       desired_cover_art_key: None,
+      #[cfg(feature = "dj-core")]
+      dj: crate::infra::dj::DjState::default(),
       friends: Vec::new(),
       friends_loading: false,
       friend_code: None,
@@ -4535,6 +4541,92 @@ impl App {
     if self.is_native_streaming_active_for_playback() && !self.queue_owns_playback() {
       self.dispatch(IoEvent::GetQueue);
     }
+  }
+
+  /// Dedupe keys for everything the DJ should not queue again: what is already
+  /// waiting in the native queue, plus the track playing right now.
+  ///
+  /// The recently-played window is added by the caller from the taste brief;
+  /// this covers only what `App` itself knows.
+  #[cfg(feature = "dj-core")]
+  // No front door calls this yet; the gate narrows once one lands.
+  #[allow(dead_code)]
+  pub fn dj_skip_keys(&self) -> std::collections::HashSet<String> {
+    use crate::infra::dj::dedupe_key;
+    let mut keys: std::collections::HashSet<String> = self
+      .native_queue
+      .iter()
+      .map(|track| dedupe_key(&track.name, &track.artists.join(", ")))
+      .collect();
+    if let Some(snapshot) = crate::infra::media_metadata::current_playback_snapshot(self) {
+      keys.insert(dedupe_key(
+        &snapshot.metadata.title,
+        &snapshot.primary_artist(),
+      ));
+    }
+    keys
+  }
+
+  /// Queue a batch of DJ-chosen tracks, returning how many were accepted.
+  ///
+  /// Routes every track through [`Self::add_track_to_native_queue`] rather than
+  /// pushing into `native_queue` directly, so the no-URI guard, the radio
+  /// rejection, and the external-Connect-device fallback to the Spotify Web API
+  /// queue all still apply. That fallback is also why callers cap the batch:
+  /// on an external device each track costs its own API round trip.
+  ///
+  /// The per-track status messages the single-track path emits are harmless
+  /// here: they are set and replaced within one lock, before any draw, and the
+  /// caller overwrites them with a single aggregate message afterwards.
+  #[cfg(feature = "dj-core")]
+  // No front door calls this yet; the gate narrows once one lands.
+  #[allow(dead_code)]
+  pub fn extend_native_queue_from_dj(&mut self, tracks: Vec<TrackInfo>) -> usize {
+    let mut accepted = 0usize;
+    for track in tracks {
+      // Mirror `add_track_to_native_queue`'s rejections so the count we report
+      // is honest, rather than inferring them from a length change.
+      let Some(uri) = track.uri.clone() else {
+        continue;
+      };
+      if uri.starts_with("radio:") {
+        continue;
+      }
+      let before = self.native_queue.len();
+      self.add_track_to_native_queue(track);
+      accepted += 1;
+      // A Spotify track on an external Connect device is dispatched to the Web
+      // API queue instead of pushed locally, so only remember what a vibe shift
+      // would actually be able to drop again. Remembered by URI, not position:
+      // the queue can be reordered, appended to, or pruned by hand before the
+      // shift happens.
+      if self.native_queue.len() > before {
+        self.dj.queued_uris.insert(uri);
+      }
+    }
+    accepted
+  }
+
+  /// Drop the DJ's own contributions from the queue.
+  ///
+  /// Used by a vibe shift: a new direction that only takes effect after the
+  /// already-queued tracks have played reads as broken, so the DJ's own picks go
+  /// and anything the user queued by hand stays — wherever it sits. Matching is
+  /// by URI, so a track the user queued by hand *and* the DJ also picked goes
+  /// too; that is the DJ's pick as much as theirs.
+  #[cfg(feature = "dj-core")]
+  // No front door calls this yet; the gate narrows once one lands.
+  #[allow(dead_code)]
+  pub fn drop_dj_queued_tracks(&mut self) -> usize {
+    let dj_uris = std::mem::take(&mut self.dj.queued_uris);
+    if dj_uris.is_empty() {
+      return 0;
+    }
+    let before = self.native_queue.len();
+    self
+      .native_queue
+      .retain(|track| !track.uri.as_ref().is_some_and(|uri| dj_uris.contains(uri)));
+    before - self.native_queue.len()
   }
 
   /// Whether the native queue's playback slot currently owns the output (either a
@@ -8791,6 +8883,56 @@ mod tests {
       explicit: false,
       image_url: None,
     }
+  }
+
+  /// A vibe shift drops the DJ's picks by identity, not by truncating a tail
+  /// count: the DJ's tracks stop being a contiguous tail the moment the user
+  /// queues by hand after a batch lands (or deletes a DJ pick from the queue
+  /// screen), and the old count-based truncate took the user's track instead.
+  #[cfg(feature = "dj-core")]
+  #[test]
+  fn a_vibe_shift_drops_the_djs_picks_and_keeps_what_the_user_queued_after_them() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+
+    app.extend_native_queue_from_dj(vec![
+      queue_track(Some("subsonic:track:dj1"), "DJ Pick 1"),
+      queue_track(Some("subsonic:track:dj2"), "DJ Pick 2"),
+    ]);
+    // The desync case: the user queues by hand *after* the DJ's batch, so the
+    // DJ's picks are no longer the queue's tail.
+    app.add_track_to_native_queue(queue_track(Some("subsonic:track:mine"), "My Track"));
+
+    assert_eq!(app.drop_dj_queued_tracks(), 2);
+    assert_eq!(app.native_queue.len(), 1);
+    assert_eq!(
+      app.native_queue[0].name, "My Track",
+      "the user's own pick must survive the shift"
+    );
+
+    // The set was consumed: a second shift with nothing new queued drops nothing.
+    assert_eq!(app.drop_dj_queued_tracks(), 0);
+  }
+
+  /// Deleting a DJ pick from the queue screen must not make a later vibe shift
+  /// overreach — the count-based version truncated by the stale count.
+  #[cfg(feature = "dj-core")]
+  #[test]
+  fn a_dj_pick_removed_by_hand_does_not_widen_the_vibe_shift() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+
+    app.add_track_to_native_queue(queue_track(Some("subsonic:track:mine"), "My Track"));
+    app.extend_native_queue_from_dj(vec![
+      queue_track(Some("subsonic:track:dj1"), "DJ Pick 1"),
+      queue_track(Some("subsonic:track:dj2"), "DJ Pick 2"),
+    ]);
+    // The user deletes one DJ pick by hand (queue-screen removal).
+    app.native_queue.retain(|track| track.name != "DJ Pick 2");
+
+    assert_eq!(app.drop_dj_queued_tracks(), 1, "only the remaining DJ pick");
+    assert_eq!(app.native_queue.len(), 1);
+    assert_eq!(app.native_queue[0].name, "My Track");
   }
 
   #[test]

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -30,6 +30,58 @@ pub fn queue_item_source(uri: &str) -> QueueItemSource {
   }
 }
 
+/// Whether a URI names something that can actually be queued or played.
+///
+/// [`queue_item_source`] classifies by scheme and treats everything it does not
+/// recognise as Spotify, which is the right default for an item that already
+/// came out of the player. It is the wrong default for a URI handed in from
+/// outside: free text, an `https://open.spotify.com/...` link, and
+/// `spotify:album:`/`spotify:playlist:` would all be classified Spotify and then
+/// queued as if they were tracks.
+///
+/// So callers taking a URI from an agent gate on this first. `spotify:track:` is
+/// the only Spotify form that names a single track; the other three schemes are
+/// opaque handles minted by their own sources, which cannot be validated further
+/// here. `radio:` is deliberately absent — a live stream is not a finite track
+/// and `App::add_track_to_native_queue` rejects it.
+// Nothing calls this until a DJ front door lands.
+#[allow(dead_code)]
+pub fn is_playable_track_uri(uri: &str) -> bool {
+  uri.starts_with("spotify:track:")
+    || uri.starts_with("file:")
+    || uri.starts_with("subsonic:")
+    || uri.starts_with("youtube:")
+}
+
+/// The Cargo feature that would make `uri`'s source playable, if this build is
+/// missing it.
+///
+/// [`is_playable_track_uri`] answers "is this the right *kind* of URI", which is
+/// a property of the scheme alone. Whether anything in *this* binary can consume
+/// it is a second question: the per-source routers are each `#[cfg]`-gated, so an
+/// `--features mcp-server` build accepts `youtube:` as well-formed and then has
+/// nothing to play it with. Callers taking a URI from an agent ask both, so the
+/// agent is told which build it is talking to rather than being told the track
+/// started.
+/// Spotify is deliberately never reported here: without `streaming` it still
+/// plays through the Web API on an external Connect device, so
+/// [`source_available`]'s stricter answer (which is about the *native* player)
+/// would refuse a URI that works.
+// Nothing calls this until a DJ front door lands.
+#[allow(dead_code)]
+pub fn missing_source_feature(uri: &str) -> Option<&'static str> {
+  let source = queue_item_source(uri);
+  if source == QueueItemSource::Spotify || source_available(source) {
+    return None;
+  }
+  Some(match source {
+    QueueItemSource::LocalFile => "local-files",
+    QueueItemSource::Subsonic => "subsonic",
+    QueueItemSource::YouTube => "youtube",
+    QueueItemSource::Spotify => unreachable!("returned above"),
+  })
+}
+
 /// A short, human-readable tag for a queue item's source, shown in the Queue
 /// screen next to each row.
 pub fn source_label(source: QueueItemSource) -> &'static str {
@@ -147,10 +199,68 @@ mod tests {
   }
 
   #[test]
+  fn only_single_track_uris_are_playable() {
+    for uri in [
+      "spotify:track:7o2AeQZzfCERsRmOM86EcB",
+      "file:/home/jay/Music/a.flac",
+      "subsonic:track:1",
+      "youtube:5NV6Rdv1a3I",
+    ] {
+      assert!(is_playable_track_uri(uri), "{uri} should be playable");
+    }
+    // The cases that used to be fabricated into a track and reported as queued.
+    // `queue_item_source` classifies every one of these as Spotify, which is
+    // exactly why the queue path cannot gate on it alone.
+    for uri in [
+      "not-a-uri",
+      "",
+      "spotify:album:1DFixLWuPkv3KT3TnV35m3",
+      "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+      "spotify:episode:512ojhOuo1ktJprKbVcKyQ",
+      "spotify:artist:4tZwfgrHOc3mvqYlEYSvVi",
+      "https://open.spotify.com/track/7o2AeQZzfCERsRmOM86EcB",
+      "radio:https://example.com/stream.aac",
+    ] {
+      assert!(!is_playable_track_uri(uri), "{uri} should not be playable");
+    }
+  }
+
+  #[test]
   fn source_labels_are_stable() {
     assert_eq!(source_label(QueueItemSource::Spotify), "Spotify");
     assert_eq!(source_label(QueueItemSource::LocalFile), "Local");
     assert_eq!(source_label(QueueItemSource::Subsonic), "Subsonic");
     assert_eq!(source_label(QueueItemSource::YouTube), "YouTube");
+  }
+
+  #[test]
+  fn spotify_is_never_reported_as_missing_a_feature() {
+    // Without `streaming` a Spotify track still plays through the Web API on an
+    // external Connect device, so gating it on `source_available` would refuse a
+    // URI that works. This is the one scheme that must always pass.
+    assert_eq!(missing_source_feature("spotify:track:abc"), None);
+  }
+
+  #[test]
+  fn a_scheme_whose_source_is_not_compiled_in_names_the_feature() {
+    // The point of the whole helper: `is_playable_track_uri` says these are
+    // well-formed, but the routers that consume them are `#[cfg]`-gated, so an
+    // `--features mcp-server` build would accept and then silently drop them.
+    for (uri, feature, compiled_in) in [
+      (
+        "file:/music/a.flac",
+        "local-files",
+        cfg!(feature = "local-files"),
+      ),
+      ("subsonic:abc", "subsonic", cfg!(feature = "subsonic")),
+      ("youtube:abc", "youtube", cfg!(feature = "youtube")),
+    ] {
+      assert!(is_playable_track_uri(uri), "{uri} should be well-formed");
+      assert_eq!(
+        missing_source_feature(uri),
+        if compiled_in { None } else { Some(feature) },
+        "{uri}"
+      );
+    }
   }
 }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -44,13 +44,21 @@ pub fn queue_item_source(uri: &str) -> QueueItemSource {
 /// opaque handles minted by their own sources, which cannot be validated further
 /// here. `radio:` is deliberately absent — a live stream is not a finite track
 /// and `App::add_track_to_native_queue` rejects it.
+///
+/// A bare scheme with nothing behind it (`spotify:track:`, `file:`) names no
+/// track at all, so the content after the prefix has to be non-empty: a model
+/// that emits the prefix and stops must be told the argument is wrong rather
+/// than have an empty handle queued for it.
 // Nothing calls this until a DJ front door lands.
 #[allow(dead_code)]
 pub fn is_playable_track_uri(uri: &str) -> bool {
-  uri.starts_with("spotify:track:")
-    || uri.starts_with("file:")
-    || uri.starts_with("subsonic:")
-    || uri.starts_with("youtube:")
+  ["spotify:track:", "file:", "subsonic:", "youtube:"]
+    .iter()
+    .any(|prefix| {
+      uri
+        .strip_prefix(prefix)
+        .is_some_and(|rest| !rest.trim().is_empty())
+    })
 }
 
 /// The Cargo feature that would make `uri`'s source playable, if this build is
@@ -220,6 +228,13 @@ mod tests {
       "spotify:artist:4tZwfgrHOc3mvqYlEYSvVi",
       "https://open.spotify.com/track/7o2AeQZzfCERsRmOM86EcB",
       "radio:https://example.com/stream.aac",
+      // A bare scheme names no track: the prefix is right and there is nothing
+      // behind it.
+      "spotify:track:",
+      "spotify:track:   ",
+      "file:",
+      "subsonic:",
+      "youtube:",
     ] {
       assert!(!is_playable_track_uri(uri), "{uri} should not be playable");
     }

--- a/src/infra/dj/brief.rs
+++ b/src/infra/dj/brief.rs
@@ -1,0 +1,301 @@
+//! The taste brief: a compact, **aggregate** summary of what the user listens
+//! to, assembled from the local listening history.
+//!
+//! This is the only thing about the user that ever reaches a model, so it is
+//! deliberately built from aggregates rather than raw records: names of tracks,
+//! artists and albums, and nothing else. No timestamps, no Spotify IDs, no
+//! identity, no play counts tied to a clock. That is a privacy property, not a
+//! token optimisation — see `docs/ai-dj.md`.
+
+use crate::infra::history::{
+  aggregate_top_albums, aggregate_top_artists, aggregate_top_tracks, filter_listens_for_period,
+  ListenRecord, RecapPeriod,
+};
+
+/// How many entries of each kind to carry. Enough for a model to infer taste,
+/// small enough to stay cheap in a prompt (and in a local model's context).
+const TOP_ARTISTS: usize = 15;
+const TOP_TRACKS: usize = 20;
+const TOP_ALBUMS: usize = 10;
+/// Recent plays exist so the model can be told *not* to repeat them, and so the
+/// enqueue path can dedupe against them.
+const RECENT: usize = 25;
+
+/// An aggregate portrait of the user's listening, plus the current steer.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TasteBrief {
+  pub period_label: &'static str,
+  pub total_plays: usize,
+  pub top_artists: Vec<String>,
+  /// `"Title — Artist"` display strings, as produced by the Stats aggregation.
+  pub top_tracks: Vec<String>,
+  pub top_albums: Vec<String>,
+  /// Newest first, `"Title — Artist"`.
+  pub recent: Vec<String>,
+  pub now_playing: Option<String>,
+  /// The user's steer ("something chill for focusing"), when they gave one.
+  pub vibe: Option<String>,
+  /// Normalised dedupe keys for [`Self::recent`]. Never rendered into a prompt —
+  /// this is for the enqueue path, so the DJ does not re-queue what just played.
+  pub recent_keys: Vec<String>,
+}
+
+pub fn period_label(period: RecapPeriod) -> &'static str {
+  match period {
+    RecapPeriod::SevenDays => "the last 7 days",
+    RecapPeriod::ThirtyDays => "the last 30 days",
+    RecapPeriod::Month => "this month",
+    RecapPeriod::Year => "this year",
+    RecapPeriod::All => "all time",
+  }
+}
+
+/// Normalise a title/artist pair into a dedupe key.
+///
+/// Lowercased, punctuation-insensitive and whitespace-collapsed, so
+/// `"Weird Fishes / Arpeggi"` and `"weird fishes/arpeggi"` collide — a model
+/// rarely reproduces a title byte-for-byte, and near-misses are exactly the
+/// duplicates worth catching.
+pub fn dedupe_key(title: &str, artist: &str) -> String {
+  // The first artist only: a model may list more or fewer collaborators than
+  // the catalogue does, and requiring the full list to match defeats the point.
+  let primary = artist.split(',').next().unwrap_or(artist);
+  format!("{}\u{1}{}", normalize(title), normalize(primary))
+}
+
+/// Lowercase, drop non-alphanumerics, collapse the resulting gaps to single
+/// spaces. Shared by [`dedupe_key`] and the resolver's match scoring so the two
+/// agree on what "the same track" means.
+pub fn normalize(value: &str) -> String {
+  let mut out = String::with_capacity(value.len());
+  let mut pending_space = false;
+  for ch in value.chars() {
+    if ch.is_alphanumeric() {
+      if pending_space && !out.is_empty() {
+        out.push(' ');
+      }
+      pending_space = false;
+      out.extend(ch.to_lowercase());
+    } else {
+      pending_space = true;
+    }
+  }
+  out
+}
+
+/// Build the brief from an already-loaded set of records.
+///
+/// Callers must not read the listens file on an async task: [`load_listens`] is
+/// blocking and `listens.jsonl` is unbounded append-only, so a long-time user's
+/// file is large. Load it in `spawn_blocking`, then call this.
+///
+/// [`load_listens`]: crate::infra::history::load_listens
+pub fn build_brief(listens: &[ListenRecord], period: RecapPeriod) -> TasteBrief {
+  let filtered = filter_listens_for_period(listens, period);
+
+  let mut recent = Vec::new();
+  let mut recent_keys = Vec::new();
+  let mut seen = std::collections::HashSet::new();
+  // `filtered` is in file order (oldest first); walk backwards for newest first.
+  for record in filtered.iter().rev() {
+    let artist = record.artists.join(", ");
+    let key = dedupe_key(&record.title, &artist);
+    if !seen.insert(key.clone()) {
+      continue;
+    }
+    recent.push(format!("{} — {}", record.title, artist));
+    recent_keys.push(key);
+    if recent.len() >= RECENT {
+      break;
+    }
+  }
+
+  TasteBrief {
+    period_label: period_label(period),
+    total_plays: filtered.len(),
+    top_artists: rank_displays(aggregate_top_artists(&filtered, TOP_ARTISTS)),
+    top_tracks: rank_displays(aggregate_top_tracks(&filtered, TOP_TRACKS)),
+    top_albums: rank_displays(aggregate_top_albums(&filtered, TOP_ALBUMS)),
+    recent,
+    now_playing: None,
+    vibe: None,
+    recent_keys,
+  }
+}
+
+fn rank_displays(entries: Vec<crate::infra::history::RankedEntry>) -> Vec<String> {
+  entries.into_iter().map(|entry| entry.display).collect()
+}
+
+impl TasteBrief {
+  /// Render the brief as the plain-text block handed to a model.
+  ///
+  /// Deliberately prose-and-lists rather than JSON: every backend consumes this,
+  /// including small local models that handle a bulleted list better than a
+  /// nested object.
+  pub fn to_prompt_block(&self) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+      "Listening history ({}, {} qualifying plays):\n",
+      self.period_label, self.total_plays
+    ));
+    push_list(&mut out, "Top artists", &self.top_artists);
+    push_list(&mut out, "Top tracks", &self.top_tracks);
+    push_list(&mut out, "Top albums", &self.top_albums);
+    push_list(
+      &mut out,
+      "Recently played (do not repeat these)",
+      &self.recent,
+    );
+    if let Some(now) = &self.now_playing {
+      out.push_str(&format!("\nCurrently playing: {now}\n"));
+    }
+    if let Some(vibe) = &self.vibe {
+      out.push_str(&format!("\nThe listener asked for: {vibe}\n"));
+    }
+    out
+  }
+
+  /// Whether there is enough history to say anything useful about taste.
+  ///
+  /// Consumed by the MCP `get_listening_history` tool, which tells the agent to
+  /// ask the user rather than infer from nothing.
+  pub fn is_sparse(&self) -> bool {
+    self.total_plays < 5
+  }
+}
+
+fn push_list(out: &mut String, label: &str, values: &[String]) {
+  if values.is_empty() {
+    return;
+  }
+  out.push_str(&format!("\n{label}:\n"));
+  for value in values {
+    out.push_str(&format!("- {value}\n"));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::infra::history::{HistoryItemKind, HistoryPlaybackSource};
+  use chrono::{Duration, Utc};
+
+  fn record(title: &str, artist: &str, uri: Option<&str>, duration_ms: u32) -> ListenRecord {
+    let now = Utc::now();
+    let listened_ms = u64::from(duration_ms);
+    ListenRecord {
+      started_at: now - Duration::minutes(5),
+      ended_at: now,
+      listened_ms,
+      duration_ms,
+      // Mirror the collector: `qualified` is precomputed on write.
+      qualified: duration_ms > 30_000 && listened_ms >= u64::from(duration_ms / 2).min(240_000),
+      title: title.to_string(),
+      artists: vec![artist.to_string()],
+      album: format!("{title} EP"),
+      item_kind: HistoryItemKind::Track,
+      item_id: None,
+      item_uri: uri.map(str::to_string),
+      context_uri: None,
+      // Every non-Spotify source is written as `ExternalDevice` by
+      // `source_snapshot`, so this field cannot distinguish them. The brief
+      // must not depend on it; `item_uri`'s scheme is the real discriminator.
+      source: HistoryPlaybackSource::ExternalDevice,
+    }
+  }
+
+  #[test]
+  fn brief_aggregates_names_only() {
+    let listens = vec![
+      record(
+        "Weird Fishes",
+        "Radiohead",
+        Some("spotify:track:a"),
+        300_000,
+      ),
+      record("Nude", "Radiohead", Some("spotify:track:b"), 300_000),
+      record(
+        "Teardrop",
+        "Massive Attack",
+        Some("spotify:track:c"),
+        300_000,
+      ),
+    ];
+    let brief = build_brief(&listens, RecapPeriod::All);
+
+    assert_eq!(brief.total_plays, 3);
+    assert!(brief.top_artists.contains(&"Radiohead".to_string()));
+    assert_eq!(brief.recent.len(), 3);
+    // Newest first: the last record in file order leads.
+    assert!(brief.recent[0].starts_with("Teardrop"));
+
+    let prompt = brief.to_prompt_block();
+    assert!(prompt.contains("Radiohead"));
+    // No identifiers of any kind leak into the prompt.
+    assert!(!prompt.contains("spotify:track"));
+  }
+
+  #[test]
+  fn non_spotify_listens_are_included_and_identified_by_uri_scheme() {
+    // Regression guard for the mislabelling at media_metadata.rs:344 — a YouTube
+    // play is written with `source: ExternalDevice`, so anything that wants to
+    // tell sources apart must read the URI scheme instead.
+    let listens = vec![record(
+      "Some Mix",
+      "Uploader",
+      Some("youtube:video:xyz"),
+      600_000,
+    )];
+    let brief = build_brief(&listens, RecapPeriod::All);
+
+    assert_eq!(brief.total_plays, 1);
+    assert!(brief.recent[0].starts_with("Some Mix"));
+    assert!(listens[0]
+      .item_uri
+      .as_deref()
+      .is_some_and(|uri| uri.starts_with("youtube:")));
+  }
+
+  #[test]
+  fn radio_never_qualifies_so_it_cannot_reach_the_brief() {
+    // The radio branch passes `duration_ms = 0` (media_metadata.rs:282), so
+    // `qualifies_listen` rejects it and `filter_listens_for_period` drops it.
+    // This is correct, not a bug to be "fixed".
+    let listens = vec![record(
+      "SomaFM Groove Salad",
+      "SomaFM",
+      Some("radio:soma"),
+      0,
+    )];
+    assert!(!listens[0].qualified);
+
+    let brief = build_brief(&listens, RecapPeriod::All);
+    assert_eq!(brief.total_plays, 0);
+    assert!(brief.recent.is_empty());
+    assert!(brief.is_sparse());
+  }
+
+  #[test]
+  fn recent_is_deduped_by_normalised_key() {
+    let listens = vec![
+      record("Weird Fishes", "Radiohead", None, 300_000),
+      record("weird  fishes!", "radiohead", None, 300_000),
+    ];
+    let brief = build_brief(&listens, RecapPeriod::All);
+    assert_eq!(brief.recent.len(), 1, "near-miss titles must collide");
+    assert_eq!(brief.recent_keys.len(), 1);
+  }
+
+  #[test]
+  fn dedupe_key_ignores_case_punctuation_and_extra_artists() {
+    assert_eq!(
+      dedupe_key("Weird Fishes / Arpeggi", "Radiohead"),
+      dedupe_key("weird fishes arpeggi", "Radiohead, Thom Yorke")
+    );
+    assert_ne!(
+      dedupe_key("Nude", "Radiohead"),
+      dedupe_key("Nude", "Prince")
+    );
+  }
+}

--- a/src/infra/dj/library.rs
+++ b/src/infra/dj/library.rs
@@ -97,7 +97,10 @@ fn is_own_playlist(entry: &PlaylistEntry, owner_id: &str) -> bool {
 ///
 /// Errors only if the playlist listing itself fails. A single unreadable playlist
 /// is skipped and logged: a partial index still filters, while failing the whole
-/// crawl would turn the feature off for one bad playlist.
+/// crawl would turn the feature off for one bad playlist. A skip marks the index
+/// [`truncated`](DjLibrary::truncated) all the same — the filter is no longer
+/// answering from everything the listener has, and a summary that claimed
+/// otherwise would read as the filter working when it is quietly under-filtering.
 pub async fn build_index(net: &Network, owner_id: &str) -> anyhow::Result<DjLibrary> {
   let mut library = DjLibrary::default();
   let playlist_ids = own_playlist_ids(net, owner_id).await?;
@@ -110,7 +113,12 @@ pub async fn build_index(net: &Network, owner_id: &str) -> anyhow::Result<DjLibr
     }
     match collect_playlist(net, &id, &mut library).await {
       Ok(()) => {}
-      Err(e) => log::debug!("DJ: skipping playlist {id} while indexing: {e}"),
+      Err(e) => {
+        // Keep going, but stop claiming the index is complete: the tracks in
+        // this playlist will not be filtered, and only `truncated` says so.
+        library.truncated = true;
+        log::debug!("DJ: skipping playlist {id} while indexing: {e}");
+      }
     }
   }
 

--- a/src/infra/dj/library.rs
+++ b/src/infra/dj/library.rs
@@ -1,0 +1,344 @@
+//! "Do they already have this?" — the two halves of the avoid-library filter.
+//!
+//! The two halves are deliberately asymmetric, because the API is:
+//!
+//! * **Liked Songs** — `me/tracks/contains` answers exactly, for up to 50 IDs per
+//!   call. A DJ batch is at most [`MAX_BATCH`](super::MAX_BATCH) tracks, so one
+//!   call per turn against the canonical truth. Nothing cached, nothing stale.
+//! * **Playlists** — no `contains` equivalent exists, so the only way to know is
+//!   to crawl every playlist and keep the answer. Hence [`build_index`] and the
+//!   [`DjLibrary`] cached on `App`.
+//!
+//! Both live here rather than in `network/dj.rs` for the same reason
+//! [`super::resolve`] does: they take `&Network` and *return* an answer instead of
+//! writing into `App`.
+
+use super::{dedupe_key, DjLibrary, MAX_LIBRARY_TRACKS};
+use crate::infra::network::Network;
+use serde::Deserialize;
+use std::collections::HashSet;
+
+/// Playlists per page. The Spotify maximum, to keep the round trips down.
+const PLAYLIST_PAGE: usize = 50;
+/// Tracks per page. Also the maximum.
+const TRACK_PAGE: usize = 100;
+/// IDs per `contains` call. A hard API limit, not a tuning choice.
+const CONTAINS_CHUNK: usize = 50;
+
+#[derive(Deserialize)]
+struct PlaylistPage {
+  #[serde(default)]
+  items: Vec<PlaylistEntry>,
+  #[serde(default)]
+  next: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PlaylistEntry {
+  id: Option<String>,
+  #[serde(default)]
+  collaborative: bool,
+  #[serde(default)]
+  owner: Option<Owner>,
+}
+
+#[derive(Deserialize)]
+struct Owner {
+  id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TrackPage {
+  #[serde(default)]
+  items: Vec<TrackItem>,
+  #[serde(default)]
+  next: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TrackItem {
+  /// `playlists/{id}/tracks` returns `track`; the newer item shape returns `item`,
+  /// and `normalize_spotify_payload` only rewrites that when `added_at` is present
+  /// — which the `fields` filter below strips. Accept both rather than depend on
+  /// which one arrives.
+  #[serde(default, alias = "item")]
+  track: Option<TrackRef>,
+}
+
+#[derive(Deserialize)]
+struct TrackRef {
+  id: Option<String>,
+  name: Option<String>,
+  #[serde(default)]
+  artists: Vec<ArtistRef>,
+}
+
+#[derive(Deserialize)]
+struct ArtistRef {
+  name: Option<String>,
+}
+
+/// Whether this playlist counts as one of the listener's own.
+///
+/// Followed playlists are excluded on purpose. Discover Weekly, Release Radar and
+/// the large editorial playlists hold thousands of tracks between them; counting
+/// those as "already have it" would reject nearly every good recommendation and
+/// read as the filter being broken.
+fn is_own_playlist(entry: &PlaylistEntry, owner_id: &str) -> bool {
+  entry.collaborative
+    || entry
+      .owner
+      .as_ref()
+      .and_then(|owner| owner.id.as_deref())
+      .is_some_and(|id| id == owner_id)
+}
+
+/// Crawl the listener's own playlists into a [`DjLibrary`].
+///
+/// Errors only if the playlist listing itself fails. A single unreadable playlist
+/// is skipped and logged: a partial index still filters, while failing the whole
+/// crawl would turn the feature off for one bad playlist.
+pub async fn build_index(net: &Network, owner_id: &str) -> anyhow::Result<DjLibrary> {
+  let mut library = DjLibrary::default();
+  let playlist_ids = own_playlist_ids(net, owner_id).await?;
+  library.playlists = playlist_ids.len();
+
+  for id in playlist_ids {
+    if library.tracks >= MAX_LIBRARY_TRACKS {
+      library.truncated = true;
+      break;
+    }
+    match collect_playlist(net, &id, &mut library).await {
+      Ok(()) => {}
+      Err(e) => log::debug!("DJ: skipping playlist {id} while indexing: {e}"),
+    }
+  }
+
+  Ok(library)
+}
+
+/// IDs of every playlist the listener owns or collaborates on.
+async fn own_playlist_ids(net: &Network, owner_id: &str) -> anyhow::Result<Vec<String>> {
+  let mut ids = Vec::new();
+  let mut offset = 0usize;
+  loop {
+    let page = net
+      .spotify_get_typed::<PlaylistPage>(
+        "me/playlists",
+        &[
+          ("limit", PLAYLIST_PAGE.to_string()),
+          ("offset", offset.to_string()),
+        ],
+      )
+      .await?;
+
+    let count = page.items.len();
+    ids.extend(
+      page
+        .items
+        .iter()
+        .filter(|entry| is_own_playlist(entry, owner_id))
+        .filter_map(|entry| entry.id.clone()),
+    );
+
+    if is_last_page(count, PLAYLIST_PAGE, page.next.is_some()) {
+      break;
+    }
+    offset += PLAYLIST_PAGE;
+  }
+  Ok(ids)
+}
+
+/// Whether to stop paginating.
+///
+/// Deliberately trusts neither signal alone. A short page is **not** proof of the
+/// end: `normalize_spotify_payload` strips the nulls Spotify returns for
+/// unreadable playlists and removed tracks, so a middle page can arrive short. And
+/// `next` is requested through a `fields` filter on the track endpoint, so it
+/// cannot be assumed present either. Stop only when both agree, with `count == 0`
+/// as the backstop that makes an unterminated `next` chain finite rather than an
+/// infinite loop.
+///
+/// Cost of being wrong in the safe direction: one extra empty request for a
+/// playlist whose length is an exact multiple of the page size.
+fn is_last_page(count: usize, page_size: usize, has_next: bool) -> bool {
+  count == 0 || (!has_next && count < page_size)
+}
+
+/// Fold one playlist's tracks into the index.
+async fn collect_playlist(
+  net: &Network,
+  playlist_id: &str,
+  library: &mut DjLibrary,
+) -> anyhow::Result<()> {
+  let path = format!("playlists/{playlist_id}/tracks");
+  let mut offset = 0usize;
+  loop {
+    let page = net
+      .spotify_get_typed::<TrackPage>(
+        &path,
+        &[
+          // Only what the two gates need. A playlist page is otherwise ~40x this
+          // size, and the crawl pays that per 100 tracks.
+          (
+            "fields",
+            "items(track(id,name,artists(name))),next".to_string(),
+          ),
+          ("limit", TRACK_PAGE.to_string()),
+          ("offset", offset.to_string()),
+        ],
+      )
+      .await?;
+
+    let count = page.items.len();
+    for item in &page.items {
+      // Episodes and removed tracks arrive as a null `track`.
+      let Some(track) = item.track.as_ref() else {
+        continue;
+      };
+      let Some(name) = track.name.as_deref().filter(|name| !name.is_empty()) else {
+        continue;
+      };
+      let artists = track
+        .artists
+        .iter()
+        .filter_map(|artist| artist.name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+      library.keys.insert(dedupe_key(name, &artists));
+      if let Some(id) = track.id.clone() {
+        library.ids.insert(id);
+      }
+      library.tracks += 1;
+      if library.tracks >= MAX_LIBRARY_TRACKS {
+        library.truncated = true;
+        return Ok(());
+      }
+    }
+
+    if is_last_page(count, TRACK_PAGE, page.next.is_some()) {
+      break;
+    }
+    offset += TRACK_PAGE;
+  }
+  Ok(())
+}
+
+/// Which of these track IDs are in the listener's Liked Songs.
+///
+/// Fails **open**: a check that errors returns no IDs for that chunk, so the
+/// tracks are kept. Dropping a good recommendation because a lookup failed is the
+/// worse outcome — the user asked for music, not for an empty queue.
+pub async fn liked_among(net: &Network, ids: &[String]) -> HashSet<String> {
+  let mut liked = HashSet::new();
+  for chunk in ids.chunks(CONTAINS_CHUNK) {
+    match net
+      .spotify_get_typed::<Vec<bool>>("me/tracks/contains", &[("ids", chunk.join(","))])
+      .await
+    {
+      Ok(flags) => {
+        for (id, is_liked) in chunk.iter().zip(flags) {
+          if is_liked {
+            liked.insert(id.clone());
+          }
+        }
+      }
+      Err(e) => log::debug!("DJ: Liked Songs check failed, keeping the batch: {e}"),
+    }
+  }
+  liked
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn entry(id: &str, owner: Option<&str>, collaborative: bool) -> PlaylistEntry {
+    PlaylistEntry {
+      id: Some(id.to_string()),
+      collaborative,
+      owner: owner.map(|id| Owner {
+        id: Some(id.to_string()),
+      }),
+    }
+  }
+
+  #[test]
+  fn own_and_collaborative_playlists_count_but_followed_ones_do_not() {
+    assert!(is_own_playlist(&entry("a", Some("me"), false), "me"));
+    // Collaborative: someone else owns it, but the listener files tracks into it.
+    assert!(is_own_playlist(&entry("b", Some("friend"), true), "me"));
+    // The case that matters: Discover Weekly would otherwise reject nearly
+    // everything worth recommending.
+    assert!(!is_own_playlist(&entry("c", Some("spotify"), false), "me"));
+    assert!(!is_own_playlist(&entry("d", None, false), "me"));
+  }
+
+  #[test]
+  fn a_playlist_page_parses_the_minimal_shape() {
+    let page: PlaylistPage = serde_json::from_str(
+      r#"{"items":[{"id":"p1","collaborative":false,"owner":{"id":"me"}}],"next":null}"#,
+    )
+    .unwrap();
+    assert_eq!(page.items.len(), 1);
+    assert!(page.next.is_none());
+  }
+
+  #[test]
+  fn a_track_page_parses_both_the_track_and_item_shapes() {
+    let page: TrackPage = serde_json::from_str(
+      r#"{"items":[
+        {"track":{"id":"t1","name":"Nude","artists":[{"name":"Radiohead"}]}},
+        {"item":{"id":"t2","name":"Nightcall","artists":[{"name":"Kavinsky"}]}},
+        {"track":null}
+      ],"next":null}"#,
+    )
+    .unwrap();
+    assert_eq!(page.items.len(), 3);
+    assert!(page.items[0].track.is_some());
+    assert!(page.items[1].track.is_some(), "the `item` alias must parse");
+    assert!(page.items[2].track.is_none(), "a null track is skipped");
+  }
+
+  #[test]
+  fn pagination_stops_only_when_both_signals_agree() {
+    // A full page always continues, even with `next` absent: the track endpoint
+    // asks for `next` through a `fields` filter, so its absence proves nothing.
+    assert!(!is_last_page(100, 100, false));
+    assert!(!is_last_page(100, 100, true));
+    // Short but `next` present: a middle page that lost rows to null-stripping.
+    // Stopping here would silently index only part of a playlist.
+    assert!(!is_last_page(48, 50, true));
+    // Short and no `next`: genuinely the end.
+    assert!(is_last_page(48, 50, false));
+    // Empty always stops, even with `next` set — the backstop against a `next`
+    // chain that never terminates.
+    assert!(is_last_page(0, 50, true));
+  }
+
+  #[test]
+  fn the_contains_chunk_matches_the_api_limit() {
+    // Not a tuning knob: 51 IDs is a 400 from Spotify.
+    assert_eq!(CONTAINS_CHUNK, 50);
+  }
+
+  #[test]
+  fn the_index_summary_admits_when_it_stopped_short() {
+    let full = DjLibrary {
+      tracks: 12,
+      playlists: 3,
+      ..DjLibrary::default()
+    };
+    assert!(full.summary().contains("12 track(s) across 3 playlist(s)"));
+    assert!(!full.summary().contains("stopped at"));
+
+    let capped = DjLibrary {
+      truncated: true,
+      ..full
+    };
+    assert!(
+      capped.summary().contains("not filtered"),
+      "a partial index has to say so, or the filter looks broken"
+    );
+  }
+}

--- a/src/infra/dj/mod.rs
+++ b/src/infra/dj/mod.rs
@@ -1,0 +1,333 @@
+//! The DJ tool layer, shared by both front doors.
+//!
+//! There are two ways to drive the DJ and they deliberately share everything
+//! below the model:
+//!
+//! * **MCP** (`mcp-server`) — spotatui exposes [`tools`] over an MCP stdio
+//!   server, so Claude Code / Codex / any MCP client is the DJ. No API key.
+//! * **In-TUI** (`ai-dj`) — a DJ screen whose "brain" is a local agent CLI, an
+//!   API key, or a local model, and which uses the same tools internally.
+//!
+//! The split that matters for anyone extending this: [`brief`] and [`tools`]
+//! only ever touch `App`, while [`resolve`] and [`library`] need the real Spotify
+//! client. That is what decides which IoEvent lane a DJ event belongs on — see
+//! `crate::infra::network::mod` (`runs_on_service_lane`), whose service lane
+//! builds its `Network` with `None` for the client.
+
+// `dj-core` is an implementation feature with no consumer of its own — it exists
+// to be pulled in by `mcp-server` and `ai-dj`, exactly as `audio-decode` is
+// pulled in by the media sources. Neither front door is built yet, so everything
+// here is legitimately unreachable for now; the allow narrows back to
+// `not(any(mcp-server, ai-dj))` once the first one lands.
+#![allow(dead_code)]
+
+pub mod brief;
+/// The avoid-library filter's two lookups. Shared: the in-TUI DJ filters with it
+/// by default, and the MCP front door uses it to mark `search_tracks` results as
+/// owned and to honour `queue_tracks(exclude_owned)`.
+pub mod library;
+pub mod resolve;
+/// The tool surface, shared by both front doors: the MCP server publishes it
+/// verbatim, and the in-TUI DJ's agent loop drives the same table.
+pub mod tools;
+
+pub use brief::dedupe_key;
+
+/// Cap on the avoid-library crawl. A listener with more saved tracks than this
+/// gets a partial index rather than an unbounded startup cost, and is told so —
+/// silently filtering against half a library would look like the filter is
+/// broken.
+pub const MAX_LIBRARY_TRACKS: usize = 20_000;
+
+/// What the listener already has, for the avoid-library filter.
+///
+/// Playlists only. Liked Songs are deliberately absent: `me/tracks/contains`
+/// answers that question exactly, for a whole batch in one call, so caching it
+/// would add staleness for nothing. See [`library`].
+#[derive(Clone, Debug, Default)]
+pub struct DjLibrary {
+  /// [`dedupe_key`] per track, so a suggestion can be rejected before it costs a
+  /// catalogue search.
+  pub keys: std::collections::HashSet<String>,
+  /// Spotify track IDs, for the exact gate after a suggestion resolves. Catches
+  /// the case the key set misses: the model named the track differently enough to
+  /// normalise apart, but search landed on the copy they own.
+  pub ids: std::collections::HashSet<String>,
+  pub playlists: usize,
+  pub tracks: usize,
+  /// Whether the crawl stopped at [`MAX_LIBRARY_TRACKS`].
+  pub truncated: bool,
+}
+
+impl DjLibrary {
+  /// One line for the transcript, so the cost of the crawl is visible.
+  pub fn summary(&self) -> String {
+    let mut text = format!(
+      "Indexed {} track(s) across {} playlist(s)",
+      self.tracks, self.playlists
+    );
+    if self.truncated {
+      text.push_str(&format!(
+        " (stopped at {MAX_LIBRARY_TRACKS}; the rest is not filtered)"
+      ));
+    }
+    text
+  }
+}
+
+/// `"Title — Artist"` for whatever is loaded, across every source.
+///
+/// Lives here rather than in [`tools`] because it is needed with or without a
+/// front door compiled in.
+pub fn current_track_label(app: &crate::core::app::App) -> Option<String> {
+  let snapshot = crate::infra::media_metadata::current_playback_snapshot(app)?;
+  Some(format!(
+    "{} — {}",
+    snapshot.metadata.title,
+    snapshot.primary_artist()
+  ))
+}
+
+/// One track a model proposed. Names only — resolution to a URI happens in
+/// [`resolve`], which drops anything the catalogue cannot confidently match.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DjSuggestion {
+  pub title: String,
+  pub artist: String,
+  /// Optional one-liner from the model. Shown in the DJ transcript when present;
+  /// never used for matching.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub why: Option<String>,
+}
+
+impl DjSuggestion {
+  pub fn label(&self) -> String {
+    format!("{} — {}", self.title, self.artist)
+  }
+}
+
+/// Who said a line in the DJ transcript.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DjSpeaker {
+  User,
+  Dj,
+  /// Machine-generated notes ("queued 5 tracks, 1 not found"), styled apart from
+  /// the model's own prose.
+  System,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DjLine {
+  pub speaker: DjSpeaker,
+  pub text: String,
+}
+
+impl DjLine {
+  pub fn user(text: impl Into<String>) -> Self {
+    Self {
+      speaker: DjSpeaker::User,
+      text: text.into(),
+    }
+  }
+  pub fn dj(text: impl Into<String>) -> Self {
+    Self {
+      speaker: DjSpeaker::Dj,
+      text: text.into(),
+    }
+  }
+  pub fn system(text: impl Into<String>) -> Self {
+    Self {
+      speaker: DjSpeaker::System,
+      text: text.into(),
+    }
+  }
+}
+
+/// How many tracks the DJ asks for, and will accept, per round.
+///
+/// Capped for three converging reasons: on an external Connect device each
+/// queued Spotify track costs its own Web API call
+/// (`App::add_track_to_native_queue`); a deep queue cannot respond to a vibe
+/// shift; and one model invocation per batch (rather than per track) is what
+/// keeps latency and subscription usage sane.
+pub const DEFAULT_BATCH: usize = 6;
+pub const MAX_BATCH: usize = 8;
+
+/// Refill the queue when it drops to this many tracks. Two tracks is roughly
+/// 6–8 minutes of runway, comfortably more than the worst case for a refill:
+/// `agent::MAX_STEPS_MUST_ACT` brain calls at `behavior.dj_agent_timeout_secs`
+/// each. That bound is why a refill gets fewer steps than a conversation.
+pub const QUEUE_LOW_WATER: usize = 2;
+
+/// Everything the DJ keeps on `App`.
+#[derive(Clone, Debug, Default)]
+pub struct DjState {
+  /// Whether the DJ keeps the queue topped up as tracks finish.
+  pub auto_queue: bool,
+  /// Bumped whenever in-flight DJ work becomes irrelevant: DJ switched off, a
+  /// vibe shift, a source change.
+  ///
+  /// **Load-bearing, not defensive.** A top-up dispatched from the advance path
+  /// lands seconds later; without re-checking this value before writing, a stale
+  /// batch queues tracks for a session the user already left. Same idiom as
+  /// `App::desired_lyrics_identity` and `App::desired_cover_art_key`.
+  pub generation: u64,
+  pub transcript: Vec<DjLine>,
+  /// The DJ's own progress flag. Deliberately *not* the global `App::is_loading`:
+  /// a brain call can run for a minute or more, and pinning the global spinner
+  /// that long is a UX bug.
+  pub thinking: bool,
+  /// Which step of how many the turn in flight is on, for the `…thinking` row.
+  ///
+  /// A multi-step turn on an agent CLI is minutes of silence otherwise, and
+  /// "thinking" alone cannot be told apart from a hang.
+  pub step: Option<(usize, usize)>,
+  /// Which turn owns [`Self::thinking`].
+  ///
+  /// Distinct from [`Self::generation`], which says whether a turn's *results* are
+  /// still wanted. This says who may clear the progress flag. An abandoned turn
+  /// finishing would otherwise clear a flag its replacement had already set, and
+  /// `wants_top_up` gates on exactly that flag — so the next tick would dispatch a
+  /// second refill and two batches would land.
+  pub turn_seq: u64,
+  pub vibe: Option<String>,
+  pub input: Vec<char>,
+  pub input_idx: usize,
+  pub input_cursor: u16,
+  /// Scroll offset into the *wrapped* transcript rows, not the message list.
+  pub scroll: u16,
+  /// URIs of the tracks the DJ put into the native queue. A vibe shift drops
+  /// exactly these, so the change is audible now rather than six tracks from
+  /// now.
+  ///
+  /// Identity, not a count: the DJ's picks are not guaranteed to be a contiguous
+  /// tail — the user can queue by hand after a batch lands, or delete a DJ pick
+  /// from the queue screen — and truncating by count in either state drops the
+  /// wrong tracks.
+  pub queued_uris: std::collections::HashSet<String>,
+  /// Reject anything the listener already has, rather than recommending it.
+  ///
+  /// Seeded from `behavior.dj_avoid_library` and toggleable at runtime, because
+  /// which mode you want depends on the ask: "more like this" wants their
+  /// favourites in scope, "find me something new" does not.
+  pub avoid_library: bool,
+  /// The playlist snapshot behind [`Self::avoid_library`]. `None` until the crawl
+  /// has run; built lazily, since it costs one API call per 100 playlist tracks
+  /// and a listener who never turns the filter on should never pay it.
+  pub library: Option<DjLibrary>,
+  /// A crawl is in flight. Guards against a second one being dispatched behind it
+  /// (the toggle and the first turn can both ask).
+  pub library_indexing: bool,
+}
+
+impl DjState {
+  /// Invalidate in-flight work and return the new generation.
+  ///
+  /// Used by `set_dj_vibe` over MCP as well as by the in-TUI vibe shift.
+  pub fn bump_generation(&mut self) -> u64 {
+    self.generation = self.generation.wrapping_add(1);
+    self.generation
+  }
+
+  /// Claim the progress flag for a turn about to be dispatched.
+  ///
+  /// Every path that starts a turn goes through here, so the returned value is
+  /// the one thing allowed to clear `thinking` again.
+  pub fn begin_turn(&mut self) -> u64 {
+    self.thinking = true;
+    self.turn_seq = self.turn_seq.wrapping_add(1);
+    self.turn_seq
+  }
+
+  /// Clear the progress flag, but only if `seq` still owns it.
+  pub fn finish_turn(&mut self, seq: u64) {
+    if self.turn_seq == seq {
+      self.thinking = false;
+      self.step = None;
+    }
+  }
+
+  pub fn push_line(&mut self, line: DjLine) {
+    self.transcript.push(line);
+    // The transcript is a conversation, not a log; an unbounded Vec here would
+    // grow for the life of the process and re-wrap on every draw.
+    const MAX_LINES: usize = 200;
+    if self.transcript.len() > MAX_LINES {
+      let overflow = self.transcript.len() - MAX_LINES;
+      self.transcript.drain(0..overflow);
+    }
+  }
+
+  pub fn take_input(&mut self) -> String {
+    let text = self.input.iter().collect::<String>();
+    self.input.clear();
+    self.input_idx = 0;
+    self.input_cursor = 0;
+    text
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn generation_bump_invalidates() {
+    let mut state = DjState::default();
+    let first = state.bump_generation();
+    let second = state.bump_generation();
+    assert_ne!(first, second);
+  }
+
+  #[test]
+  fn transcript_is_bounded() {
+    let mut state = DjState::default();
+    for i in 0..250 {
+      state.push_line(DjLine::dj(format!("line {i}")));
+    }
+    assert_eq!(state.transcript.len(), 200);
+    // Oldest dropped, newest kept.
+    assert_eq!(state.transcript.last().unwrap().text, "line 249");
+  }
+
+  #[test]
+  fn only_the_newest_turn_may_clear_the_progress_flag() {
+    // The interleaving this exists for: turn A is in flight, the listener toggles
+    // auto-queue off and on, the tick dispatches B — then A finishes. If A could
+    // clear the flag, `wants_top_up` would see an idle DJ with a short queue and
+    // dispatch C, and B and C would both queue a batch.
+    let mut state = DjState::default();
+    let a = state.begin_turn();
+    let b = state.begin_turn();
+    assert_ne!(a, b);
+
+    state.finish_turn(a);
+    assert!(state.thinking, "a stale turn does not own the flag");
+
+    state.finish_turn(b);
+    assert!(!state.thinking, "the turn that owns it does");
+    assert!(state.step.is_none(), "and clears the step counter with it");
+  }
+
+  #[test]
+  fn take_input_clears_cursor_state() {
+    let mut state = DjState::default();
+    state.input = "chill".chars().collect();
+    state.input_idx = 5;
+    state.input_cursor = 5;
+    assert_eq!(state.take_input(), "chill");
+    assert!(state.input.is_empty());
+    assert_eq!(state.input_idx, 0);
+    assert_eq!(state.input_cursor, 0);
+  }
+
+  #[test]
+  fn suggestion_label_is_stable() {
+    let suggestion = DjSuggestion {
+      title: "Nude".into(),
+      artist: "Radiohead".into(),
+      why: None,
+    };
+    assert_eq!(suggestion.label(), "Nude — Radiohead");
+  }
+}

--- a/src/infra/dj/resolve.rs
+++ b/src/infra/dj/resolve.rs
@@ -1,0 +1,414 @@
+//! Turning names into playable URIs.
+//!
+//! A model hands back `(title, artist)` pairs, some of which do not exist. This
+//! module searches the catalogue for each one and **drops anything it cannot
+//! confidently match** — hallucinated tracks are the primary failure mode once
+//! the model is the recommender, and queueing a fuzzy near-miss is worse than
+//! queueing nothing. Search always returns *something*, so a title match is
+//! required rather than trusting the top hit.
+//!
+//! Spotify's own `/recommendations` is not used anywhere here: it has been
+//! restricted to apps that held extended quota before 2024-11-27, and spotatui
+//! users register their own client ID, so it returns 403 for them. The model is
+//! the recommender; this module is only the lookup.
+
+use super::brief::{dedupe_key, normalize};
+use super::DjSuggestion;
+use crate::core::plugin_api::TrackInfo;
+use crate::infra::network::search::TrackSearchResponse;
+use crate::infra::network::Network;
+use rspotify::model::track::FullTrack;
+use std::collections::HashSet;
+
+/// How many candidates to ask the catalogue for per suggestion. Enough to get
+/// past a remaster or a live version at the top of the list, small enough to
+/// keep the response cheap.
+const CANDIDATES: usize = 5;
+
+/// What came back from a resolve pass.
+///
+/// Not `Eq`: `TrackInfo` is only `PartialEq` (its shape is pinned by the plugin
+/// contract).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ResolveReport {
+  /// Playable tracks, in the order the suggestions arrived.
+  pub resolved: Vec<TrackInfo>,
+  /// `"Title — Artist"` for suggestions with no confident catalogue match.
+  /// Reported back to whichever model asked, so it can correct itself on its
+  /// next step rather than naming the same nonexistent track again.
+  pub unresolved: Vec<String>,
+  /// Suggestions dropped because they were already queued, playing, or recently
+  /// played — see [`SkipSets::session`], which spans all three.
+  pub duplicates: Vec<String>,
+  /// Suggestions dropped because the listener already has them, with the
+  /// avoid-library filter on.
+  ///
+  /// A separate bucket from [`Self::duplicates`] because the two need different
+  /// words in front of the user and different words to the model: "already queued"
+  /// is wrong for a track they own, and reporting these as *not in the catalogue*
+  /// would tell the model something false.
+  pub in_library: Vec<String>,
+}
+
+/// The two reasons a suggestion can be rejected before it is even searched for.
+///
+/// Kept apart rather than merged into one set so [`ResolveReport`] can say which
+/// happened. Both hold [`dedupe_key`] values.
+pub struct SkipSets<'a> {
+  /// Already queued, playing, or recently played. Always applied.
+  pub session: &'a HashSet<String>,
+  /// In the listener's own playlists. Empty unless the caller asked to avoid the
+  /// library: in-TUI that is the <kbd>Ctrl</kbd>+<kbd>O</kbd> toggle, over MCP it is
+  /// `queue_tracks(exclude_owned: true)`. Left empty for an ordinary MCP queue, where
+  /// the agent named specific tracks and dropping one behind its back would be wrong.
+  pub library: &'a HashSet<String>,
+}
+
+impl ResolveReport {
+  /// One-line summary for a status message or an MCP tool result.
+  pub fn summary(&self) -> String {
+    let mut parts = vec![format!("queued {}", self.resolved.len())];
+    if !self.unresolved.is_empty() {
+      parts.push(format!("{} not found", self.unresolved.len()));
+    }
+    if !self.in_library.is_empty() {
+      parts.push(format!("{} already yours", self.in_library.len()));
+    }
+    if !self.duplicates.is_empty() {
+      parts.push(format!("{} already queued", self.duplicates.len()));
+    }
+    parts.join(", ")
+  }
+}
+
+/// Resolve suggestions to tracks, skipping duplicates and stopping at `cap`.
+///
+/// `skips` holds [`dedupe_key`] values for everything to reject unheard, split by
+/// reason. `cap` bounds the batch — on an external Connect device each queued
+/// Spotify track becomes its own Web API call
+/// (`App::add_track_to_native_queue`), so an unbounded batch is an unbounded
+/// number of round trips.
+///
+/// The library gate here is the *cheap* one: it matches on the name the model
+/// gave, before any search is paid for. The exact gate runs on the resolved track
+/// ID afterwards, in the caller — see `Network::reject_owned_tracks`.
+pub async fn resolve_suggestions(
+  net: &Network,
+  suggestions: &[DjSuggestion],
+  skips: &SkipSets<'_>,
+  cap: usize,
+  #[allow(unused_variables)] youtube_fallback: Option<&YouTubeResolver>,
+) -> ResolveReport {
+  let mut report = ResolveReport::default();
+  // Guards against a model repeating itself inside one reply, which it does.
+  let mut claimed: HashSet<String> = HashSet::new();
+
+  for suggestion in suggestions {
+    if report.resolved.len() >= cap {
+      break;
+    }
+    let label = suggestion.label();
+    let key = dedupe_key(&suggestion.title, &suggestion.artist);
+    if skips.library.contains(&key) {
+      report.in_library.push(label);
+      continue;
+    }
+    if skips.session.contains(&key) || !claimed.insert(key) {
+      report.duplicates.push(label);
+      continue;
+    }
+
+    match resolve_one(net, suggestion, youtube_fallback).await {
+      Some(track) => report.resolved.push(track),
+      None => {
+        // Deliberately debug-level and never a toast: a model that invents a
+        // track is routine, and surfacing it would be constant noise.
+        log::debug!("DJ: no catalogue match for {label}");
+        report.unresolved.push(label);
+      }
+    }
+  }
+
+  report
+}
+
+async fn resolve_one(
+  net: &Network,
+  suggestion: &DjSuggestion,
+  youtube_fallback: Option<&YouTubeResolver>,
+) -> Option<TrackInfo> {
+  if let Some(track) = resolve_spotify(net, &suggestion.title, &suggestion.artist).await {
+    return Some(track);
+  }
+  #[cfg(feature = "youtube")]
+  if let Some(resolver) = youtube_fallback {
+    if let Some(track) = resolver
+      .resolve(&suggestion.title, &suggestion.artist)
+      .await
+    {
+      return Some(track);
+    }
+  }
+  let _ = youtube_fallback;
+  None
+}
+
+/// Search Spotify for one track and return the best confident match.
+///
+/// Unlike `SearchNetwork::get_search_results` and `search_tracks_for_playlist`,
+/// which are fire-and-forget and write into `App`, this **returns** its result —
+/// the DJ needs an answer, not a UI side effect.
+pub async fn resolve_spotify(net: &Network, title: &str, artist: &str) -> Option<TrackInfo> {
+  // Spotify field filters keep the fuzzy matching honest; a bare concatenated
+  // query happily returns a different artist's song with a similar name.
+  let query = vec![
+    (
+      "q",
+      format!("track:\"{}\" artist:\"{}\"", escape(title), escape(artist)),
+    ),
+    ("type", "track".to_string()),
+    ("limit", CANDIDATES.to_string()),
+    ("offset", "0".to_string()),
+  ];
+
+  let response = match net
+    .spotify_get_typed::<TrackSearchResponse>("search", &query)
+    .await
+  {
+    Ok(response) => response,
+    Err(e) => {
+      // A resolve miss must never surface as the modal error page; the caller
+      // reports an aggregate count instead.
+      log::debug!("DJ: Spotify search failed for {title} — {artist}: {e}");
+      return None;
+    }
+  };
+
+  best_spotify_match(&response.tracks.items, title, artist)
+}
+
+/// Strip the characters that would break out of a quoted Spotify field filter.
+fn escape(value: &str) -> String {
+  value.replace(['"', '\\'], " ")
+}
+
+fn best_spotify_match(candidates: &[FullTrack], title: &str, artist: &str) -> Option<TrackInfo> {
+  candidates
+    .iter()
+    .filter(|track| track.id.is_some())
+    .filter_map(|track| {
+      let names = track
+        .artists
+        .iter()
+        .map(|a| a.name.clone())
+        .collect::<Vec<_>>()
+        .join(", ");
+      let score = match_score(&track.name, &names, title, artist)?;
+      Some((score, track))
+    })
+    // `max_by_key` keeps the *last* maximum; candidates are in relevance order,
+    // so prefer the earliest by comparing on a descending index tiebreak.
+    .enumerate()
+    .max_by_key(|(index, (score, _))| (*score, usize::MAX - index))
+    .map(|(_, (_, track))| TrackInfo::from(track))
+}
+
+/// Score a candidate against what was asked for, or `None` to reject it.
+///
+/// Rejecting is the important half. Search never returns nothing, so without a
+/// floor every invented track resolves to whatever was closest.
+fn match_score(
+  candidate_title: &str,
+  candidate_artist: &str,
+  want_title: &str,
+  want_artist: &str,
+) -> Option<u8> {
+  let (ct, ca) = (normalize(candidate_title), normalize(candidate_artist));
+  let (wt, wa) = (normalize(want_title), normalize(want_artist));
+  if ct.is_empty() || wt.is_empty() {
+    return None;
+  }
+
+  let title_score = if ct == wt {
+    2
+  } else if ct.contains(&wt) || wt.contains(&ct) {
+    // Covers "Weird Fishes" vs "Weird Fishes / Arpeggi" and
+    // "Nude" vs "Nude - Remastered".
+    1
+  } else {
+    return None;
+  };
+
+  // An artist mismatch on an otherwise-matching title is usually a cover, a
+  // karaoke version, or a different band entirely — all wrong.
+  let artist_score = if ca == wa {
+    2
+  } else if !wa.is_empty() && (ca.contains(&wa) || wa.contains(&ca)) {
+    1
+  } else if wa.is_empty() {
+    0
+  } else {
+    return None;
+  };
+
+  Some(title_score * 2 + artist_score)
+}
+
+/// YouTube fallback for tracks Spotify does not have (or cannot license).
+///
+/// Holds a built source rather than building one per lookup, because
+/// `YouTubeSource::search` shells out to `yt-dlp` and the config read behind
+/// `build_source` needs the `App` lock.
+pub struct YouTubeResolver {
+  #[cfg(feature = "youtube")]
+  source: crate::infra::youtube::YouTubeSource,
+}
+
+impl YouTubeResolver {
+  #[cfg(feature = "youtube")]
+  pub async fn new(app: &std::sync::Arc<tokio::sync::Mutex<crate::core::app::App>>) -> Self {
+    Self {
+      source: crate::infra::youtube::dispatch::build_source(app).await,
+    }
+  }
+
+  #[cfg(feature = "youtube")]
+  async fn resolve(&self, title: &str, artist: &str) -> Option<TrackInfo> {
+    use crate::core::source::Searcher;
+    let query = format!("{artist} {title}");
+    let results = match self.source.search(&query).await {
+      Ok(results) => results,
+      Err(e) => {
+        log::debug!("DJ: YouTube search failed for {query}: {e}");
+        return None;
+      }
+    };
+    // A YouTube title is free text ("Radiohead - Weird Fishes [HQ]"), so the
+    // strict scoring used for Spotify would reject nearly everything. Require
+    // the normalised title to appear somewhere in the video title instead.
+    let wanted = normalize(title);
+    results.tracks.into_iter().find(|track| {
+      let haystack = normalize(&format!("{} {}", track.name, track.artists.join(" ")));
+      !wanted.is_empty() && haystack.contains(&wanted)
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// `TrackInfo` has no `Default` (the plugin contract pins its shape), so
+  /// build a minimal placeholder for the report-shape tests.
+  fn stub_track() -> TrackInfo {
+    TrackInfo {
+      uri: Some("spotify:track:stub".to_string()),
+      name: "Stub".to_string(),
+      artists: vec!["Stub".to_string()],
+      album: String::new(),
+      duration_ms: 200_000,
+      id: Some("stub".to_string()),
+      album_id: None,
+      artist_refs: Vec::new(),
+      is_playable: true,
+      is_local: false,
+      track_number: 1,
+      explicit: false,
+      image_url: None,
+    }
+  }
+
+  #[test]
+  fn exact_title_and_artist_scores_highest() {
+    let exact = match_score("Weird Fishes", "Radiohead", "Weird Fishes", "Radiohead");
+    let partial = match_score(
+      "Weird Fishes / Arpeggi",
+      "Radiohead",
+      "Weird Fishes",
+      "Radiohead",
+    );
+    assert!(exact > partial);
+    assert!(partial.is_some());
+  }
+
+  #[test]
+  fn punctuation_and_case_do_not_matter() {
+    assert!(match_score("NUDE!", "radiohead", "Nude", "Radiohead").is_some());
+  }
+
+  #[test]
+  fn remaster_suffix_still_matches() {
+    assert!(match_score("Nude - Remastered 2017", "Radiohead", "Nude", "Radiohead").is_some());
+  }
+
+  #[test]
+  fn wrong_artist_is_rejected_even_with_matching_title() {
+    // The cover-version trap: right title, wrong band.
+    assert_eq!(
+      match_score("Nude", "Karaoke Kings", "Nude", "Radiohead"),
+      None
+    );
+  }
+
+  #[test]
+  fn unrelated_title_is_rejected() {
+    // The hallucination trap: search would have returned this happily.
+    assert_eq!(
+      match_score("Purple Moonlight", "Radiohead", "Weird Fishes", "Radiohead"),
+      None
+    );
+  }
+
+  #[test]
+  fn collaborator_differences_still_match() {
+    assert!(match_score(
+      "Tearing Me Up",
+      "Bob Moses",
+      "Tearing Me Up",
+      "Bob Moses, RAC"
+    )
+    .is_some());
+  }
+
+  #[test]
+  fn the_summary_distinguishes_owned_from_already_queued() {
+    let owned = ResolveReport {
+      in_library: vec!["a".into()],
+      ..ResolveReport::default()
+    };
+    let summary = owned.summary();
+    assert!(summary.contains("1 already yours"));
+    assert!(
+      !summary.contains("already queued"),
+      "a track they own was never queued; saying so explains nothing"
+    );
+  }
+
+  #[test]
+  fn summary_counts_what_is_still_in_the_report() {
+    // `summary()` reads `resolved`, so a caller that takes the vector first gets
+    // "queued 0" no matter how many landed. Guards the ordering in `dj_queue`.
+    let mut report = ResolveReport {
+      resolved: vec![stub_track()],
+      ..ResolveReport::default()
+    };
+    assert!(report.summary().contains("queued 1"));
+    let _ = std::mem::take(&mut report.resolved);
+    assert!(report.summary().contains("queued 0"));
+  }
+
+  #[test]
+  fn summary_mentions_every_bucket() {
+    let report = ResolveReport {
+      resolved: vec![stub_track()],
+      unresolved: vec!["ghost".into()],
+      duplicates: vec!["dupe".into()],
+      in_library: vec!["owned".into()],
+    };
+    let summary = report.summary();
+    assert!(summary.contains("queued 1"));
+    assert!(summary.contains("1 not found"));
+    assert!(summary.contains("1 already queued"));
+    assert!(summary.contains("1 already yours"));
+  }
+}

--- a/src/infra/dj/resolve.rs
+++ b/src/infra/dj/resolve.rs
@@ -25,6 +25,28 @@ use std::collections::HashSet;
 /// keep the response cheap.
 const CANDIDATES: usize = 5;
 
+/// Shortest normalised title allowed to match as a *substring* rather than
+/// exactly.
+///
+/// "Go" or "Hey" is a substring of half the catalogue, so for a title that short
+/// the substring branch stops rejecting anything and the resolver hands back
+/// whatever search felt like returning. Four is the lowest bar that still lets
+/// the suffix cases through: "Nude" inside "Nude - Remastered 2017" is exactly
+/// four characters, and that is the case this whole branch exists for. Anything
+/// shorter has to match exactly.
+const MIN_SUBSTRING_TITLE: usize = 4;
+
+/// What separates two artists inside one credit.
+///
+/// The catalogue joins its artist list with `", "`; a model writes a
+/// collaboration with `&`, `;`, ` x ` or `feat.`. Splitting on these is the whole
+/// point of [`shares_an_artist`] — a `contains` test accepts "Radiohead Tribute
+/// Band" for "Radiohead", which is a different band playing the same songs.
+const CREDIT_PUNCTUATION: [char; 3] = [',', ';', '&'];
+/// Standalone words that join two artists. Matched as whole tokens, never as
+/// substrings: "Daft Punk" contains "ft ".
+const CREDIT_JOIN_WORDS: [&str; 4] = ["x", "feat", "ft", "featuring"];
+
 /// What came back from a resolve pass.
 ///
 /// Not `Eq`: `TrackInfo` is only `PartialEq` (its shape is pinned by the plugin
@@ -231,7 +253,7 @@ fn match_score(
 
   let title_score = if ct == wt {
     2
-  } else if ct.contains(&wt) || wt.contains(&ct) {
+  } else if contains_meaningfully(&ct, &wt) {
     // Covers "Weird Fishes" vs "Weird Fishes / Arpeggi" and
     // "Nude" vs "Nude - Remastered".
     1
@@ -240,10 +262,12 @@ fn match_score(
   };
 
   // An artist mismatch on an otherwise-matching title is usually a cover, a
-  // karaoke version, or a different band entirely — all wrong.
+  // karaoke version, or a different band entirely — all wrong. A credit is a
+  // *list* of artists, so the question is whether the two credits name an artist
+  // in common, not whether one string sits inside the other.
   let artist_score = if ca == wa {
     2
-  } else if !wa.is_empty() && (ca.contains(&wa) || wa.contains(&ca)) {
+  } else if !wa.is_empty() && shares_an_artist(candidate_artist, want_artist) {
     1
   } else if wa.is_empty() {
     0
@@ -252,6 +276,72 @@ fn match_score(
   };
 
   Some(title_score * 2 + artist_score)
+}
+
+/// Substring title match, guarded on the length of the *contained* title in
+/// whichever direction it matched — see [`MIN_SUBSTRING_TITLE`].
+fn contains_meaningfully(candidate: &str, wanted: &str) -> bool {
+  let long_enough = |title: &str| title.chars().count() >= MIN_SUBSTRING_TITLE;
+  (long_enough(wanted) && candidate.contains(wanted))
+    || (long_enough(candidate) && wanted.contains(candidate))
+}
+
+/// Whether two credits name at least one artist in common.
+///
+/// Equality per listed artist, not containment across the whole credit. That is
+/// what separates the two cases this has to get right: "Bob Moses, RAC" and
+/// "Bob Moses" list an artist in common and are the same track, while "Radiohead
+/// Tribute Band" lists exactly one artist, which is not Radiohead.
+fn shares_an_artist(candidate: &str, wanted: &str) -> bool {
+  let wanted = credited_artists(wanted);
+  !wanted.is_empty()
+    && credited_artists(candidate)
+      .iter()
+      .any(|name| wanted.contains(name))
+}
+
+/// Split a credit into the artists it names, each normalised for comparison.
+fn credited_artists(credit: &str) -> Vec<String> {
+  let mut names = Vec::new();
+  for chunk in credit.split(CREDIT_PUNCTUATION) {
+    let mut current: Vec<&str> = Vec::new();
+    for token in chunk.split_whitespace() {
+      let bare = token
+        .trim_matches(|c: char| !c.is_alphanumeric())
+        .to_lowercase();
+      if CREDIT_JOIN_WORDS.contains(&bare.as_str()) {
+        push_artist(&mut names, &current);
+        current.clear();
+      } else {
+        current.push(token);
+      }
+    }
+    push_artist(&mut names, &current);
+  }
+  if names.is_empty() {
+    // An artist named after a join word (there is a producer called X) splits to
+    // nothing; fall back to the credit whole rather than to "matches anything".
+    push_artist(&mut names, &[credit]);
+  }
+  names
+}
+
+fn push_artist(names: &mut Vec<String>, tokens: &[&str]) {
+  let name = artist_key(&tokens.join(" "));
+  if !name.is_empty() {
+    names.push(name);
+  }
+}
+
+/// Normalise one artist name for equality: [`normalize`] plus a dropped leading
+/// "the", because a model writes "Chemical Brothers" for a catalogue credited
+/// "The Chemical Brothers" and that is the same band.
+fn artist_key(name: &str) -> String {
+  let normalized = normalize(name);
+  normalized
+    .strip_prefix("the ")
+    .unwrap_or(&normalized)
+    .to_string()
 }
 
 /// YouTube fallback for tracks Spotify does not have (or cannot license).
@@ -368,6 +458,81 @@ mod tests {
       "Bob Moses, RAC"
     )
     .is_some());
+  }
+
+  #[test]
+  fn a_tribute_band_is_not_the_artist() {
+    // The case containment cannot see: "radiohead tribute band" contains
+    // "radiohead", and a token-subset test does not help either — {radiohead} is
+    // a subset of {radiohead, tribute, band}. One listed artist, and it is not
+    // the one that was asked for.
+    assert_eq!(
+      match_score("Nude", "Radiohead Tribute Band", "Nude", "Radiohead"),
+      None
+    );
+    // And the other way round, for a model that names the tribute act.
+    assert_eq!(
+      match_score("Nude", "Radiohead", "Nude", "Radiohead Tribute Band"),
+      None
+    );
+  }
+
+  #[test]
+  fn a_credit_that_lists_the_artist_still_matches() {
+    // Whichever side carries the longer credit, and whichever separator the
+    // model reached for.
+    for (candidate, wanted) in [
+      ("Bob Moses, RAC", "Bob Moses"),
+      ("Bob Moses", "Bob Moses, RAC"),
+      ("Kaytranada & Anderson .Paak", "Kaytranada"),
+      ("Skrillex x Diplo", "Diplo"),
+      ("Calvin Harris feat. Rihanna", "Rihanna"),
+      ("Calvin Harris (feat. Rihanna)", "Calvin Harris"),
+    ] {
+      assert!(
+        match_score("Tearing Me Up", candidate, "Tearing Me Up", wanted).is_some(),
+        "{candidate} should match {wanted}"
+      );
+    }
+  }
+
+  #[test]
+  fn a_leading_the_is_not_a_different_band() {
+    // A model writes the credit without the article about as often as with it.
+    assert!(match_score(
+      "Block Rockin Beats",
+      "The Chemical Brothers",
+      "Block Rockin Beats",
+      "Chemical Brothers"
+    )
+    .is_some());
+  }
+
+  #[test]
+  fn a_join_word_is_not_matched_inside_a_name() {
+    // "daft punk" contains "ft " — splitting on raw substrings would cut the
+    // band in half and then match "punk" against anything punk.
+    assert_eq!(
+      match_score("Around the World", "Daft Punk", "Around the World", "Punk"),
+      None
+    );
+  }
+
+  #[test]
+  fn a_short_title_has_to_match_exactly() {
+    // "go" is a substring of half the catalogue, so the substring branch stops
+    // rejecting anything for a title this short.
+    assert_eq!(
+      match_score("Go Your Own Way", "Fleetwood Mac", "Go", "Fleetwood Mac"),
+      None
+    );
+    // Same in the other direction: a short *candidate* inside a long request.
+    assert_eq!(
+      match_score("Go", "Fleetwood Mac", "Go Your Own Way", "Fleetwood Mac"),
+      None
+    );
+    // The title itself is still perfectly resolvable, exactly.
+    assert!(match_score("Go", "The Chemical Brothers", "Go", "Chemical Brothers").is_some());
   }
 
   #[test]

--- a/src/infra/dj/tools.rs
+++ b/src/infra/dj/tools.rs
@@ -1,0 +1,930 @@
+//! The DJ tool surface: one definition, two consumers.
+//!
+//! The MCP server (`mcp-server`) publishes these verbatim as MCP tools; the
+//! in-TUI DJ (`ai-dj`) calls the same handlers directly. Keeping the list here
+//! means an agent driving spotatui over MCP and the built-in DJ can never drift
+//! apart in what they are able to do.
+//!
+//! Schemas are JSON Schema 2020-12, which is the MCP default dialect (a tool
+//! taking no arguments uses `{"type":"object","additionalProperties":false}`, the
+//! spec's recommended empty schema). The list order is fixed and deterministic:
+//! MCP clients cache `tools/list`, and a stable order also improves prompt-cache
+//! hit rates when the tools are rendered into model context.
+
+use super::{brief, DjSuggestion, MAX_BATCH};
+use crate::core::app::App;
+use crate::infra::network::IoEvent;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Static description of one tool.
+pub struct ToolSpec {
+  pub name: &'static str,
+  /// MCP-only: the in-TUI DJ renders `name` and `description` alone.
+  pub title: &'static str,
+  pub description: &'static str,
+  /// Whether the tool only reads state. Surfaced to MCP clients so they can
+  /// decide what to confirm with the user.
+  pub read_only: bool,
+  /// Whether executing it needs the live Spotify client (and therefore the
+  /// serial IoEvent lane) rather than just the `App` lock.
+  pub needs_network: bool,
+  pub schema: fn() -> Value,
+}
+
+/// Every tool, in a fixed order.
+pub const TOOLS: &[ToolSpec] = &[
+  ToolSpec {
+    name: "get_listening_history",
+    title: "Listening history",
+    description: "Summarise what the user has been listening to: top artists, top tracks, top albums, and recent plays. Call this first when choosing music for them. Returns aggregate names only — no identifiers or timestamps.",
+    read_only: true,
+    needs_network: false,
+    schema: || {
+      json!({
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string",
+            "enum": ["7d", "30d", "month", "year", "all"],
+            "description": "Window to summarise. Defaults to 30d."
+          }
+        },
+        "additionalProperties": false
+      })
+    },
+  },
+  ToolSpec {
+    name: "get_now_playing",
+    title: "Now playing",
+    description: "The currently playing or paused track, whether playback is active, and how many tracks are waiting in the queue.",
+    read_only: true,
+    needs_network: false,
+    schema: || json!({"type": "object", "additionalProperties": false}),
+  },
+  ToolSpec {
+    name: "get_queue",
+    title: "Queue",
+    description: "The tracks currently queued up, in play order.",
+    read_only: true,
+    needs_network: false,
+    schema: || json!({"type": "object", "additionalProperties": false}),
+  },
+  ToolSpec {
+    name: "search_tracks",
+    title: "Search tracks",
+    description: "Search the catalogue for tracks and return their playable URIs. Use this to check that something exists before queueing it by name. Each result is marked `owned` when the user already has it (Liked Songs, or a playlist they own or collaborate on) — prefer results marked new when they asked for something they have not heard.",
+    read_only: true,
+    needs_network: true,
+    schema: || {
+      json!({
+        "type": "object",
+        "properties": {
+          "query": {"type": "string", "description": "Free-text search, e.g. 'radiohead weird fishes'."},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 20, "description": "Maximum results. Defaults to 10."}
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      })
+    },
+  },
+  ToolSpec {
+    name: "queue_tracks",
+    title: "Queue tracks",
+    description: "Add tracks to the play queue. Give either a `uri` from search_tracks, or a `title` plus `artist` to be looked up. Tracks that cannot be found are skipped and reported back, so check the result rather than assuming everything was queued.",
+    read_only: false,
+    needs_network: true,
+    schema: || {
+      json!({
+        "type": "object",
+        "properties": {
+          "tracks": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": MAX_BATCH,
+            "description": "Tracks to queue, in play order.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uri": {"type": "string", "description": "Exact URI from search_tracks. Preferred when known."},
+                "title": {"type": "string"},
+                "artist": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          },
+          "exclude_owned": {
+            "type": "boolean",
+            "description": "Skip tracks the user already has (Liked Songs, or a playlist they own or collaborate on) instead of queueing them; the skipped ones are reported back. Defaults to false. Set it when they asked for music they have not heard, not when they named specific tracks. Nothing is substituted for a skipped track, so fewer may be queued than requested."
+          }
+        },
+        "required": ["tracks"],
+        "additionalProperties": false
+      })
+    },
+  },
+  ToolSpec {
+    name: "play_now",
+    title: "Play now",
+    description: "Start playing a track immediately, interrupting whatever is playing. Use queue_tracks instead unless the user asked for something right now. The track has to exist: give a URI from search_tracks rather than one you assembled yourself.",
+    read_only: false,
+    needs_network: true,
+    schema: || {
+      json!({
+        "type": "object",
+        "properties": {"uri": {"type": "string", "description": "A track URI from search_tracks."}},
+        "required": ["uri"],
+        "additionalProperties": false
+      })
+    },
+  },
+  ToolSpec {
+    name: "skip_track",
+    title: "Skip track",
+    description: "Skip to the next track.",
+    read_only: false,
+    needs_network: false,
+    schema: || json!({"type": "object", "additionalProperties": false}),
+  },
+  ToolSpec {
+    name: "set_dj_vibe",
+    title: "Set DJ vibe",
+    description: "Set the standing direction the built-in auto-queue DJ follows when it refills the queue on its own, e.g. 'mellow instrumental for focusing'. Pass null to clear it. This does not start playback or queue anything. The built-in DJ is optional and may be switched off or not built in at all, so read the result: it says whether anything will act on the vibe. Either way it is stored and returned by get_listening_history, so you can honour it yourself when you queue.",
+    read_only: false,
+    needs_network: false,
+    schema: || {
+      json!({
+        "type": "object",
+        "properties": {"vibe": {"type": ["string", "null"], "description": "The direction to follow, or null to clear."}},
+        "additionalProperties": false
+      })
+    },
+  },
+];
+
+pub fn spec(name: &str) -> Option<&'static ToolSpec> {
+  TOOLS.iter().find(|tool| tool.name == name)
+}
+
+/// A validated tool invocation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DjToolCall {
+  GetListeningHistory {
+    period: crate::infra::history::RecapPeriod,
+  },
+  GetNowPlaying,
+  GetQueue,
+  SearchTracks {
+    query: String,
+    limit: usize,
+  },
+  QueueTracks {
+    items: Vec<QueueItem>,
+    /// Reject anything the listener already has rather than queueing it.
+    ///
+    /// Off by default, and deliberately so: an agent told to queue one specific
+    /// track the listener owns should get that track, not an explanation. It is
+    /// opt-in for the *recommendation* case, where "you already have this" is the
+    /// answer the caller actually wants.
+    exclude_owned: bool,
+    /// Extra [`super::dedupe_key`] values to reject, on top of what is queued and
+    /// playing.
+    ///
+    /// Not an argument any caller can pass: [`parse_call`] always leaves it empty,
+    /// so an MCP agent told to queue a specific track always gets that track. The
+    /// in-TUI DJ fills it with its recently-played window, which is a taste rule
+    /// belonging to that front door alone — put in `App::dj_skip_keys` it would
+    /// silently drop tracks an agent explicitly asked for.
+    extra_skip_keys: Vec<String>,
+  },
+  PlayNow {
+    uri: String,
+  },
+  SkipTrack,
+  SetDjVibe {
+    vibe: Option<String>,
+  },
+}
+
+/// One entry of `queue_tracks`: either an exact URI or a name to resolve.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QueueItem {
+  Uri(String),
+  Named(DjSuggestion),
+}
+
+/// Why a call could not be parsed.
+///
+/// Distinct from an execution failure: per MCP, a bad request shape is a
+/// protocol error while a tool that ran and failed is a result with
+/// `isError: true`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ToolCallError {
+  UnknownTool(String),
+  InvalidArguments(String),
+}
+
+impl std::fmt::Display for ToolCallError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::UnknownTool(name) => write!(f, "Unknown tool: {name}"),
+      Self::InvalidArguments(detail) => write!(f, "Invalid arguments: {detail}"),
+    }
+  }
+}
+
+/// What a tool produced.
+pub struct ToolOutcome {
+  /// Human/model-readable text. Always populated.
+  pub text: String,
+  /// Machine-readable mirror, when the tool has one. MCP-only: the in-TUI DJ
+  /// feeds `text` back to its model, which reads prose perfectly well.
+  pub structured: Option<Value>,
+  /// True for an execution failure the model can act on and retry.
+  pub is_error: bool,
+}
+
+impl ToolOutcome {
+  pub fn ok(text: impl Into<String>) -> Self {
+    Self {
+      text: text.into(),
+      structured: None,
+      is_error: false,
+    }
+  }
+
+  pub fn with_data(text: impl Into<String>, structured: Value) -> Self {
+    Self {
+      text: text.into(),
+      structured: Some(structured),
+      is_error: false,
+    }
+  }
+
+  pub fn error(text: impl Into<String>) -> Self {
+    Self {
+      text: text.into(),
+      structured: None,
+      is_error: true,
+    }
+  }
+}
+
+fn period_from_str(value: &str) -> Option<crate::infra::history::RecapPeriod> {
+  use crate::infra::history::RecapPeriod;
+  match value {
+    "7d" => Some(RecapPeriod::SevenDays),
+    "30d" => Some(RecapPeriod::ThirtyDays),
+    "month" => Some(RecapPeriod::Month),
+    "year" => Some(RecapPeriod::Year),
+    "all" => Some(RecapPeriod::All),
+    _ => None,
+  }
+}
+
+/// Validate `(name, arguments)` into a [`DjToolCall`].
+///
+/// Every input is checked here rather than in the handlers, because MCP requires
+/// servers to validate tool inputs and because both front doors funnel through
+/// this one function.
+pub fn parse_call(name: &str, args: &Value) -> Result<DjToolCall, ToolCallError> {
+  use crate::infra::history::RecapPeriod;
+  let invalid = |detail: &str| ToolCallError::InvalidArguments(detail.to_string());
+  // An absent `arguments` is equivalent to `{}` for the no-argument tools.
+  let obj = match args {
+    Value::Null => &Value::Null,
+    Value::Object(_) => args,
+    _ => return Err(invalid("arguments must be an object")),
+  };
+  let get = |key: &str| obj.get(key);
+
+  match name {
+    "get_listening_history" => {
+      let period = match get("period") {
+        None | Some(Value::Null) => RecapPeriod::ThirtyDays,
+        Some(Value::String(value)) => period_from_str(value)
+          .ok_or_else(|| invalid("period must be one of 7d, 30d, month, year, all"))?,
+        Some(_) => return Err(invalid("period must be a string")),
+      };
+      Ok(DjToolCall::GetListeningHistory { period })
+    }
+    "get_now_playing" => Ok(DjToolCall::GetNowPlaying),
+    "get_queue" => Ok(DjToolCall::GetQueue),
+    "search_tracks" => {
+      let query = get("query")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("query is required and must be a string"))?
+        .trim()
+        .to_string();
+      if query.is_empty() {
+        return Err(invalid("query must not be empty"));
+      }
+      let limit = match get("limit") {
+        None | Some(Value::Null) => 10,
+        Some(value) => value
+          .as_u64()
+          .filter(|n| (1..=20).contains(n))
+          .ok_or_else(|| invalid("limit must be an integer between 1 and 20"))?
+          as usize,
+      };
+      Ok(DjToolCall::SearchTracks { query, limit })
+    }
+    "queue_tracks" => {
+      let entries = get("tracks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid("tracks is required and must be an array"))?;
+      if entries.is_empty() {
+        return Err(invalid("tracks must not be empty"));
+      }
+      if entries.len() > MAX_BATCH {
+        return Err(ToolCallError::InvalidArguments(format!(
+          "tracks must contain at most {MAX_BATCH} entries"
+        )));
+      }
+      let mut items = Vec::with_capacity(entries.len());
+      for entry in entries {
+        let uri = entry.get("uri").and_then(Value::as_str);
+        let title = entry.get("title").and_then(Value::as_str);
+        let artist = entry.get("artist").and_then(Value::as_str);
+        match (uri, title, artist) {
+          (Some(uri), _, _) if !uri.trim().is_empty() => {
+            items.push(QueueItem::Uri(uri.trim().to_string()))
+          }
+          (_, Some(title), Some(artist)) if !title.trim().is_empty() => {
+            items.push(QueueItem::Named(DjSuggestion {
+              title: title.trim().to_string(),
+              artist: artist.trim().to_string(),
+              why: None,
+            }))
+          }
+          _ => {
+            return Err(invalid(
+              "each track needs either a uri, or both title and artist",
+            ))
+          }
+        }
+      }
+      let exclude_owned = match get("exclude_owned") {
+        None | Some(Value::Null) => false,
+        Some(Value::Bool(value)) => *value,
+        Some(_) => return Err(invalid("exclude_owned must be a boolean")),
+      };
+      Ok(DjToolCall::QueueTracks {
+        items,
+        exclude_owned,
+        // Never from the wire: see the field's own note.
+        extra_skip_keys: Vec::new(),
+      })
+    }
+    "play_now" => {
+      let uri = get("uri")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|uri| !uri.is_empty())
+        .ok_or_else(|| invalid("uri is required and must be a non-empty string"))?
+        .to_string();
+      // Rejected at parse time, unlike `queue_tracks`: this tool takes exactly
+      // one URI, so there is no partial success to report and an invalid
+      // argument is the whole request.
+      if !crate::core::queue::is_playable_track_uri(&uri) {
+        return Err(invalid(
+          "uri must name a single playable track (spotify:track:…, file:…, \
+           subsonic:…, or youtube:…); album, playlist and https links are not \
+           playable here",
+        ));
+      }
+      Ok(DjToolCall::PlayNow { uri })
+    }
+    "skip_track" => Ok(DjToolCall::SkipTrack),
+    "set_dj_vibe" => {
+      let vibe = match get("vibe") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) => {
+          let trimmed = value.trim();
+          if trimmed.is_empty() {
+            None
+          } else {
+            Some(trimmed.to_string())
+          }
+        }
+        Some(_) => return Err(invalid("vibe must be a string or null")),
+      };
+      Ok(DjToolCall::SetDjVibe { vibe })
+    }
+    other => Err(ToolCallError::UnknownTool(other.to_string())),
+  }
+}
+
+impl DjToolCall {
+  pub fn needs_network(&self) -> bool {
+    matches!(
+      self,
+      Self::SearchTracks { .. } | Self::QueueTracks { .. } | Self::PlayNow { .. }
+    )
+  }
+
+  pub fn tool_name(&self) -> &'static str {
+    match self {
+      Self::GetListeningHistory { .. } => "get_listening_history",
+      Self::GetNowPlaying => "get_now_playing",
+      Self::GetQueue => "get_queue",
+      Self::SearchTracks { .. } => "search_tracks",
+      Self::QueueTracks { .. } => "queue_tracks",
+      Self::PlayNow { .. } => "play_now",
+      Self::SkipTrack => "skip_track",
+      Self::SetDjVibe { .. } => "set_dj_vibe",
+    }
+  }
+}
+
+/// Execute the calls that only need the `App` lock (plus, for history, a
+/// blocking file read).
+///
+/// Returns `None` for calls that need the Spotify client; those go through the
+/// serial IoEvent lane instead — see `crate::infra::network::dj`.
+pub async fn execute_app_only(app: &Arc<Mutex<App>>, call: &DjToolCall) -> Option<ToolOutcome> {
+  match call {
+    DjToolCall::GetListeningHistory { period } => Some(history_outcome(app, *period).await),
+    DjToolCall::GetNowPlaying => Some(now_playing_outcome(app).await),
+    DjToolCall::GetQueue => Some(queue_outcome(app).await),
+    DjToolCall::SkipTrack => {
+      let mut app = app.lock().await;
+      app.dispatch(IoEvent::NextTrack);
+      Some(ToolOutcome::ok("Skipped to the next track"))
+    }
+    DjToolCall::SetDjVibe { vibe } => {
+      let mut app = app.lock().await;
+      // A new standing direction invalidates any refill already in flight for
+      // the old one.
+      app.dj.bump_generation();
+      app.dj.vibe = vibe.clone();
+      Some(ToolOutcome::ok(match vibe.as_deref() {
+        Some(vibe) => format!("DJ vibe set to: {vibe}. {}", vibe_effect(&app)),
+        None => "DJ vibe cleared".to_string(),
+      }))
+    }
+    // These need the real Spotify client, which only the serial lane has.
+    // `play_now` is among them because it confirms the track exists before
+    // interrupting what is playing: dispatching blind used to report success
+    // for a URI that stopped playback instead of starting it.
+    DjToolCall::SearchTracks { .. }
+    | DjToolCall::QueueTracks { .. }
+    | DjToolCall::PlayNow { .. } => None,
+  }
+}
+
+/// What, if anything, will actually act on a vibe that was just set.
+///
+/// Worth a sentence rather than a bare "vibe set". The vibe is a standing
+/// direction for the *in-TUI* auto-queue DJ, and in a build without one nothing
+/// consumes it on its own. An agent told only "DJ vibe set to: mellow"
+/// reasonably concludes the music is about to change, and would be wrong.
+///
+/// It is never *ignored*, which is why this points at the fallback: the vibe is
+/// stored on `App` and comes back out through `get_listening_history`, so an
+/// agent running its own top-up loop can read it and honour it itself.
+fn vibe_effect(app: &App) -> &'static str {
+  // `App::dj` exists under `dj-core`, so `auto_queue` is readable here — but it
+  // is permanently false in a build with no in-TUI DJ, and saying "auto-queue is
+  // off" would imply it could be turned on. Once `ai-dj` exists this grows the
+  // arm that reports the live toggle.
+  let _ = app;
+  "This build has no built-in auto-queue DJ, so nothing will act on it automatically. It is \
+   stored and returned by get_listening_history, so you can follow it yourself when you queue."
+}
+
+async fn history_outcome(
+  app: &Arc<Mutex<App>>,
+  period: crate::infra::history::RecapPeriod,
+) -> ToolOutcome {
+  // `load_listens` is blocking and reads the whole file, which is unbounded
+  // append-only — never call it directly on an async task.
+  let loaded = tokio::task::spawn_blocking(crate::infra::history::load_listens).await;
+  let listens = match loaded {
+    Ok(Ok(listens)) => listens,
+    Ok(Err(e)) => return ToolOutcome::error(format!("Could not read listening history: {e}")),
+    Err(e) => return ToolOutcome::error(format!("Listening history task failed: {e}")),
+  };
+
+  let mut summary = brief::build_brief(&listens, period);
+  {
+    let app = app.lock().await;
+    summary.now_playing = super::current_track_label(&app);
+    summary.vibe = app.dj.vibe.clone();
+  }
+
+  if summary.is_sparse() {
+    return ToolOutcome::ok(format!(
+      "Very little listening history so far ({} qualifying plays in {}). Ask the user what they \
+       feel like instead of inferring it.",
+      summary.total_plays, summary.period_label
+    ));
+  }
+
+  let structured = json!({
+    "period": summary.period_label,
+    "total_plays": summary.total_plays,
+    "top_artists": summary.top_artists,
+    "top_tracks": summary.top_tracks,
+    "top_albums": summary.top_albums,
+    "recent": summary.recent,
+    "now_playing": summary.now_playing,
+    "vibe": summary.vibe,
+  });
+  ToolOutcome::with_data(summary.to_prompt_block(), structured)
+}
+
+async fn now_playing_outcome(app: &Arc<Mutex<App>>) -> ToolOutcome {
+  let app = app.lock().await;
+  let queue_depth = app.native_queue.len();
+  // One snapshot for both the label and the transport state: it is the
+  // source-agnostic view (Spotify, local, Subsonic, YouTube, radio), so this
+  // works whatever is actually producing sound.
+  match crate::infra::media_metadata::current_playback_snapshot(&app) {
+    Some(snapshot) => {
+      let label = format!(
+        "{} — {}",
+        snapshot.metadata.title,
+        snapshot.primary_artist()
+      );
+      let state = if snapshot.is_playing {
+        "playing"
+      } else {
+        "paused"
+      };
+      ToolOutcome::with_data(
+        format!("{state}: {label} ({queue_depth} track(s) queued)"),
+        json!({
+          "track": label,
+          "is_playing": snapshot.is_playing,
+          "is_live": snapshot.is_live,
+          "queue_depth": queue_depth,
+        }),
+      )
+    }
+    None => ToolOutcome::with_data(
+      format!("Nothing is playing ({queue_depth} track(s) queued)"),
+      json!({"track": Value::Null, "is_playing": false, "queue_depth": queue_depth}),
+    ),
+  }
+}
+
+async fn queue_outcome(app: &Arc<Mutex<App>>) -> ToolOutcome {
+  let app = app.lock().await;
+  if app.native_queue.is_empty() {
+    return ToolOutcome::with_data("The queue is empty", json!({"tracks": []}));
+  }
+  let labels = app
+    .native_queue
+    .iter()
+    .map(|track| format!("{} — {}", track.name, track.artists.join(", ")))
+    .collect::<Vec<_>>();
+  let text = labels
+    .iter()
+    .enumerate()
+    .map(|(index, label)| format!("{}. {}", index + 1, label))
+    .collect::<Vec<_>>()
+    .join("\n");
+  ToolOutcome::with_data(text, json!({"tracks": labels}))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::infra::history::RecapPeriod;
+
+  #[test]
+  fn every_tool_schema_is_a_valid_object_schema() {
+    for tool in TOOLS {
+      let schema = (tool.schema)();
+      assert_eq!(
+        schema.get("type").and_then(Value::as_str),
+        Some("object"),
+        "{} must have an object input schema",
+        tool.name
+      );
+      // MCP requires a valid schema object, never null.
+      assert!(schema.is_object(), "{} schema must be an object", tool.name);
+    }
+  }
+
+  #[test]
+  fn tool_names_satisfy_mcp_naming_rules() {
+    for tool in TOOLS {
+      assert!(
+        (1..=128).contains(&tool.name.len()),
+        "{} name length",
+        tool.name
+      );
+      assert!(
+        tool
+          .name
+          .chars()
+          .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.')),
+        "{} has characters MCP disallows",
+        tool.name
+      );
+    }
+  }
+
+  #[test]
+  fn tool_names_are_unique_and_order_is_deterministic() {
+    let names: Vec<_> = TOOLS.iter().map(|tool| tool.name).collect();
+    let unique: std::collections::HashSet<_> = names.iter().collect();
+    assert_eq!(names.len(), unique.len(), "duplicate tool name");
+    // Order is part of the contract: MCP clients cache tools/list.
+    assert_eq!(names[0], "get_listening_history");
+    assert_eq!(names.last(), Some(&"set_dj_vibe"));
+  }
+
+  #[test]
+  fn no_argument_tools_use_the_recommended_empty_schema() {
+    for name in ["get_now_playing", "get_queue", "skip_track"] {
+      let schema = (spec(name).unwrap().schema)();
+      assert_eq!(
+        schema.get("additionalProperties"),
+        Some(&Value::Bool(false)),
+        "{name} should reject unexpected arguments"
+      );
+      assert!(schema.get("properties").is_none(), "{name} takes no args");
+    }
+  }
+
+  #[test]
+  fn history_period_defaults_and_parses() {
+    let call = parse_call("get_listening_history", &json!({})).unwrap();
+    assert_eq!(
+      call,
+      DjToolCall::GetListeningHistory {
+        period: RecapPeriod::ThirtyDays
+      }
+    );
+    let call = parse_call("get_listening_history", &json!({"period": "7d"})).unwrap();
+    assert_eq!(
+      call,
+      DjToolCall::GetListeningHistory {
+        period: RecapPeriod::SevenDays
+      }
+    );
+    assert!(matches!(
+      parse_call("get_listening_history", &json!({"period": "fortnight"})),
+      Err(ToolCallError::InvalidArguments(_))
+    ));
+  }
+
+  #[test]
+  fn null_arguments_are_accepted_for_no_argument_tools() {
+    assert_eq!(
+      parse_call("get_now_playing", &Value::Null).unwrap(),
+      DjToolCall::GetNowPlaying
+    );
+  }
+
+  #[test]
+  fn unknown_tool_is_distinct_from_bad_arguments() {
+    // MCP treats these differently: unknown tool and malformed request are
+    // protocol errors, a tool that ran and failed is isError.
+    assert!(matches!(
+      parse_call("make_coffee", &json!({})),
+      Err(ToolCallError::UnknownTool(_))
+    ));
+    assert!(matches!(
+      parse_call("search_tracks", &json!({})),
+      Err(ToolCallError::InvalidArguments(_))
+    ));
+  }
+
+  #[test]
+  fn search_validates_query_and_limit() {
+    assert!(parse_call("search_tracks", &json!({"query": "   "})).is_err());
+    assert!(parse_call("search_tracks", &json!({"query": "a", "limit": 0})).is_err());
+    assert!(parse_call("search_tracks", &json!({"query": "a", "limit": 99})).is_err());
+    let call = parse_call("search_tracks", &json!({"query": " nude ", "limit": 3})).unwrap();
+    assert_eq!(
+      call,
+      DjToolCall::SearchTracks {
+        query: "nude".into(),
+        limit: 3
+      }
+    );
+  }
+
+  #[test]
+  fn queue_accepts_uris_and_named_pairs() {
+    let call = parse_call(
+      "queue_tracks",
+      &json!({"tracks": [
+        {"uri": "spotify:track:abc"},
+        {"title": "Nude", "artist": "Radiohead"}
+      ]}),
+    )
+    .unwrap();
+    let DjToolCall::QueueTracks {
+      items,
+      exclude_owned,
+      extra_skip_keys,
+    } = call
+    else {
+      panic!("expected QueueTracks");
+    };
+    assert_eq!(items[0], QueueItem::Uri("spotify:track:abc".into()));
+    assert!(matches!(&items[1], QueueItem::Named(s) if s.title == "Nude"));
+    assert!(
+      !exclude_owned,
+      "an agent told to queue a specific track must get it, even one the listener owns"
+    );
+    assert!(
+      extra_skip_keys.is_empty(),
+      "the wire can never fill this: it is the in-TUI DJ's own taste policy"
+    );
+
+    let call = parse_call(
+      "queue_tracks",
+      &json!({"tracks": [{"uri": "spotify:track:abc"}], "exclude_owned": true}),
+    )
+    .unwrap();
+    assert!(matches!(
+      call,
+      DjToolCall::QueueTracks {
+        exclude_owned: true,
+        ..
+      }
+    ));
+  }
+
+  #[test]
+  fn play_now_rejects_anything_that_is_not_a_single_track() {
+    // Rejected at parse time rather than reported as a failed execution: the
+    // tool takes exactly one URI, so a bad one is the whole request. It used to
+    // be dispatched blind, which stopped playback while reporting success.
+    for uri in [
+      "not-a-uri",
+      "spotify:album:1DFixLWuPkv3KT3TnV35m3",
+      "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+      "https://open.spotify.com/track/7o2AeQZzfCERsRmOM86EcB",
+    ] {
+      let error =
+        parse_call("play_now", &json!({"uri": uri})).expect_err(&format!("{uri} must not parse"));
+      let ToolCallError::InvalidArguments(detail) = error else {
+        panic!("{uri} should be an argument error, not an unknown tool");
+      };
+      // Names the shape that does work, so the model can fix it in one step.
+      assert!(detail.contains("spotify:track:"), "{uri}: {detail}");
+    }
+
+    for uri in ["spotify:track:abc", "file:/music/a.flac", "youtube:abc"] {
+      assert!(
+        parse_call("play_now", &json!({"uri": uri})).is_ok(),
+        "{uri}"
+      );
+    }
+  }
+
+  #[test]
+  fn play_now_needs_the_network_so_it_can_check_the_track_exists() {
+    // The lane split is what makes the existence check possible at all; the
+    // app-only lane has no Spotify client.
+    let call = parse_call("play_now", &json!({"uri": "spotify:track:abc"})).unwrap();
+    assert!(call.needs_network());
+  }
+
+  #[test]
+  fn exclude_owned_must_be_a_boolean_if_present() {
+    // A string "true" is the shape a model gets wrong; accepting it silently
+    // would turn the guarantee on (or off) by accident.
+    assert!(matches!(
+      parse_call(
+        "queue_tracks",
+        &json!({"tracks": [{"uri": "spotify:track:a"}], "exclude_owned": "true"})
+      ),
+      Err(ToolCallError::InvalidArguments(_))
+    ));
+    // Explicit null is the same as absent.
+    assert!(matches!(
+      parse_call(
+        "queue_tracks",
+        &json!({"tracks": [{"uri": "spotify:track:a"}], "exclude_owned": null})
+      ),
+      Ok(DjToolCall::QueueTracks {
+        exclude_owned: false,
+        ..
+      })
+    ));
+  }
+
+  #[test]
+  fn the_queue_schema_declares_exclude_owned_without_requiring_it() {
+    let schema = (spec("queue_tracks").unwrap().schema)();
+    let property = schema
+      .get("properties")
+      .and_then(|properties| properties.get("exclude_owned"))
+      .expect("exclude_owned must be declared, or clients cannot pass it");
+    assert_eq!(property.get("type"), Some(&json!("boolean")));
+    // `additionalProperties: false` means an undeclared param is rejected
+    // outright, so the schema and `parse_call` have to agree.
+    assert_eq!(
+      schema.get("additionalProperties"),
+      Some(&Value::Bool(false))
+    );
+    let required = schema
+      .get("required")
+      .and_then(Value::as_array)
+      .expect("tracks stays required");
+    assert!(
+      !required.contains(&json!("exclude_owned")),
+      "the default has to be usable without passing anything"
+    );
+  }
+
+  #[test]
+  fn queue_rejects_incomplete_entries_and_oversized_batches() {
+    assert!(parse_call("queue_tracks", &json!({"tracks": [{"title": "Nude"}]})).is_err());
+    assert!(parse_call("queue_tracks", &json!({"tracks": []})).is_err());
+    let too_many: Vec<_> = (0..MAX_BATCH + 1)
+      .map(|i| json!({"uri": format!("spotify:track:{i}")}))
+      .collect();
+    assert!(parse_call("queue_tracks", &json!({"tracks": too_many})).is_err());
+  }
+
+  #[tokio::test]
+  async fn setting_a_vibe_says_whether_anything_will_act_on_it() {
+    let app = Arc::new(Mutex::new(App::default()));
+    let outcome = execute_app_only(
+      &app,
+      &DjToolCall::SetDjVibe {
+        vibe: Some("mellow instrumental".into()),
+      },
+    )
+    .await
+    .expect("set_dj_vibe is answered without the network");
+
+    assert!(!outcome.is_error);
+    assert!(outcome.text.contains("mellow instrumental"));
+    assert_eq!(
+      app.lock().await.dj.vibe.as_deref(),
+      Some("mellow instrumental")
+    );
+
+    // The whole point: a bare "vibe set" lets an agent conclude the music is
+    // about to change. Nothing is refilling the queue in either build here, so
+    // the result has to say so and point at the fallback.
+    assert!(
+      outcome.text.contains("get_listening_history"),
+      "the agent needs to be told it can read the vibe back: {}",
+      outcome.text
+    );
+    assert!(
+      outcome.text.contains("no built-in auto-queue DJ"),
+      "with no in-TUI DJ there is nothing to switch on, and saying \"off\" would imply there is: {}",
+      outcome.text
+    );
+  }
+
+  #[tokio::test]
+  async fn clearing_a_vibe_stays_terse() {
+    // Nothing was set, so there is no expectation to correct.
+    let app = Arc::new(Mutex::new(App::default()));
+    let outcome = execute_app_only(&app, &DjToolCall::SetDjVibe { vibe: None })
+      .await
+      .unwrap();
+    assert_eq!(outcome.text, "DJ vibe cleared");
+    assert!(app.lock().await.dj.vibe.is_none());
+  }
+
+  #[test]
+  fn vibe_treats_blank_as_cleared() {
+    assert_eq!(
+      parse_call("set_dj_vibe", &json!({"vibe": "  "})).unwrap(),
+      DjToolCall::SetDjVibe { vibe: None }
+    );
+    assert_eq!(
+      parse_call("set_dj_vibe", &json!({"vibe": " mellow "})).unwrap(),
+      DjToolCall::SetDjVibe {
+        vibe: Some("mellow".into())
+      }
+    );
+  }
+
+  #[test]
+  fn needs_network_matches_the_spec_table() {
+    // The lane split depends on these agreeing; a mismatch would send a
+    // Spotify-dependent call to a Network built with no client.
+    for tool in TOOLS {
+      let args = match tool.name {
+        "search_tracks" => json!({"query": "x"}),
+        "queue_tracks" => json!({"tracks": [{"uri": "spotify:track:x"}]}),
+        "play_now" => json!({"uri": "spotify:track:x"}),
+        _ => json!({}),
+      };
+      let call = parse_call(tool.name, &args).unwrap();
+      assert_eq!(
+        call.needs_network(),
+        tool.needs_network,
+        "{} disagrees about needing the network",
+        tool.name
+      );
+      assert_eq!(call.tool_name(), tool.name);
+    }
+  }
+}

--- a/src/infra/dj/tools.rs
+++ b/src/infra/dj/tools.rs
@@ -351,7 +351,11 @@ pub fn parse_call(name: &str, args: &Value) -> Result<DjToolCall, ToolCallError>
           (Some(uri), _, _) if !uri.trim().is_empty() => {
             items.push(QueueItem::Uri(uri.trim().to_string()))
           }
-          (_, Some(title), Some(artist)) if !title.trim().is_empty() => {
+          // Both halves have to be real: a blank artist resolves to nothing, so
+          // accepting it would turn an argument error into a silent "not found".
+          (_, Some(title), Some(artist))
+            if !title.trim().is_empty() && !artist.trim().is_empty() =>
+          {
             items.push(QueueItem::Named(DjSuggestion {
               title: title.trim().to_string(),
               artist: artist.trim().to_string(),
@@ -563,9 +567,17 @@ async fn now_playing_outcome(app: &Arc<Mutex<App>>) -> ToolOutcome {
         }),
       )
     }
+    // Same keys as the playing branch, `is_live` included: a payload whose shape
+    // depends on playback state makes a client read a missing key as unknown
+    // rather than as "no, this is not a live stream".
     None => ToolOutcome::with_data(
       format!("Nothing is playing ({queue_depth} track(s) queued)"),
-      json!({"track": Value::Null, "is_playing": false, "queue_depth": queue_depth}),
+      json!({
+        "track": Value::Null,
+        "is_playing": false,
+        "is_live": false,
+        "queue_depth": queue_depth,
+      }),
     ),
   }
 }
@@ -841,10 +853,46 @@ mod tests {
   fn queue_rejects_incomplete_entries_and_oversized_batches() {
     assert!(parse_call("queue_tracks", &json!({"tracks": [{"title": "Nude"}]})).is_err());
     assert!(parse_call("queue_tracks", &json!({"tracks": []})).is_err());
+    // A blank half is as incomplete as a missing one. Accepted, it would build a
+    // suggestion nothing can resolve and be reported as "not in the catalogue",
+    // which tells the model the track does not exist instead of that it sent a
+    // bad argument.
+    for entry in [
+      json!({"title": "Nude", "artist": "   "}),
+      json!({"title": "  ", "artist": "Radiohead"}),
+    ] {
+      assert!(
+        matches!(
+          parse_call("queue_tracks", &json!({"tracks": [entry.clone()]})),
+          Err(ToolCallError::InvalidArguments(_))
+        ),
+        "{entry} should be an argument error"
+      );
+    }
     let too_many: Vec<_> = (0..MAX_BATCH + 1)
       .map(|i| json!({"uri": format!("spotify:track:{i}")}))
       .collect();
     assert!(parse_call("queue_tracks", &json!({"tracks": too_many})).is_err());
+  }
+
+  #[tokio::test]
+  async fn now_playing_keeps_one_payload_shape_whether_or_not_anything_plays() {
+    // A default `App` has no playback context and no native track, so the
+    // snapshot is `None` — the branch that used to drop `is_live`.
+    let app = Arc::new(Mutex::new(App::default()));
+    let outcome = execute_app_only(&app, &DjToolCall::GetNowPlaying)
+      .await
+      .expect("get_now_playing is answered without the network");
+    let data = outcome
+      .structured
+      .expect("now_playing returns structured data");
+
+    assert_eq!(data.get("track"), Some(&Value::Null));
+    assert_eq!(data.get("is_playing"), Some(&json!(false)));
+    // The key the playing branch always sends. Absent, a client cannot tell "not
+    // a live stream" from "this build never says".
+    assert_eq!(data.get("is_live"), Some(&json!(false)));
+    assert_eq!(data.get("queue_depth"), Some(&json!(0)));
   }
 
   #[tokio::test]

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,6 +1,8 @@
 pub mod audio;
 #[cfg(feature = "discord-rpc")]
 pub mod discord_rpc;
+#[cfg(feature = "dj-core")]
+pub mod dj;
 pub mod history;
 #[cfg(feature = "local-files")]
 pub mod local;

--- a/src/infra/network/dj.rs
+++ b/src/infra/network/dj.rs
@@ -1,0 +1,79 @@
+//! Network-lane handlers for the DJ.
+//!
+//! These run on the **serial** IoEvent lane, which is where the real Spotify
+//! client lives. The service lane deliberately constructs its `Network` with
+//! `None` for the client (`runtime.rs`), so anything that has to resolve a track
+//! name to a URI belongs here rather than there.
+
+use super::Network;
+use crate::infra::dj::{library, DjLibrary, DjLine};
+
+/// Helpers shared by both front doors.
+impl Network {
+  /// Serial lane: crawl the listener's own playlists for the avoid-library
+  /// filter, and cache the result on `App`.
+  ///
+  /// Idempotent by way of `library_indexing`: the in-TUI toggle, the first turn,
+  /// and an MCP `search_tracks` can all ask for this, and a second crawl would be
+  /// pure cost.
+  pub async fn dj_index_library(&mut self) {
+    let already = {
+      let mut app = self.app.lock().await;
+      let already = app.dj.library_indexing || app.dj.library.is_some();
+      if !already {
+        app.dj.library_indexing = true;
+      }
+      already
+    };
+    if already {
+      return;
+    }
+
+    let outcome = self.build_dj_library().await;
+    let mut app = self.app.lock().await;
+    app.dj.library_indexing = false;
+    match outcome {
+      Ok(library) => {
+        let summary = library.summary();
+        app.dj.library = Some(library);
+        app.dj.push_line(DjLine::system(summary.clone()));
+        app.set_status_message(format!("DJ: {summary}"), 5);
+      }
+      Err(e) => {
+        log::warn!("DJ: could not index the library: {e}");
+        let message = format!("DJ: could not read your playlists ({e}); recommending unfiltered");
+        app.dj.push_line(DjLine::system(message.clone()));
+        app.set_error_status_message(message, 8);
+      }
+    }
+  }
+
+  /// Run the crawl, resolving the listener's own account ID first.
+  async fn build_dj_library(&self) -> anyhow::Result<DjLibrary> {
+    if self.spotify.is_none() {
+      anyhow::bail!("no Spotify session");
+    }
+    let cached = {
+      self
+        .app
+        .lock()
+        .await
+        .user
+        .as_ref()
+        .map(|user| user.id.clone())
+    };
+    let owner_id = match cached {
+      Some(id) => id,
+      // Not fetched yet (or a source other than Spotify was browsed first). One
+      // cheap call rather than filtering against nothing.
+      None => {
+        #[derive(serde::Deserialize)]
+        struct Me {
+          id: String,
+        }
+        self.spotify_get_typed::<Me>("me", &[]).await?.id
+      }
+    };
+    library::build_index(self, &owner_id).await
+  }
+}

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dj-core")]
+pub mod dj;
 pub mod friends;
 pub mod ids;
 pub mod library;
@@ -279,6 +281,15 @@ pub enum IoEvent {
   /// auth.
   #[cfg(feature = "cover-art")]
   FetchCoverArt(crate::tui::cover_art::CoverArtRequest),
+  /// Crawl the listener's own playlists for the avoid-library filter.
+  ///
+  /// Serial lane: it needs the real Spotify client. Both front doors dispatch it
+  /// — the in-TUI DJ when the filter is switched on, and MCP from
+  /// `search_tracks` — so that marking results as owned never crawls *inside* a
+  /// latency-sensitive tool call. Neither exists yet, hence the allow.
+  #[cfg(feature = "dj-core")]
+  #[allow(dead_code)]
+  DjIndexLibrary,
 }
 
 /// An in-flight in-TUI Spotify login. Holds the exact PKCE client that generated
@@ -805,6 +816,10 @@ impl Network {
       #[cfg(feature = "cover-art")]
       IoEvent::FetchCoverArt(request) => {
         self.fetch_cover_art(request).await;
+      }
+      #[cfg(feature = "dj-core")]
+      IoEvent::DjIndexLibrary => {
+        self.dj_index_library().await;
       }
       IoEvent::GetUserTopTracks(time_range) => {
         self.get_user_top_tracks(time_range).await;

--- a/src/infra/network/search.rs
+++ b/src/infra/network/search.rs
@@ -14,9 +14,12 @@ pub struct ArtistSearchResponse {
   artists: Page<FullArtist>,
 }
 
+/// `pub(crate)` so the DJ resolver can reuse the track-search shape: unlike the
+/// handlers in this module, it needs a *returned* result rather than a write into
+/// `App` (see `crate::infra::dj::resolve`).
 #[derive(Deserialize, Debug)]
-struct TrackSearchResponse {
-  tracks: Page<FullTrack>,
+pub(crate) struct TrackSearchResponse {
+  pub(crate) tracks: Page<FullTrack>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
# Summary

Bottom of a 5-PR stack splitting the AI DJ / MCP server work (~16k lines) into
reviewable layers. Part of #196.

This PR adds the `dj-core` cargo feature: the implementation both DJ front
doors sit on, with neither door attached yet.

- The taste brief built from the local listening history (only aggregate
  track/artist/album names, no identifiers or timestamps)
- The name-to-URI resolver: suggestions the catalogue cannot confidently match
  are dropped rather than approximated
- The avoid-library index (Liked Songs plus owned/collaborative playlists)
- The shared tool table and bulk-enqueue plumbing, with `DjIndexLibrary` as
  the one IoEvent this layer needs

Nothing consumes `dj-core` on its own, so the module carries a crate-level
scoped `allow(dead_code)` that narrows as the front doors land in the next
PRs, and CI exercises it through the all-sources leg until the single-door
legs arrive.

The stack re-authors this work into layers, so commits here do not correspond
1:1 to `feat/ai-dj-mcp-server`; the tree at the top of the stack is verified
byte-identical to that branch. Stack: dj/core -> dj/mcp-server -> dj/brains ->
dj/screen -> dj/agent-plugin.

# Testing

- cargo fmt --all
- cargo clippy --locked --no-default-features --features telemetry -- -D warnings
- cargo clippy --locked --no-default-features --features telemetry,dj-core -- -D warnings
- cargo test --no-default-features --features telemetry (567 passed)
- cargo test --no-default-features --features telemetry,dj-core (612 passed)
- cargo check --locked
- clippy on the all-sources set minus audio-viz (that leg builds only in CI)

# Additional notes

Review scope for this PR is the shared layer only; the MCP server, the model
backends, the DJ screen, and the agent plugin each get their own PR in the
stack.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared AI DJ capabilities for listening-history summaries, playback context, music discovery, vibe control, and queue management.
  * AI DJ suggestions can resolve tracks from Spotify, with optional YouTube fallback and duplicate filtering.
  * Added playlist and liked-song library indexing to improve personalized recommendations.
* **Bug Fixes**
  * Improved queue validation for Spotify, local, Subsonic, and YouTube tracks.
  * Preserves user-added tracks when AI DJ queue content is refreshed or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->