### PR TITLE
feat(dj): the DJ's brains land before its screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,17 @@ jobs:
           # Keep this list in sync with cd.yml's `Build release binary` step
           # whenever a feature is added there, or the release build becomes the
           # first place a break shows up.
-          # `dj-core` is implied by both of them, so it is exercised here too.
           - name: all-sources
             args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
-          # `mcp-server` is the first front door onto `dj-core`, and it has to build
-          # on its own: this slim leg proves the MCP door compiles without the rest
-          # of the release feature set that all-sources turns on around it.
+          # `mcp-server` and `ai-dj` are two front doors on the same `dj-core`
+          # implementation, and each has to build without the other: the shared
+          # code is gated `any(mcp-server, ai-dj)`, so a gate that names only one
+          # of them still passes all-sources. Only a single-door leg catches it.
+          # Both are slim, so they cost a fraction of the all-sources leg.
           - name: mcp-only
             args: "--locked --no-default-features --features telemetry,mcp-server"
+          - name: ai-dj-only
+            args: "--locked --no-default-features --features telemetry,ai-dj"
           # Slim build used for fast local iteration (matches CLAUDE.md).
           - name: slim
             args: "--locked --no-default-features --features telemetry"
@@ -82,9 +85,11 @@ jobs:
             args: "--locked"
           - name: all-sources
             args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
-          # See the check job for why the mcp-only leg exists.
+          # See the check job for why the two single-door DJ legs exist.
           - name: mcp-only
             args: "--locked --no-default-features --features telemetry,mcp-server"
+          - name: ai-dj-only
+            args: "--locked --no-default-features --features telemetry,ai-dj"
           - name: slim
             args: "--locked --no-default-features --features telemetry"
     env:
@@ -136,9 +141,11 @@ jobs:
             args: "--locked"
           - name: all-sources
             args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
-          # See the check job for why the mcp-only leg exists.
+          # See the check job for why the two single-door DJ legs exist.
           - name: mcp-only
             args: "--locked --no-default-features --features telemetry,mcp-server"
+          - name: ai-dj-only
+            args: "--locked --no-default-features --features telemetry,ai-dj"
           - name: slim
             args: "--locked --no-default-features --features telemetry"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
             args: "--locked"
           # The exact feature set shipped for Linux by cd.yml, so every new
           # source subsystem (local-files, subsonic, internet-radio, youtube),
-          # cover-art, and the MCP server are compiled and tested in CI.
+          # cover-art, and both DJ front doors are compiled and tested in CI.
           # Keep this list in sync with cd.yml's `Build release binary` step
           # whenever a feature is added there, or the release build becomes the
           # first place a break shows up.
-          # `dj-core` is implied by `mcp-server`, so it is exercised here too.
+          # `dj-core` is implied by both of them, so it is exercised here too.
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # `mcp-server` is the first front door onto `dj-core`, and it has to build
           # on its own: this slim leg proves the MCP door compiles without the rest
           # of the release feature set that all-sources turns on around it.
@@ -81,7 +81,7 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # See the check job for why the mcp-only leg exists.
           - name: mcp-only
             args: "--locked --no-default-features --features telemetry,mcp-server"
@@ -135,7 +135,7 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # See the check job for why the mcp-only leg exists.
           - name: mcp-only
             args: "--locked --no-default-features --features telemetry,mcp-server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,10 @@ dj-core = []
 # LLM client and no API key are compiled in: `--features mcp-server` alone is a
 # complete "drive it from your coding agent" build.
 mcp-server = ["dj-core"]
+# The in-TUI DJ: a DJ screen with a chat prompt, continuous auto-queue and a
+# vibe-shift key, backed by a locally-installed agent CLI, an API key, or a local
+# model. Deliberately not in `default`: it egresses to a third-party provider.
+ai-dj = ["dj-core"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -49,7 +49,7 @@ pub fn queue_item_source(uri: &str) -> QueueItemSource {
 /// track at all, so the content after the prefix has to be non-empty: a model
 /// that emits the prefix and stops must be told the argument is wrong rather
 /// than have an empty handle queued for it.
-#[cfg_attr(not(feature = "mcp-server"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "mcp-server", feature = "ai-dj")), allow(dead_code))]
 pub fn is_playable_track_uri(uri: &str) -> bool {
   ["spotify:track:", "file:", "subsonic:", "youtube:"]
     .iter()
@@ -74,7 +74,7 @@ pub fn is_playable_track_uri(uri: &str) -> bool {
 /// plays through the Web API on an external Connect device, so
 /// [`source_available`]'s stricter answer (which is about the *native* player)
 /// would refuse a URI that works.
-#[cfg_attr(not(feature = "mcp-server"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "mcp-server", feature = "ai-dj")), allow(dead_code))]
 pub fn missing_source_feature(uri: &str) -> Option<&'static str> {
   let source = queue_item_source(uri);
   if source == QueueItemSource::Spotify || source_available(source) {

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -1741,10 +1741,16 @@ impl UserConfig {
         }
       }
       if let Some(dj_agent_command) = behavior_config.dj_agent_command {
-        if dj_agent_command.iter().any(|part| !part.trim().is_empty()) {
+        // Only argv[0] has to be a real word: it is the program to exec, and a
+        // blank one reaches `spawn` as a confusing ENOENT. Later arguments are
+        // left alone, since a CLI can legitimately take an empty one.
+        if dj_agent_command
+          .first()
+          .is_some_and(|program| !program.trim().is_empty())
+        {
           self.behavior.dj_agent_command = dj_agent_command;
         } else {
-          log::warn!("behavior.dj_agent_command is empty; keeping the default");
+          log::warn!("behavior.dj_agent_command has no program to run; keeping the default");
         }
       }
       if let Some(dj_agent_prompt_via) = behavior_config.dj_agent_prompt_via {
@@ -2973,8 +2979,13 @@ volume_increment: 5
     config.behavior.dj_agent_command = vec!["codex".to_string()];
     config.behavior.dj_agent_prompt_via = Some("arg".to_string());
     config.behavior.dj_agent_model = Some("haiku".to_string());
+    config.behavior.dj_agent_timeout_secs = 240;
+    config.behavior.dj_model = Some("some-model".to_string());
+    config.behavior.dj_base_url = Some("http://localhost:1234/v1".to_string());
+    config.behavior.dj_api_key = Some("sk-not-a-real-key".to_string());
 
-    // Mirrors what `save_config` writes, then reads it back.
+    // Mirrors what `save_config` writes, then reads it back. Every persisted DJ
+    // key belongs here: one left out is one a persistence regression keeps green.
     let written = serde_yaml::to_string(&BehaviorConfigString {
       dj_backend: Some(config.behavior.dj_backend.clone()),
       dj_batch_size: Some(config.behavior.dj_batch_size),
@@ -2982,6 +2993,10 @@ volume_increment: 5
       dj_agent_command: Some(config.behavior.dj_agent_command.clone()),
       dj_agent_prompt_via: config.behavior.dj_agent_prompt_via.clone(),
       dj_agent_model: config.behavior.dj_agent_model.clone(),
+      dj_agent_timeout_secs: Some(config.behavior.dj_agent_timeout_secs),
+      dj_model: config.behavior.dj_model.clone(),
+      dj_base_url: config.behavior.dj_base_url.clone(),
+      dj_api_key: config.behavior.dj_api_key.clone(),
       ..Default::default()
     })
     .unwrap();
@@ -2999,6 +3014,33 @@ volume_increment: 5
       Some("arg")
     );
     assert_eq!(reloaded.behavior.dj_agent_model.as_deref(), Some("haiku"));
+    assert_eq!(reloaded.behavior.dj_agent_timeout_secs, 240);
+    assert_eq!(reloaded.behavior.dj_model.as_deref(), Some("some-model"));
+    assert_eq!(
+      reloaded.behavior.dj_base_url.as_deref(),
+      Some("http://localhost:1234/v1")
+    );
+    assert_eq!(
+      reloaded.behavior.dj_api_key.as_deref(),
+      Some("sk-not-a-real-key")
+    );
+  }
+
+  /// argv[0] is the program to exec, so a blank one is no command at all.
+  #[cfg(feature = "ai-dj")]
+  #[test]
+  fn a_dj_agent_command_without_a_program_keeps_the_default() {
+    let default = super::default_dj_agent_command();
+
+    let config = loaded("dj_agent_command:\n  - '   '\n  - -p");
+    assert_eq!(
+      config.behavior.dj_agent_command, default,
+      "a blank argv[0] reaches spawn as a confusing ENOENT"
+    );
+
+    // A blank *later* argument is the user's business, so it still loads.
+    let config = loaded("dj_agent_command:\n  - claude\n  - ''");
+    assert_eq!(config.behavior.dj_agent_command, vec!["claude", ""]);
   }
 
   #[cfg(feature = "ai-dj")]

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -800,6 +800,26 @@ pub struct BehaviorConfigString {
   pub playbar_cover_art_size_percent: Option<u16>,
   #[cfg(feature = "mcp-server")]
   pub mcp_enabled: Option<bool>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_backend: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_command: Option<Vec<String>>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_prompt_via: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_timeout_secs: Option<u64>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_model: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_model: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_base_url: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_api_key: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_batch_size: Option<usize>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_history_period: Option<String>,
   pub keepawake_enabled: Option<bool>,
   pub enable_media_keys: Option<bool>,
   pub sync_token: Option<String>,
@@ -897,6 +917,54 @@ pub struct BehaviorConfig {
   /// `~/.config/spotatui/mcp.json`.
   #[cfg(feature = "mcp-server")]
   pub mcp_enabled: bool,
+  /// Which DJ brain to use: `agent_cli`, `anthropic`, or `openai_compat`.
+  #[cfg(feature = "ai-dj")]
+  pub dj_backend: String,
+  /// argv for the `agent_cli` backend. A config field rather than a hardcoded
+  /// table so any headless agent works and spotatui never tracks their flags.
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_command: Vec<String>,
+  /// How the prompt reaches that CLI: `stdin` or `arg`.
+  ///
+  /// `None` means "unset: the preset decides". It has to be optional, because a
+  /// resolved `String` here can never fall through to the preset's own mode, and
+  /// getting it wrong is not cosmetic: `agy` ignores stdin entirely, so a prompt
+  /// written there is silently dropped and the DJ answers something else.
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_prompt_via: Option<String>,
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_timeout_secs: u64,
+  /// Model for the `agent_cli` backend, passed as that CLI's own model flag
+  /// (`claude --model haiku`).
+  ///
+  /// Separate from [`Self::dj_model`] on purpose: they are different namespaces.
+  /// `dj_model` is an API model id billed per token; this is a CLI alias spent
+  /// against the subscription the CLI is already logged into. One field would make
+  /// `claude-haiku-4-5` and `haiku` interchangeable, and they are not.
+  #[cfg(feature = "ai-dj")]
+  pub dj_agent_model: Option<String>,
+  /// Model id for the API backends (`anthropic`, `openai_compat`).
+  #[cfg(feature = "ai-dj")]
+  pub dj_model: Option<String>,
+  /// Base URL for `openai_compat`. Defaults to Ollama's local endpoint.
+  #[cfg(feature = "ai-dj")]
+  pub dj_base_url: Option<String>,
+  /// API key for the HTTP backends.
+  ///
+  /// **Stored in plaintext in the YAML config** — prefer the
+  /// `SPOTATUI_DJ_API_KEY` environment variable, which overrides this field at
+  /// request time and is never written to disk. The config directory is `0700`
+  /// on unix and carries a `.gitignore`, but a plaintext secret is still a
+  /// plaintext secret.
+  #[cfg(feature = "ai-dj")]
+  pub dj_api_key: Option<String>,
+  /// How many tracks the DJ queues per round. Clamped to the resolver's cap.
+  #[cfg(feature = "ai-dj")]
+  pub dj_batch_size: usize,
+  /// History window the taste brief summarises: `7d`, `30d`, `month`, `year`,
+  /// `all`.
+  #[cfg(feature = "ai-dj")]
+  pub dj_history_period: String,
   pub keepawake_enabled: bool,
   /// When false, spotatui ignores OS media-control commands (headphone
   /// play/pause/skip buttons, media keys, MPRIS/SMTC/Now Playing, playerctl).
@@ -953,6 +1021,25 @@ pub struct BehaviorConfig {
   pub library_height_percent: Option<u8>,
   pub small_terminal_width: u16,
   pub small_terminal_height: u16,
+}
+
+/// The DJ brains a config may name. Module-level rather than a local `const` in
+/// the load validator so the validator and the picker cannot drift apart.
+#[cfg(feature = "ai-dj")]
+pub const DJ_BACKENDS: [&str; 3] = ["agent_cli", "anthropic", "openai_compat"];
+
+/// The shipped default backend.
+#[cfg(feature = "ai-dj")]
+pub const DEFAULT_DJ_BACKEND: &str = "agent_cli";
+
+/// The shipped default `agent_cli` argv.
+///
+/// A function rather than a `const` because it allocates, and one source of truth
+/// so nothing else has to keep a second copy of the argv spotatui ships in step
+/// with this one.
+#[cfg(feature = "ai-dj")]
+pub fn default_dj_agent_command() -> Vec<String> {
+  vec!["claude".to_string(), "-p".to_string()]
 }
 
 impl BehaviorConfig {
@@ -1211,6 +1298,28 @@ impl UserConfig {
         playbar_cover_art_size_percent: 100,
         #[cfg(feature = "mcp-server")]
         mcp_enabled: false,
+        #[cfg(feature = "ai-dj")]
+        dj_backend: DEFAULT_DJ_BACKEND.to_string(),
+        #[cfg(feature = "ai-dj")]
+        dj_agent_command: default_dj_agent_command(),
+        // Unset, so the preset's own delivery mode applies. Pinning "stdin" here
+        // would silently break `agy`, which reads the prompt from argv only.
+        #[cfg(feature = "ai-dj")]
+        dj_agent_prompt_via: None,
+        #[cfg(feature = "ai-dj")]
+        dj_agent_timeout_secs: 90,
+        #[cfg(feature = "ai-dj")]
+        dj_agent_model: None,
+        #[cfg(feature = "ai-dj")]
+        dj_model: None,
+        #[cfg(feature = "ai-dj")]
+        dj_base_url: None,
+        #[cfg(feature = "ai-dj")]
+        dj_api_key: None,
+        #[cfg(feature = "ai-dj")]
+        dj_batch_size: crate::infra::dj::DEFAULT_BATCH,
+        #[cfg(feature = "ai-dj")]
+        dj_history_period: "30d".to_string(),
         keepawake_enabled: true,
         enable_media_keys: true,
         sync_token: None,
@@ -1617,6 +1726,78 @@ impl UserConfig {
     #[cfg(feature = "mcp-server")]
     if let Some(mcp_enabled) = behavior_config.mcp_enabled {
       self.behavior.mcp_enabled = mcp_enabled;
+    }
+    #[cfg(feature = "ai-dj")]
+    {
+      if let Some(dj_backend) = behavior_config.dj_backend {
+        let normalized = dj_backend.trim().to_ascii_lowercase();
+        if DJ_BACKENDS.contains(&normalized.as_str()) {
+          self.behavior.dj_backend = normalized;
+        } else {
+          log::warn!(
+            "behavior.dj_backend '{dj_backend}' is not one of {DJ_BACKENDS:?}; keeping '{}'",
+            self.behavior.dj_backend
+          );
+        }
+      }
+      if let Some(dj_agent_command) = behavior_config.dj_agent_command {
+        if dj_agent_command.iter().any(|part| !part.trim().is_empty()) {
+          self.behavior.dj_agent_command = dj_agent_command;
+        } else {
+          log::warn!("behavior.dj_agent_command is empty; keeping the default");
+        }
+      }
+      if let Some(dj_agent_prompt_via) = behavior_config.dj_agent_prompt_via {
+        match crate::infra::dj::brain::agent_cli::PromptDelivery::from_config_str(
+          &dj_agent_prompt_via,
+        ) {
+          // Store the canonical form, so `arg`/`argv`/`last-arg` all read back the
+          // same way.
+          Some(delivery) => {
+            self.behavior.dj_agent_prompt_via = Some(delivery.to_config_str().to_string())
+          }
+          None => log::warn!(
+            "behavior.dj_agent_prompt_via '{dj_agent_prompt_via}' is not 'stdin' or 'arg';              keeping '{}'",
+            self
+              .behavior
+              .dj_agent_prompt_via
+              .as_deref()
+              .unwrap_or("unset")
+          ),
+        }
+      }
+      if let Some(secs) = behavior_config.dj_agent_timeout_secs {
+        // A sub-second timeout would kill every agent before it started.
+        self.behavior.dj_agent_timeout_secs = secs.clamp(5, 600);
+      }
+      if let Some(dj_agent_model) = behavior_config.dj_agent_model {
+        self.behavior.dj_agent_model =
+          Some(dj_agent_model).filter(|model| !model.trim().is_empty());
+      }
+      if let Some(dj_model) = behavior_config.dj_model {
+        self.behavior.dj_model = Some(dj_model).filter(|model| !model.trim().is_empty());
+      }
+      if let Some(dj_base_url) = behavior_config.dj_base_url {
+        self.behavior.dj_base_url = Some(dj_base_url).filter(|url| !url.trim().is_empty());
+      }
+      if let Some(dj_api_key) = behavior_config.dj_api_key {
+        self.behavior.dj_api_key = Some(dj_api_key).filter(|key| !key.trim().is_empty());
+      }
+      if let Some(dj_batch_size) = behavior_config.dj_batch_size {
+        self.behavior.dj_batch_size = dj_batch_size.clamp(1, crate::infra::dj::MAX_BATCH);
+      }
+      if let Some(dj_history_period) = behavior_config.dj_history_period {
+        const PERIODS: [&str; 5] = ["7d", "30d", "month", "year", "all"];
+        let normalized = dj_history_period.trim().to_ascii_lowercase();
+        if PERIODS.contains(&normalized.as_str()) {
+          self.behavior.dj_history_period = normalized;
+        } else {
+          log::warn!(
+            "behavior.dj_history_period '{dj_history_period}' is not one of {PERIODS:?};              keeping '{}'",
+            self.behavior.dj_history_period
+          );
+        }
+      }
     }
     if let Some(keepawake_enabled) = behavior_config.keepawake_enabled {
       self.behavior.keepawake_enabled = keepawake_enabled;
@@ -2094,6 +2275,28 @@ impl UserConfig {
       playbar_cover_art_size_percent: Some(self.behavior.playbar_cover_art_size_percent),
       #[cfg(feature = "mcp-server")]
       mcp_enabled: Some(self.behavior.mcp_enabled),
+      #[cfg(feature = "ai-dj")]
+      dj_backend: Some(self.behavior.dj_backend.clone()),
+      #[cfg(feature = "ai-dj")]
+      dj_agent_command: Some(self.behavior.dj_agent_command.clone()),
+      // Passed through rather than wrapped in `Some`: it is already an `Option`,
+      // and `null` on disk is what lets the preset decide.
+      #[cfg(feature = "ai-dj")]
+      dj_agent_prompt_via: self.behavior.dj_agent_prompt_via.clone(),
+      #[cfg(feature = "ai-dj")]
+      dj_agent_timeout_secs: Some(self.behavior.dj_agent_timeout_secs),
+      #[cfg(feature = "ai-dj")]
+      dj_agent_model: self.behavior.dj_agent_model.clone(),
+      #[cfg(feature = "ai-dj")]
+      dj_model: self.behavior.dj_model.clone(),
+      #[cfg(feature = "ai-dj")]
+      dj_base_url: self.behavior.dj_base_url.clone(),
+      #[cfg(feature = "ai-dj")]
+      dj_api_key: self.behavior.dj_api_key.clone(),
+      #[cfg(feature = "ai-dj")]
+      dj_batch_size: Some(self.behavior.dj_batch_size),
+      #[cfg(feature = "ai-dj")]
+      dj_history_period: Some(self.behavior.dj_history_period.clone()),
       keepawake_enabled: Some(self.behavior.keepawake_enabled),
       enable_media_keys: Some(self.behavior.enable_media_keys),
       // --- Phase 2/3/6 new fields (persist whatever the user set) ---
@@ -2711,6 +2914,118 @@ mod tests {
       serde_yaml::from_str("playbar_cover_art_size_percent: 250").unwrap();
     config.load_behaviorconfig(behavior).unwrap();
     assert_eq!(config.behavior.playbar_cover_art_size_percent, 200);
+  }
+
+  /// A config written by a build *with* the DJ features must still load in a
+  /// build without them, and vice versa.
+  ///
+  /// This is a real cross-build hazard, not a hypothetical: a user can save from
+  /// the Settings screen on an `ai-dj` build and then run a slim release binary.
+  /// `BehaviorConfigString` has no `deny_unknown_fields`, so serde ignores keys it
+  /// does not know — this test is what keeps that true if the derive ever changes.
+  #[test]
+  fn unknown_behavior_keys_are_ignored_rather_than_fatal() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    // Every DJ/MCP key, as an `ai-dj` + `mcp-server` build would write them,
+    // alongside a key that no build has ever had.
+    let yaml = "
+mcp_enabled: true
+dj_backend: openai_compat
+dj_agent_command:
+  - claude
+  - -p
+dj_agent_prompt_via: stdin
+dj_agent_timeout_secs: 120
+dj_agent_model: haiku
+dj_model: some-model
+dj_base_url: http://localhost:11434/v1
+dj_api_key: secret
+dj_batch_size: 7
+dj_history_period: 7d
+dj_configured: true
+a_key_from_the_future: 42
+volume_increment: 5
+";
+    let parsed: BehaviorConfigString =
+      serde_yaml::from_str(yaml).expect("unknown keys must not fail the parse");
+    // The key every build does understand still came through.
+    assert_eq!(parsed.volume_increment, Some(5));
+
+    // And the merge accepts it without erroring.
+    let mut config = UserConfig::new();
+    config
+      .load_behaviorconfig(parsed)
+      .expect("loading must not fail");
+    assert_eq!(config.behavior.volume_increment, 5);
+  }
+
+  /// The DJ keys a build *does* understand survive a save/load round trip.
+  #[cfg(feature = "ai-dj")]
+  #[test]
+  fn dj_behavior_keys_round_trip_through_yaml() {
+    use super::{BehaviorConfigString, UserConfig};
+
+    let mut config = UserConfig::new();
+    config.behavior.dj_backend = "openai_compat".to_string();
+    config.behavior.dj_batch_size = 7;
+    config.behavior.dj_history_period = "7d".to_string();
+    config.behavior.dj_agent_command = vec!["codex".to_string()];
+    config.behavior.dj_agent_prompt_via = Some("arg".to_string());
+    config.behavior.dj_agent_model = Some("haiku".to_string());
+
+    // Mirrors what `save_config` writes, then reads it back.
+    let written = serde_yaml::to_string(&BehaviorConfigString {
+      dj_backend: Some(config.behavior.dj_backend.clone()),
+      dj_batch_size: Some(config.behavior.dj_batch_size),
+      dj_history_period: Some(config.behavior.dj_history_period.clone()),
+      dj_agent_command: Some(config.behavior.dj_agent_command.clone()),
+      dj_agent_prompt_via: config.behavior.dj_agent_prompt_via.clone(),
+      dj_agent_model: config.behavior.dj_agent_model.clone(),
+      ..Default::default()
+    })
+    .unwrap();
+
+    let mut reloaded = UserConfig::new();
+    reloaded
+      .load_behaviorconfig(serde_yaml::from_str(&written).unwrap())
+      .unwrap();
+    assert_eq!(reloaded.behavior.dj_backend, "openai_compat");
+    assert_eq!(reloaded.behavior.dj_batch_size, 7);
+    assert_eq!(reloaded.behavior.dj_history_period, "7d");
+    assert_eq!(reloaded.behavior.dj_agent_command, vec!["codex"]);
+    assert_eq!(
+      reloaded.behavior.dj_agent_prompt_via.as_deref(),
+      Some("arg")
+    );
+    assert_eq!(reloaded.behavior.dj_agent_model.as_deref(), Some("haiku"));
+  }
+
+  #[cfg(feature = "ai-dj")]
+  fn loaded(yaml: &str) -> super::UserConfig {
+    use super::{BehaviorConfigString, UserConfig};
+    let mut config = UserConfig::new();
+    config
+      .load_behaviorconfig(serde_yaml::from_str::<BehaviorConfigString>(yaml).unwrap())
+      .unwrap();
+    config
+  }
+
+  #[cfg(feature = "ai-dj")]
+  #[test]
+  fn an_invalid_dj_agent_prompt_via_keeps_the_previous_value() {
+    let config = loaded("dj_agent_prompt_via: carrier pigeon");
+    assert_eq!(
+      config.behavior.dj_agent_prompt_via, None,
+      "unset stays unset, so the preset still decides"
+    );
+
+    let config = loaded("dj_agent_prompt_via: argv");
+    assert_eq!(
+      config.behavior.dj_agent_prompt_via.as_deref(),
+      Some("arg"),
+      "the canonical form is stored, not what the user typed"
+    );
   }
 
   #[test]

--- a/src/infra/dj/brain/agent_cli.rs
+++ b/src/infra/dj/brain/agent_cli.rs
@@ -1,0 +1,609 @@
+//! The agent-CLI brain: reuse a coding agent the user already has.
+//!
+//! `claude`, `codex`, `agy` (Antigravity, which replaced Google's Gemini CLI),
+//! and friends all run headless and read a prompt from stdin or argv, so spotatui
+//! can borrow whichever one the user already has installed and authenticated.
+//! **No API key is involved** — the agent uses the subscription it is already
+//! logged into.
+//!
+//! The command line is a **config field, not a hardcoded table**: the user
+//! supplies argv, spotatui writes the prompt and reads stdout. Presets exist as
+//! conveniences, but this is what makes the backend genuinely
+//! provider-agnostic, and it means spotatui never has to track any CLI's flag
+//! churn.
+//!
+//! Each step is a fresh subprocess with several seconds of startup cost, so a
+//! multi-step turn is genuinely expensive here — which is why [`super::super::agent`]
+//! caps the number of steps rather than letting a turn run as long as it likes.
+
+use super::{parse_step, system_prompt, user_prompt, DjRequest, DjStep};
+use anyhow::{anyhow, Context, Result};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// How the prompt reaches the CLI.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PromptDelivery {
+  /// Written to the child's stdin. Verified for `claude -p` and `codex exec -`.
+  #[default]
+  Stdin,
+  /// Appended as the final argv entry, so the preceding flag receives it as its
+  /// value. `agy` (and the legacy `gemini`) **require** this: `agy` ignores stdin
+  /// entirely, and a prompt written there is silently dropped in favour of
+  /// whatever the CLI decides to answer on its own.
+  Arg,
+}
+
+impl PromptDelivery {
+  pub fn from_config_str(value: &str) -> Option<Self> {
+    match value.trim().to_ascii_lowercase().as_str() {
+      "stdin" => Some(Self::Stdin),
+      "arg" | "argv" | "lastarg" | "last-arg" => Some(Self::Arg),
+      _ => None,
+    }
+  }
+
+  pub fn to_config_str(self) -> &'static str {
+    match self {
+      Self::Stdin => "stdin",
+      Self::Arg => "arg",
+    }
+  }
+}
+
+/// A known agent CLI: how to run it headless, and how to name a model.
+///
+/// Split into `base` + `delivery_argv` rather than one flat argv because the
+/// model flag has to land **between** them. [`AgentCliBrain::run`] appends the
+/// prompt as the last argv entry for [`PromptDelivery::Arg`], so a flag appended
+/// to the tail would swallow the prompt: `agy -p --model X "<prompt>"` passes
+/// `--model` as the value of `-p`. Verified argv shapes:
+///
+/// ```text
+/// claude --model haiku -p                 (prompt on stdin)
+/// codex exec --model gpt-5 -              (prompt on stdin, `-` is the positional)
+/// agy --model gemini-3.6-flash-low -p "…" (prompt as the value of -p)
+/// copilot --no-color --model … -p "…"     (prompt as the value of -p)
+/// opencode run -m openai/gpt-5.4 "…"      (prompt as a bare trailing positional)
+/// gemini -m … -p "…"                      (legacy)
+/// ```
+pub struct AgentPreset {
+  /// Lookup key. Also the binary name, which is what detection stats on `PATH`.
+  pub key: &'static str,
+  /// argv before the model flag. `base[0]` is the program.
+  pub base: &'static [&'static str],
+  /// argv after the model flag: the flag or positional that carries the prompt.
+  ///
+  /// Empty for a CLI that takes the prompt as a bare trailing positional
+  /// (`opencode run "…"`), since [`AgentCliBrain::run`] appends it either way.
+  pub delivery_argv: &'static [&'static str],
+  /// How this CLI names a model. `None` means it cannot be told.
+  pub model_flag: Option<&'static str>,
+  pub delivery: PromptDelivery,
+}
+
+impl AgentPreset {
+  /// Full argv, with the model flag inserted before the delivery token.
+  ///
+  /// `None` reproduces byte-for-byte what the flat preset table produced before
+  /// the model flag existed, which is what keeps an install that never chose a
+  /// model on exactly its previous behaviour.
+  pub fn argv(&self, model: Option<&str>) -> Vec<String> {
+    let mut argv: Vec<String> = self.base.iter().map(|part| part.to_string()).collect();
+    if let (Some(flag), Some(model)) = (self.model_flag, model) {
+      argv.push(flag.to_string());
+      argv.push(model.to_string());
+    }
+    argv.extend(self.delivery_argv.iter().map(|part| part.to_string()));
+    argv
+  }
+}
+
+/// Convenience presets. Verified against the installed CLIs' own `--help`.
+pub const PRESETS: &[AgentPreset] = &[
+  AgentPreset {
+    key: "claude",
+    base: &["claude"],
+    delivery_argv: &["-p"],
+    model_flag: Some("--model"),
+    delivery: PromptDelivery::Stdin,
+  },
+  AgentPreset {
+    key: "codex",
+    base: &["codex", "exec"],
+    delivery_argv: &["-"],
+    model_flag: Some("--model"),
+    delivery: PromptDelivery::Stdin,
+  },
+  // Antigravity, which replaced the Gemini CLI. `agy` IGNORES stdin: the prompt
+  // has to be the value of `-p`, so `Arg` here is load-bearing, not a preference.
+  AgentPreset {
+    key: "agy",
+    base: &["agy"],
+    delivery_argv: &["-p"],
+    model_flag: Some("--model"),
+    delivery: PromptDelivery::Arg,
+  },
+  // `--no-color` keeps ANSI escapes out of the JSON. A plain completion needs no
+  // `--allow-all-tools`, despite what the non-interactive help implies.
+  AgentPreset {
+    key: "copilot",
+    base: &["copilot", "--no-color"],
+    delivery_argv: &["-p"],
+    model_flag: Some("--model"),
+    delivery: PromptDelivery::Arg,
+  },
+  // The prompt is a trailing positional here, not a flag value, so nothing
+  // carries it and `delivery_argv` is empty.
+  AgentPreset {
+    key: "opencode",
+    base: &["opencode", "run"],
+    delivery_argv: &[],
+    model_flag: Some("-m"),
+    delivery: PromptDelivery::Arg,
+  },
+  // Legacy. Google superseded it with `agy`; kept so an existing config that
+  // names it keeps working.
+  AgentPreset {
+    key: "gemini",
+    base: &["gemini"],
+    delivery_argv: &["-p"],
+    model_flag: Some("-m"),
+    delivery: PromptDelivery::Arg,
+  },
+];
+
+/// Look up a preset by the binary name, for config convenience.
+pub fn preset(name: &str) -> Option<&'static AgentPreset> {
+  PRESETS.iter().find(|preset| preset.key == name)
+}
+
+#[derive(Debug)]
+pub struct AgentCliBrain {
+  command: Vec<String>,
+  prompt_via: PromptDelivery,
+  timeout: Duration,
+  cwd: PathBuf,
+}
+
+impl AgentCliBrain {
+  /// `cwd` should be a scratch directory, **not** the user's current directory.
+  ///
+  /// Coding agents read `CLAUDE.md` / `AGENTS.md` and project files from their
+  /// working directory. Pointed at a repository, the DJ gets a prompt polluted
+  /// with codebase context and starts suggesting tracks about Rust.
+  pub fn new(
+    command: Vec<String>,
+    prompt_via: PromptDelivery,
+    timeout: Duration,
+    cwd: PathBuf,
+  ) -> Result<Self> {
+    if command.is_empty() {
+      return Err(anyhow!(
+        "behavior.dj_agent_command is empty; set it to the agent CLI to run, e.g. [\"claude\", \"-p\"]"
+      ));
+    }
+    Ok(Self {
+      command,
+      prompt_via,
+      timeout,
+      cwd,
+    })
+  }
+
+  pub async fn step(&self, request: &DjRequest) -> Result<DjStep> {
+    let prompt = format!("{}\n\n{}", system_prompt(), user_prompt(request));
+    let stdout = self.run(&prompt).await?;
+    parse_step(&stdout).with_context(|| {
+      format!(
+        "could not read a decision out of `{}` output",
+        self.command.join(" ")
+      )
+    })
+  }
+
+  async fn run(&self, prompt: &str) -> Result<String> {
+    // The scratch directory is created lazily; a missing cwd makes `spawn` fail
+    // with a confusing ENOENT that looks like a missing binary.
+    if let Err(e) = tokio::fs::create_dir_all(&self.cwd).await {
+      log::debug!("DJ: could not create the agent scratch dir: {e}");
+    }
+
+    let (program, args) = self.command.split_first().expect("checked non-empty");
+    let mut command = Command::new(program);
+    command
+      .args(args)
+      .current_dir(&self.cwd)
+      .stdout(Stdio::piped())
+      .stderr(Stdio::piped())
+      .kill_on_drop(true);
+
+    match self.prompt_via {
+      PromptDelivery::Stdin => {
+        command.stdin(Stdio::piped());
+      }
+      PromptDelivery::Arg => {
+        command.arg(prompt).stdin(Stdio::null());
+      }
+    }
+
+    let mut child = command.spawn().with_context(|| {
+      format!("could not run `{program}`. Is it installed and on PATH? (behavior.dj_agent_command)")
+    })?;
+
+    if self.prompt_via == PromptDelivery::Stdin {
+      // Dropping stdin is what tells the CLI the prompt is complete; without it
+      // the child waits for more input and we hit the timeout instead.
+      let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("could not open stdin for `{program}`"))?;
+      stdin.write_all(prompt.as_bytes()).await?;
+      stdin.shutdown().await?;
+      drop(stdin);
+    }
+
+    let output = match tokio::time::timeout(self.timeout, child.wait_with_output()).await {
+      Ok(result) => result.with_context(|| format!("`{program}` failed to run"))?,
+      // `kill_on_drop` reaps the child when the future is dropped here.
+      Err(_) => {
+        return Err(anyhow!(
+          "`{program}` did not answer within {}s",
+          self.timeout.as_secs()
+        ))
+      }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if !output.status.success() {
+      let stderr = String::from_utf8_lossy(&output.stderr);
+      // Some CLIs write a usable answer to stdout and still exit non-zero, so
+      // only fail outright when there is nothing to read.
+      if stdout.trim().is_empty() {
+        return Err(anyhow!(
+          "`{program}` exited with {}: {}",
+          output.status,
+          stderr.trim().chars().take(300).collect::<String>()
+        ));
+      }
+      log::debug!("DJ: `{program}` exited non-zero but produced output; using it");
+    }
+    Ok(stdout)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn request() -> DjRequest {
+    DjRequest {
+      want: 2,
+      ..DjRequest::default()
+    }
+  }
+
+  /// Every agent stand-in these tests exec, keyed by name.
+  ///
+  /// **All of them are written before any test spawns anything, and that is the
+  /// point** — it is not merely tidier than writing each on demand.
+  ///
+  /// `fork` duplicates every file descriptor open in the process at that instant.
+  /// A test writing its stub while another test forks leaks a *writable* fd for
+  /// that stub into the new child, which holds it for the sliver of time before its
+  /// own `exec`. Exec'ing a file that any process holds open for writing fails with
+  /// `ETXTBSY`, so the first test lost a coin flip roughly one run in five.
+  ///
+  /// Renaming the file into place does **not** fix this: the stray fd refers to the
+  /// inode, which the rename carries along with it. Only ordering fixes it. Every
+  /// test calls [`stub`] before it spawns, and the first call writes the whole set
+  /// while the rest block on the `OnceLock`, so by the time any `fork` happens
+  /// there is no writable fd left to inherit.
+  ///
+  /// The directory is per-process for the adjacent reason: a fixed path collides
+  /// with a previous `cargo test` run still finishing.
+  fn stubs() -> &'static std::collections::HashMap<&'static str, PathBuf> {
+    static STUBS: std::sync::OnceLock<std::collections::HashMap<&'static str, PathBuf>> =
+      std::sync::OnceLock::new();
+    STUBS.get_or_init(|| {
+      let dir = std::env::temp_dir().join(format!("spotatui-dj-stubs-{}", std::process::id()));
+      std::fs::create_dir_all(&dir).unwrap();
+      [
+        (
+          "fake-dj",
+          r#"cat >/dev/null
+echo 'Here you go: ```json'
+echo '{"say":"Some mellow stuff.","tool_calls":[{"name":"queue_tracks","arguments":{"tracks":[{"title":"Weird Fishes","artist":"Radiohead"}]}}]}'
+echo '```'"#,
+        ),
+        // Echoes back what it read, so a prompt that never arrived fails the test
+        // rather than silently producing a generic answer.
+        (
+          "echo-dj",
+          r#"PROMPT=$(cat)
+case "$PROMPT" in
+  *"Take the next step now"*) echo '{"say":"got it","tool_calls":[]}' ;;
+  *) echo '{"say":"no prompt received","tool_calls":[]}' ;;
+esac"#,
+        ),
+        (
+          "arg-dj",
+          r#"case "$*" in
+  *"Take the next step now"*) echo '{"say":"via argv","tool_calls":[]}' ;;
+  *) echo '{"say":"missing","tool_calls":[]}' ;;
+esac"#,
+        ),
+        (
+          "grumpy-dj",
+          r#"cat >/dev/null
+echo '{"say":"fine","tool_calls":[]}'
+exit 3"#,
+        ),
+        (
+          "broken-dj",
+          r#"cat >/dev/null
+echo 'not logged in' >&2
+exit 1"#,
+        ),
+        ("chatty-dj", "cat >/dev/null\necho 'I would rather not.'"),
+        ("slow-dj", "sleep 30"),
+      ]
+      .into_iter()
+      .map(|(name, body)| {
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        #[cfg(unix)]
+        {
+          use std::os::unix::fs::PermissionsExt;
+          std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        (name, path)
+      })
+      .collect()
+    })
+  }
+
+  /// Path of one stand-in, as an argv entry.
+  fn stub(name: &str) -> String {
+    stubs()[name].to_string_lossy().to_string()
+  }
+
+  fn scratch() -> PathBuf {
+    std::env::temp_dir().join("spotatui-dj-scratch")
+  }
+
+  fn brain(argv: Vec<String>, delivery: PromptDelivery) -> AgentCliBrain {
+    AgentCliBrain::new(argv, delivery, Duration::from_secs(10), scratch()).unwrap()
+  }
+
+  #[test]
+  fn an_empty_command_is_rejected_with_an_actionable_message() {
+    let err = AgentCliBrain::new(
+      vec![],
+      PromptDelivery::Stdin,
+      Duration::from_secs(1),
+      scratch(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("dj_agent_command"));
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn reads_a_fenced_reply_from_stdout() {
+    let command = stub("fake-dj");
+    let reply = brain(vec![command.clone()], PromptDelivery::Stdin)
+      .step(&request())
+      .await
+      .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("Some mellow stuff."));
+    assert_eq!(reply.calls[0].name, "queue_tracks");
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn a_prior_tool_result_reaches_the_next_step() {
+    // The loop's whole premise: what a tool returned has to be in the next
+    // prompt, or the DJ cannot act on what it just learned.
+    let command = stub("echo-dj");
+    let request = DjRequest {
+      want: 2,
+      scratch: vec![super::super::ToolExchange {
+        name: "search_tracks".into(),
+        arguments: serde_json::json!({"query": "nude radiohead"}),
+        result: "Nude — Radiohead [spotify:track:abc] [new]".into(),
+      }],
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    assert!(prompt.contains("search_tracks"), "{prompt}");
+    assert!(prompt.contains("spotify:track:abc"), "{prompt}");
+    // And the stub still answers, so the enlarged prompt is still deliverable.
+    let reply = brain(vec![command], PromptDelivery::Stdin)
+      .step(&request)
+      .await
+      .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("got it"));
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn stdin_delivery_actually_sends_the_prompt() {
+    // Echoes back what it read, so a prompt that never arrived would fail here
+    // rather than silently producing a generic answer.
+    let command = stub("echo-dj");
+    let reply = brain(vec![command.clone()], PromptDelivery::Stdin)
+      .step(&request())
+      .await
+      .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("got it"));
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn arg_delivery_passes_the_prompt_as_the_final_argument() {
+    let command = stub("arg-dj");
+    let reply = brain(vec![command.clone()], PromptDelivery::Arg)
+      .step(&request())
+      .await
+      .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("via argv"));
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn a_nonzero_exit_with_usable_output_is_still_accepted() {
+    let command = stub("grumpy-dj");
+    let reply = brain(vec![command.clone()], PromptDelivery::Stdin)
+      .step(&request())
+      .await
+      .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("fine"));
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn a_nonzero_exit_with_no_output_reports_stderr() {
+    let command = stub("broken-dj");
+    let err = brain(vec![command.clone()], PromptDelivery::Stdin)
+      .step(&request())
+      .await
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("not logged in"), "{err}");
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn garbage_output_reports_which_command_produced_it() {
+    let command = stub("chatty-dj");
+    let err = brain(vec![command.clone()], PromptDelivery::Stdin)
+      .step(&request())
+      .await
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("chatty-dj"), "{err}");
+  }
+
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn a_hanging_cli_hits_the_timeout_instead_of_blocking_forever() {
+    let command = stub("slow-dj");
+    let brain = AgentCliBrain::new(
+      vec![command.clone()],
+      PromptDelivery::Arg,
+      Duration::from_millis(150),
+      scratch(),
+    )
+    .unwrap();
+    let err = brain.step(&request()).await.unwrap_err().to_string();
+    assert!(err.contains("did not answer within"), "{err}");
+  }
+
+  #[tokio::test]
+  async fn a_missing_binary_says_so_rather_than_failing_obscurely() {
+    let err = brain(
+      vec!["spotatui-definitely-not-a-real-binary".to_string()],
+      PromptDelivery::Stdin,
+    )
+    .step(&request())
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("Is it installed"), "{err}");
+  }
+
+  #[test]
+  fn presets_cover_the_installed_agents_and_round_trip() {
+    for entry in PRESETS {
+      let found = preset(entry.key).expect("every preset is findable by its key");
+      // The key doubles as the binary name, which is what PATH detection stats.
+      assert_eq!(found.base[0], entry.key);
+      assert_eq!(
+        PromptDelivery::from_config_str(entry.delivery.to_config_str()),
+        Some(entry.delivery)
+      );
+    }
+    assert!(preset("nonexistent-agent").is_none());
+  }
+
+  #[test]
+  fn a_preset_with_no_model_produces_exactly_the_argv_it_did_before() {
+    assert_eq!(preset("claude").unwrap().argv(None), vec!["claude", "-p"]);
+    assert_eq!(
+      preset("codex").unwrap().argv(None),
+      vec!["codex", "exec", "-"]
+    );
+    assert_eq!(preset("gemini").unwrap().argv(None), vec!["gemini", "-p"]);
+  }
+
+  #[test]
+  fn the_model_flag_lands_before_the_delivery_flag_for_arg_delivery() {
+    // `run` appends the prompt *after* this argv, so `-p` has to stay last or
+    // `--model` becomes the value of `-p` and the prompt is never delivered.
+    assert_eq!(
+      preset("agy").unwrap().argv(Some("gemini-3.6-flash-low")),
+      vec!["agy", "--model", "gemini-3.6-flash-low", "-p"]
+    );
+  }
+
+  #[test]
+  fn the_model_flag_lands_before_the_trailing_stdin_positional() {
+    assert_eq!(
+      preset("codex").unwrap().argv(Some("gpt-5")),
+      vec!["codex", "exec", "--model", "gpt-5", "-"]
+    );
+  }
+
+  #[test]
+  fn the_opencode_preset_appends_the_prompt_as_a_bare_positional() {
+    // `delivery_argv` is empty here, so nothing may be left dangling after the
+    // model flag for `run` to read as a value.
+    assert_eq!(
+      preset("opencode").unwrap().argv(Some("openai/gpt-5.4")),
+      vec!["opencode", "run", "-m", "openai/gpt-5.4"]
+    );
+    assert_eq!(
+      preset("opencode").unwrap().argv(None),
+      vec!["opencode", "run"]
+    );
+  }
+
+  #[test]
+  fn the_copilot_preset_keeps_p_last_so_it_receives_the_prompt() {
+    assert_eq!(
+      preset("copilot").unwrap().argv(Some("claude-sonnet-4.5")),
+      vec![
+        "copilot",
+        "--no-color",
+        "--model",
+        "claude-sonnet-4.5",
+        "-p"
+      ]
+    );
+  }
+
+  #[test]
+  fn the_agy_preset_delivers_the_prompt_as_an_argument() {
+    // Not a preference: `agy` reads nothing from stdin, so `Stdin` here would make
+    // it answer a question nobody asked.
+    assert_eq!(preset("agy").unwrap().delivery, PromptDelivery::Arg);
+  }
+
+  #[test]
+  fn prompt_delivery_parses_the_forms_a_user_might_write() {
+    assert_eq!(
+      PromptDelivery::from_config_str("STDIN"),
+      Some(PromptDelivery::Stdin)
+    );
+    assert_eq!(
+      PromptDelivery::from_config_str(" arg "),
+      Some(PromptDelivery::Arg)
+    );
+    assert_eq!(PromptDelivery::from_config_str("carrier pigeon"), None);
+  }
+}

--- a/src/infra/dj/brain/agent_cli.rs
+++ b/src/infra/dj/brain/agent_cli.rs
@@ -234,20 +234,39 @@ impl AgentCliBrain {
       format!("could not run `{program}`. Is it installed and on PATH? (behavior.dj_agent_command)")
     })?;
 
-    if self.prompt_via == PromptDelivery::Stdin {
+    let stdin = match self.prompt_via {
+      PromptDelivery::Stdin => Some(
+        child
+          .stdin
+          .take()
+          .ok_or_else(|| anyhow!("could not open stdin for `{program}`"))?,
+      ),
+      PromptDelivery::Arg => None,
+    };
+
+    // The write and the wait have to run *together*. The prompt is not small —
+    // it carries every tool schema plus this turn's tool results — and an agent
+    // CLI starts printing to stdout immediately. Writing it all first deadlocks
+    // once both pipes fill: we wait for the child to read, the child waits for
+    // us to read. Worse, that hang is in `write_all`, before the timeout below
+    // is ever armed, so the serial IoEvent pump stops for good.
+    let feed = async {
       // Dropping stdin is what tells the CLI the prompt is complete; without it
       // the child waits for more input and we hit the timeout instead.
-      let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| anyhow!("could not open stdin for `{program}`"))?;
-      stdin.write_all(prompt.as_bytes()).await?;
-      stdin.shutdown().await?;
-      drop(stdin);
-    }
+      if let Some(mut stdin) = stdin {
+        stdin.write_all(prompt.as_bytes()).await?;
+        stdin.shutdown().await?;
+      }
+      Ok::<_, std::io::Error>(())
+    };
+    let feed_and_wait = async {
+      let (written, output) = tokio::join!(feed, child.wait_with_output());
+      written.with_context(|| format!("could not send the prompt to `{program}`"))?;
+      output.with_context(|| format!("`{program}` failed to run"))
+    };
 
-    let output = match tokio::time::timeout(self.timeout, child.wait_with_output()).await {
-      Ok(result) => result.with_context(|| format!("`{program}` failed to run"))?,
+    let output = match tokio::time::timeout(self.timeout, feed_and_wait).await {
+      Ok(result) => result?,
       // `kill_on_drop` reaps the child when the future is dropped here.
       Err(_) => {
         return Err(anyhow!(
@@ -349,6 +368,22 @@ echo 'not logged in' >&2
 exit 1"#,
         ),
         ("chatty-dj", "cat >/dev/null\necho 'I would rather not.'"),
+        // Fills its stdout pipe *before* it reads a byte of stdin, which is what
+        // a real agent CLI does with its progress chatter. Feed it a prompt
+        // larger than the pipe buffer and only a concurrent write survives.
+        (
+          "backpressure-dj",
+          r#"i=0
+while [ $i -lt 2000 ]; do
+  echo 'still thinking .............................................................'
+  i=$((i + 1))
+done
+PROMPT=$(cat)
+case "$PROMPT" in
+  *"Take the next step now"*) echo '{"say":"drained","tool_calls":[]}' ;;
+  *) echo '{"say":"no prompt received","tool_calls":[]}' ;;
+esac"#,
+        ),
         ("slow-dj", "sleep 30"),
       ]
       .into_iter()
@@ -441,6 +476,42 @@ exit 1"#,
       .await
       .unwrap();
     assert_eq!(reply.say.as_deref(), Some("got it"));
+  }
+
+  /// A prompt bigger than the pipe buffer, against a CLI that talks first.
+  ///
+  /// Writing the whole prompt before collecting the output deadlocks here, and the
+  /// outer timeout is the point of the test: that hang lands in `write_all`,
+  /// *before* the brain arms its own timeout, so a regression would otherwise stop
+  /// the suite rather than fail it.
+  #[cfg(unix)]
+  #[tokio::test]
+  async fn a_prompt_larger_than_the_pipe_buffer_does_not_deadlock() {
+    let command = stub("backpressure-dj");
+    let request = DjRequest {
+      want: 2,
+      scratch: vec![super::super::ToolExchange {
+        name: "search_tracks".into(),
+        arguments: serde_json::json!({"query": "everything"}),
+        result: "Nude — Radiohead [spotify:track:abc] [new]\n".repeat(4000),
+      }],
+      ..DjRequest::default()
+    };
+    let prompt = format!("{}\n\n{}", system_prompt(), user_prompt(&request));
+    assert!(
+      prompt.len() > 64 * 1024,
+      "the prompt must exceed the pipe buffer to exercise this at all, was {}",
+      prompt.len()
+    );
+
+    let reply = tokio::time::timeout(
+      Duration::from_secs(30),
+      brain(vec![command], PromptDelivery::Stdin).step(&request),
+    )
+    .await
+    .expect("deadlocked: the prompt write must run alongside the output read")
+    .unwrap();
+    assert_eq!(reply.say.as_deref(), Some("drained"));
   }
 
   #[cfg(unix)]

--- a/src/infra/dj/brain/anthropic.rs
+++ b/src/infra/dj/brain/anthropic.rs
@@ -1,0 +1,318 @@
+//! The Anthropic Messages API brain.
+//!
+//! Raw HTTP rather than an SDK, because there is no official Anthropic SDK for
+//! Rust — which is the documented approach for an unsupported language.
+//!
+//! Two model-behaviour constraints are baked in and should not be "fixed" later:
+//!
+//! * **No sampling parameters.** Current models reject `temperature` / `top_p` /
+//!   `top_k` with a 400, so variety cannot come from a temperature knob. It comes
+//!   from rotating the history window and from asking for more candidates than
+//!   are queued.
+//! * **`stop_reason == "refusal"` must be checked before reading `content`**, or
+//!   a refused request panics on an empty array.
+//!
+//! Non-streaming on purpose: a DJ turn is one sentence plus a track list, well
+//! inside the client timeout, and streaming would buy nothing but machinery.
+
+use super::{parse_step, step_schema, system_prompt, user_prompt, DjRequest, DjStep};
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+pub const DEFAULT_MODEL: &str = "claude-haiku-4-5";
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+const API_VERSION: &str = "2023-06-01";
+const MAX_TOKENS: u32 = 2048;
+
+pub struct AnthropicBrain {
+  api_key: String,
+  model: String,
+  /// A field rather than a constant so the HTTP layer is testable against a local
+  /// listener. `friends.rs` hardcodes its URLs and consequently has no tests;
+  /// `requests.rs` threads a base URL and does.
+  base_url: String,
+  http: reqwest::Client,
+}
+
+impl AnthropicBrain {
+  pub fn new(api_key: String, model: Option<String>, base_url: Option<String>) -> Result<Self> {
+    if api_key.trim().is_empty() {
+      return Err(anyhow!(
+        "no API key for the Anthropic DJ backend. Set SPOTATUI_DJ_API_KEY, or \
+         behavior.dj_api_key in config.yml"
+      ));
+    }
+    Ok(Self {
+      api_key,
+      model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+      base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+      // Shared, and always with an explicit timeout — see `super::shared_client`.
+      http: super::shared_client(),
+    })
+  }
+
+  pub async fn step(&self, request: &DjRequest) -> Result<DjStep> {
+    let body = json!({
+      "model": self.model,
+      "max_tokens": MAX_TOKENS,
+      "system": system_prompt(),
+      "messages": [{ "role": "user", "content": user_prompt(request) }],
+      // Constrain the shape at the API level instead of asking nicely for JSON.
+      "output_config": { "format": { "type": "json_schema", "schema": step_schema() } },
+    });
+
+    let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+    let response = self
+      .http
+      .post(&url)
+      .header("x-api-key", &self.api_key)
+      .header("anthropic-version", API_VERSION)
+      .header("content-type", "application/json")
+      .json(&body)
+      .send()
+      .await
+      .map_err(|e| anyhow!("could not reach the Anthropic API: {e}"))?;
+
+    let status = response.status();
+    let payload: Value = response
+      .json()
+      .await
+      .map_err(|e| anyhow!("Anthropic API returned a body we could not read ({status}): {e}"))?;
+
+    if !status.is_success() {
+      let message = payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("no error message");
+      return Err(anyhow!("Anthropic API error {status}: {message}"));
+    }
+
+    // Checked before touching `content`: a refusal comes back as HTTP 200 with an
+    // empty content array, so indexing first would panic.
+    if payload.get("stop_reason").and_then(Value::as_str) == Some("refusal") {
+      let category = payload
+        .get("stop_details")
+        .and_then(|details| details.get("category"))
+        .and_then(Value::as_str)
+        .unwrap_or("unspecified");
+      return Err(anyhow!(
+        "the model declined this request (category: {category})"
+      ));
+    }
+
+    let text = first_text_block(&payload)
+      .ok_or_else(|| anyhow!("Anthropic API returned no text content"))?;
+    parse_step(&text)
+  }
+}
+
+/// Hand-written so the API key can never reach a log line or panic message.
+///
+/// A `#[derive(Debug)]` here would print the key verbatim anywhere the struct is
+/// formatted, which is exactly the accident this avoids.
+impl std::fmt::Debug for AnthropicBrain {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("AnthropicBrain")
+      .field("model", &self.model)
+      .field("base_url", &self.base_url)
+      .field("api_key", &"<redacted>")
+      .finish()
+  }
+}
+
+/// Concatenate the `text` blocks of a Messages API response.
+///
+/// A response may lead with `thinking` blocks, so filtering by type is required
+/// rather than reading `content[0]`.
+fn first_text_block(payload: &Value) -> Option<String> {
+  let blocks = payload.get("content")?.as_array()?;
+  let text = blocks
+    .iter()
+    .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+    .filter_map(|block| block.get("text").and_then(Value::as_str))
+    .collect::<Vec<_>>()
+    .join("\n");
+  (!text.trim().is_empty()).then_some(text)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+  use tokio::net::TcpListener;
+
+  fn request() -> DjRequest {
+    DjRequest {
+      want: 2,
+      ..DjRequest::default()
+    }
+  }
+
+  /// Minimal one-shot HTTP server, mirroring `network::requests`' test pattern
+  /// (there is no mockito/wiremock in this repo). Returns the request body.
+  async fn serve_once(status: &str, body: Value) -> (String, tokio::task::JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let status = status.to_string();
+    let handle = tokio::spawn(async move {
+      let (mut stream, _) = listener.accept().await.unwrap();
+      let (read_half, mut write_half) = stream.split();
+      let mut reader = BufReader::new(read_half);
+
+      // Read headers, note the declared length, then read exactly that body.
+      let mut content_length = 0usize;
+      loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+          content_length = value.trim().parse().unwrap_or(0);
+        }
+        if line == "\r\n" || line.is_empty() {
+          break;
+        }
+      }
+      let mut request_body = vec![0u8; content_length];
+      if content_length > 0 {
+        tokio::io::AsyncReadExt::read_exact(&mut reader, &mut request_body)
+          .await
+          .unwrap();
+      }
+
+      let payload = body.to_string();
+      write_half
+        .write_all(
+          format!(
+            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{payload}",
+            payload.len()
+          )
+          .as_bytes(),
+        )
+        .await
+        .unwrap();
+      write_half.flush().await.unwrap();
+      String::from_utf8_lossy(&request_body).to_string()
+    });
+    (base_url, handle)
+  }
+
+  fn brain(base_url: String) -> AnthropicBrain {
+    AnthropicBrain::new("test-key".into(), None, Some(base_url)).unwrap()
+  }
+
+  #[test]
+  fn a_blank_key_is_rejected_with_the_env_var_named() {
+    let err = AnthropicBrain::new("   ".into(), None, None)
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("SPOTATUI_DJ_API_KEY"));
+  }
+
+  #[tokio::test]
+  async fn parses_a_successful_reply() {
+    let (base_url, server) = serve_once(
+      "200 OK",
+      json!({
+        "stop_reason": "end_turn",
+        "content": [{"type": "text", "text": r#"{"say":"Mellow.","tool_calls":[{"name":"queue_tracks","arguments":{"tracks":[{"title":"Nude","artist":"Radiohead"}]}}]}"#}]
+      }),
+    )
+    .await;
+    let reply = brain(base_url).step(&request()).await.unwrap();
+    assert_eq!(reply.say.as_deref(), Some("Mellow."));
+    assert_eq!(reply.calls[0].name, "queue_tracks");
+    server.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn sends_no_sampling_parameters() {
+    // Current Anthropic models reject temperature/top_p/top_k with a 400, so
+    // this asserts we never send them.
+    let (base_url, server) = serve_once(
+      "200 OK",
+      json!({"stop_reason": "end_turn", "content": [{"type": "text", "text": r#"{"say":"ok","tracks":[]}"#}]}),
+    )
+    .await;
+    let _ = brain(base_url).step(&request()).await;
+    let sent = server.await.unwrap();
+    let body: Value = serde_json::from_str(&sent).unwrap();
+    assert!(body.get("temperature").is_none());
+    assert!(body.get("top_p").is_none());
+    assert!(body.get("top_k").is_none());
+    // And it does constrain the output shape at the API level.
+    assert_eq!(
+      body["output_config"]["format"]["type"],
+      json!("json_schema")
+    );
+    assert_eq!(body["model"], json!(DEFAULT_MODEL));
+  }
+
+  #[tokio::test]
+  async fn a_refusal_is_reported_rather_than_panicking_on_empty_content() {
+    // Regression guard: a refusal is HTTP 200 with `content: []`, so any code
+    // that reads content[0] first would panic here.
+    let (base_url, server) = serve_once(
+      "200 OK",
+      json!({"stop_reason": "refusal", "stop_details": {"category": "cyber"}, "content": []}),
+    )
+    .await;
+    let err = brain(base_url)
+      .step(&request())
+      .await
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("declined"), "{err}");
+    assert!(err.contains("cyber"), "{err}");
+    server.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn an_api_error_surfaces_the_servers_message() {
+    let (base_url, server) = serve_once(
+      "401 Unauthorized",
+      json!({"error": {"message": "invalid x-api-key"}}),
+    )
+    .await;
+    let err = brain(base_url)
+      .step(&request())
+      .await
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("invalid x-api-key"), "{err}");
+    server.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn thinking_blocks_before_the_text_are_skipped() {
+    let (base_url, server) = serve_once(
+      "200 OK",
+      json!({
+        "stop_reason": "end_turn",
+        "content": [
+          {"type": "thinking", "thinking": ""},
+          {"type": "text", "text": r#"{"say":"after thinking","tracks":[{"title":"A","artist":"B"}]}"#}
+        ]
+      }),
+    )
+    .await;
+    let reply = brain(base_url).step(&request()).await.unwrap();
+    assert_eq!(reply.say.as_deref(), Some("after thinking"));
+    server.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn a_response_with_no_text_content_is_an_error() {
+    let (base_url, server) = serve_once(
+      "200 OK",
+      json!({"stop_reason": "end_turn", "content": [{"type": "thinking", "thinking": ""}]}),
+    )
+    .await;
+    let err = brain(base_url)
+      .step(&request())
+      .await
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("no text content"), "{err}");
+    server.await.unwrap();
+  }
+}

--- a/src/infra/dj/brain/mod.rs
+++ b/src/infra/dj/brain/mod.rs
@@ -52,7 +52,15 @@ pub fn shared_client() -> reqwest::Client {
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(120))
         .build()
-        .unwrap_or_default()
+        .unwrap_or_else(|e| {
+          // Nothing can put the timeouts back: they only exist on the builder
+          // that just failed. Say so, so a DJ turn that hangs forever has a
+          // reason in the log rather than looking like a stuck model.
+          log::warn!(
+            "DJ: could not build the timed HTTP client ({e}); falling back to an untimed one"
+          );
+          reqwest::Client::default()
+        })
     })
     .clone()
 }
@@ -200,6 +208,13 @@ fn tool_catalogue() -> String {
 /// `arguments` is deliberately an unconstrained object: the per-tool schemas vary,
 /// and no single schema can describe them all. [`super::tools::parse_call`]
 /// validates the arguments properly once the tool is known.
+///
+/// That is also why this is **not** offered to OpenAI as a `strict` schema.
+/// Strict structured output requires `properties` and `additionalProperties:
+/// false` on every object, which a free-form argument bag cannot have; asking for
+/// strict anyway earns a 400 and a second, unstructured request on every turn.
+/// Non-strict, the schema is still sent and still guides the reply, and
+/// [`parse_step`] is tolerant enough to cover the rest.
 pub fn step_schema() -> Value {
   json!({
     "type": "object",
@@ -213,7 +228,8 @@ pub fn step_schema() -> Value {
             "name": {"type": "string", "enum": TOOLS.iter().map(|tool| tool.name).collect::<Vec<_>>()},
             "arguments": {"type": "object"}
           },
-          "required": ["name", "arguments"]
+          "required": ["name", "arguments"],
+          "additionalProperties": false
         }
       }
     },

--- a/src/infra/dj/brain/mod.rs
+++ b/src/infra/dj/brain/mod.rs
@@ -1,0 +1,709 @@
+//! The in-TUI DJ's "brain": where the DJ's decisions come from.
+//!
+//! Three backends behind one contract:
+//!
+//! * [`agent_cli`] — a coding agent the user already has installed and
+//!   authenticated (`claude`, `codex`, `copilot`, …). **No API key**, since it
+//!   rides their existing subscription.
+//! * [`anthropic`] — the Anthropic Messages API with a key.
+//! * [`openai_compat`] — anything speaking `/chat/completions`, which covers
+//!   OpenAI, OpenRouter, and local models via Ollama or LM Studio.
+//!
+//! ## One step at a time
+//!
+//! A brain does not answer a whole turn; it answers one **step** — some words for
+//! the listener, some tool calls, or both. [`super::agent`] runs the tools and
+//! calls back with the results, so the DJ can search before it commits, look at
+//! the queue, or simply ask a question and stop. A step with nothing to call is
+//! how a plain conversational reply happens.
+//!
+//! The tools are [`super::tools::TOOLS`] verbatim — the same table the MCP server
+//! publishes — so a tool added there is one the in-TUI DJ can use with no change
+//! here.
+//!
+//! **All three backends speak the same JSON step protocol** rather than each
+//! adopting its provider's native tool-calling. `agent_cli` is a one-shot
+//! subprocess and has no native form to adopt, and keeping one protocol means one
+//! prompt and one parser for all three. The two HTTP backends still get the shape
+//! enforced for them: [`step_schema`] is what they hand to structured output.
+
+pub mod agent_cli;
+pub mod anthropic;
+pub mod openai_compat;
+
+use super::brief::TasteBrief;
+use super::tools::TOOLS;
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Shared HTTP client for the DJ's API backends.
+///
+/// A blanket timeout is mandatory, not optional — the same reasoning as
+/// `network::requests::shared_http_client`: a hung request on the serial IoEvent
+/// pump would freeze every other event behind it. The window is generous because
+/// a reasoning model can legitimately take a while.
+pub fn shared_client() -> reqwest::Client {
+  static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+  CLIENT
+    .get_or_init(|| {
+      reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .unwrap_or_default()
+    })
+    .clone()
+}
+
+/// What the DJ is asked for, at one step of a turn.
+///
+/// `Default` exists for the test fixtures: the struct gains a field per prompt
+/// feature, and the backend tests' near-identical literals would each need
+/// updating for every one.
+#[derive(Default)]
+pub struct DjRequest {
+  pub brief: TasteBrief,
+  /// The conversation so far, oldest first, as `(speaker, text)`.
+  pub history: Vec<(String, String)>,
+  /// Tools already called *this turn*, with what they returned. Empty on the
+  /// first step; this is how the loop feeds results back.
+  pub scratch: Vec<ToolExchange>,
+  /// How many tracks to queue, when this turn queues any.
+  pub want: usize,
+  /// Whether the listener wants only tracks they do not already have. A hard
+  /// filter enforces this after the fact; saying it in the prompt is what stops
+  /// the model burning the whole batch on their favourites first.
+  pub avoid_library: bool,
+  /// Whether this turn must end in music rather than words.
+  ///
+  /// Set for an auto-queue refill and a vibe shift, where nobody is watching the
+  /// screen: a clarifying question there is indistinguishable from a hang.
+  pub must_act: bool,
+}
+
+/// One completed tool call, as the next step sees it.
+#[derive(Clone)]
+pub struct ToolExchange {
+  pub name: String,
+  pub arguments: Value,
+  /// What the tool returned, verbatim. Errors included — an error the model can
+  /// read is how it recovers without a repair round.
+  pub result: String,
+}
+
+/// A tool the model wants run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolInvocation {
+  pub name: String,
+  pub arguments: Value,
+}
+
+/// One step of a turn: something to say, something to run, or both.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DjStep {
+  /// A sentence for the transcript, if the model offered one.
+  pub say: Option<String>,
+  /// Empty means the turn is over — which is exactly what a conversational reply
+  /// looks like.
+  pub calls: Vec<ToolInvocation>,
+}
+
+/// The backends, dispatched by `match`.
+///
+/// Deliberately an enum rather than a trait: all three are known at compile time,
+/// and `async fn` in a trait object would need the `async-trait` crate — a new
+/// dependency for no benefit.
+#[derive(Debug)]
+pub enum DjBrain {
+  AgentCli(agent_cli::AgentCliBrain),
+  Anthropic(anthropic::AnthropicBrain),
+  OpenAiCompat(openai_compat::OpenAiCompatBrain),
+}
+
+impl DjBrain {
+  pub async fn step(&self, request: &DjRequest) -> Result<DjStep> {
+    match self {
+      Self::AgentCli(brain) => brain.step(request).await,
+      Self::Anthropic(brain) => brain.step(request).await,
+      Self::OpenAiCompat(brain) => brain.step(request).await,
+    }
+  }
+
+  /// Short label for status messages.
+  pub fn label(&self) -> &'static str {
+    match self {
+      Self::AgentCli(_) => "agent CLI",
+      Self::Anthropic(_) => "Anthropic",
+      Self::OpenAiCompat(_) => "OpenAI-compatible",
+    }
+  }
+}
+
+/// The system prompt every backend uses.
+///
+/// The tool list is rendered from [`TOOLS`], so the DJ inherits whatever the MCP
+/// server publishes.
+pub fn system_prompt() -> String {
+  format!(
+    "You are the DJ for a terminal music player, talking to the listener in a chat \
+     window. You can hold a conversation and you can act on the player.\n\n\
+     Work one step at a time. Each step you reply with ONLY a JSON object, no prose \
+     outside it:\n{}\n\n\
+     `say` is what the listener reads: a sentence or two, plain text.\n\
+     `tool_calls` is what you want run. Anything you call is executed and the \
+     results come straight back to you, so you can look something up, then decide.\n\n\
+     Rules:\n\
+     - Reply with words and NO tool calls when you are done, or when you would \
+       rather ask the listener something than guess. Asking is normal; do not queue \
+       music just to have done something.\n\
+     - Do not narrate a tool call you have not made. Call it, read the result, then \
+       tell the listener what actually happened.\n\
+     - When you queue, give real, existing tracks with their exact released titles \
+       and the primary artist. queue_tracks reports what it could not find, so read \
+       its result instead of assuming.\n\
+     - Do not repeat anything listed as recently played, queued, or now playing.\n\
+     - Vary the artists; do not queue several tracks by the same one unless asked.\n\n\
+     Tools:\n{}",
+    step_shape_hint(),
+    tool_catalogue()
+  )
+}
+
+fn step_shape_hint() -> String {
+  json!({
+    "say": "what the listener reads, or empty",
+    "tool_calls": [{"name": "a tool name", "arguments": {}}]
+  })
+  .to_string()
+}
+
+/// The tool table as prompt text: name, what it does, and its argument schema.
+fn tool_catalogue() -> String {
+  TOOLS
+    .iter()
+    .map(|tool| {
+      format!(
+        "- {}: {}\n  arguments: {}",
+        tool.name,
+        tool.description,
+        (tool.schema)()
+      )
+    })
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+/// The JSON Schema backends use to constrain a step, where they support it.
+///
+/// `arguments` is deliberately an unconstrained object: the per-tool schemas vary,
+/// and no single schema can describe them all. [`super::tools::parse_call`]
+/// validates the arguments properly once the tool is known.
+pub fn step_schema() -> Value {
+  json!({
+    "type": "object",
+    "properties": {
+      "say": {"type": "string"},
+      "tool_calls": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string", "enum": TOOLS.iter().map(|tool| tool.name).collect::<Vec<_>>()},
+            "arguments": {"type": "object"}
+          },
+          "required": ["name", "arguments"]
+        }
+      }
+    },
+    "required": ["say", "tool_calls"],
+    "additionalProperties": false
+  })
+}
+
+/// The user-turn text: the taste brief, the conversation, and the ask.
+pub fn user_prompt(request: &DjRequest) -> String {
+  let mut prompt = request.brief.to_prompt_block();
+
+  if !request.history.is_empty() {
+    prompt.push_str("\nConversation so far:\n");
+    for (speaker, text) in &request.history {
+      prompt.push_str(&format!("{speaker}: {text}\n"));
+    }
+  }
+
+  if !request.scratch.is_empty() {
+    prompt.push_str("\nTools you have already run this turn:\n");
+    for exchange in &request.scratch {
+      prompt.push_str(&format!(
+        "{}({}) returned:\n{}\n\n",
+        exchange.name, exchange.arguments, exchange.result
+      ));
+    }
+  }
+
+  if request.avoid_library {
+    prompt.push_str(
+      "\nThe listener only wants tracks they do NOT already own. Anything already \
+       in their Liked Songs or their own playlists will be rejected, so avoid the \
+       obvious well-known picks for this taste and reach for adjacent artists, \
+       deeper album cuts, and newer releases instead.\n",
+    );
+  }
+
+  prompt.push_str(&if request.must_act {
+    // No listener is watching a refill, so a question here reads as a hang.
+    format!(
+      "\nQueue {} track(s) now with queue_tracks, naming them by title and artist — \
+       it resolves names itself, so do not spend a step searching first. Do not ask \
+       any questions; nobody is watching. Reply with only the JSON object.",
+      request.want
+    )
+  } else {
+    format!(
+      "\nTake the next step now. Queue about {} track(s) if this is the point at \
+       which you queue. Reply with only the JSON object.",
+      request.want
+    )
+  });
+  prompt
+}
+
+/// Pull a [`DjStep`] out of whatever a backend produced.
+///
+/// Deliberately tolerant. A structured-output request gives back bare JSON, but
+/// an agent CLI wraps its answer in prose and often a ```json fence — and each
+/// CLI does it differently. Scanning for the JSON is uniform across all of them
+/// and survives version bumps in any of them.
+pub fn parse_step(raw: &str) -> Result<DjStep> {
+  let candidate = extract_json_object(raw)
+    .ok_or_else(|| anyhow!("no JSON object found in the reply: {}", truncate(raw, 200)))?;
+  let value: Value = serde_json::from_str(&candidate).map_err(|e| {
+    anyhow!(
+      "reply was not valid JSON ({e}): {}",
+      truncate(&candidate, 200)
+    )
+  })?;
+
+  let say = value
+    .get("say")
+    .and_then(Value::as_str)
+    .map(str::trim)
+    .filter(|say| !say.is_empty())
+    .map(str::to_string);
+
+  let mut calls: Vec<ToolInvocation> = value
+    .get("tool_calls")
+    .and_then(Value::as_array)
+    .map(|calls| {
+      calls
+        .iter()
+        .filter_map(|call| {
+          let name = call.get("name").and_then(Value::as_str)?.trim();
+          if name.is_empty() {
+            return None;
+          }
+          Some(ToolInvocation {
+            name: name.to_string(),
+            // A tool taking no arguments is often written without the key at all.
+            arguments: call.get("arguments").cloned().unwrap_or_else(|| json!({})),
+          })
+        })
+        .collect()
+    })
+    .unwrap_or_default();
+
+  // A bare `tracks` array is not the protocol, but small local models fall back to
+  // it constantly. Reading it as the queue call it plainly means costs ten lines
+  // and is the difference between a weak model working and doing nothing.
+  if calls.is_empty() {
+    if let Some(tracks) = value.get("tracks").and_then(Value::as_array) {
+      if !tracks.is_empty() {
+        calls.push(ToolInvocation {
+          name: "queue_tracks".to_string(),
+          arguments: json!({ "tracks": tracks }),
+        });
+      }
+    }
+  }
+
+  if calls.is_empty() && say.is_none() {
+    return Err(anyhow!(
+      "reply contained neither a message nor any tool calls"
+    ));
+  }
+  Ok(DjStep { say, calls })
+}
+
+/// Find the JSON object in a blob of text.
+///
+/// Prefers the **last** fenced ```json block, then the last balanced `{…}` run:
+/// a model that reasons out loud before answering tends to put the real answer
+/// last, and an agent CLI may echo the requested shape from the prompt before
+/// producing its own.
+fn extract_json_object(raw: &str) -> Option<String> {
+  if let Some(fenced) = last_fenced_block(raw) {
+    if let Some(object) = last_balanced_object(&fenced) {
+      return Some(object);
+    }
+  }
+  last_balanced_object(raw)
+}
+
+fn last_fenced_block(raw: &str) -> Option<String> {
+  let mut blocks = Vec::new();
+  let mut rest = raw;
+  while let Some(start) = rest.find("```") {
+    let after = &rest[start + 3..];
+    // Skip an optional language tag on the fence line.
+    let body_start = after.find('\n').map(|i| i + 1).unwrap_or(after.len());
+    let body = &after[body_start..];
+    match body.find("```") {
+      Some(end) => {
+        blocks.push(body[..end].to_string());
+        rest = &body[end + 3..];
+      }
+      // Unterminated fence: take the remainder, since a truncated reply is
+      // still worth trying to read.
+      None => {
+        blocks.push(body.to_string());
+        break;
+      }
+    }
+  }
+  blocks.pop()
+}
+
+/// The last top-level balanced `{…}` in `raw`, ignoring braces inside strings.
+fn last_balanced_object(raw: &str) -> Option<String> {
+  let bytes = raw.as_bytes();
+  let mut best: Option<(usize, usize)> = None;
+  let mut start: Option<usize> = None;
+  let mut depth = 0usize;
+  let mut in_string = false;
+  let mut escaped = false;
+
+  for (index, &byte) in bytes.iter().enumerate() {
+    if in_string {
+      if escaped {
+        escaped = false;
+      } else if byte == b'\\' {
+        escaped = true;
+      } else if byte == b'"' {
+        in_string = false;
+      }
+      continue;
+    }
+    match byte {
+      b'"' => in_string = true,
+      b'{' => {
+        if depth == 0 {
+          start = Some(index);
+        }
+        depth += 1;
+      }
+      b'}' => {
+        depth = depth.saturating_sub(1);
+        if depth == 0 {
+          if let Some(open) = start.take() {
+            best = Some((open, index + 1));
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+  best.map(|(open, close)| raw[open..close].to_string())
+}
+
+fn truncate(value: &str, max: usize) -> String {
+  let trimmed = value.trim();
+  if trimmed.chars().count() <= max {
+    return trimmed.to_string();
+  }
+  trimmed.chars().take(max).collect::<String>() + "…"
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_a_bare_json_step() {
+    let step = parse_step(
+      r#"{"say":"Here you go.","tool_calls":[{"name":"queue_tracks","arguments":{"tracks":[{"title":"Nude","artist":"Radiohead"}]}}]}"#,
+    )
+    .unwrap();
+    assert_eq!(step.say.as_deref(), Some("Here you go."));
+    assert_eq!(step.calls.len(), 1);
+    assert_eq!(step.calls[0].name, "queue_tracks");
+  }
+
+  #[test]
+  fn a_step_with_words_and_no_calls_is_a_conversational_reply() {
+    // The whole point of the loop's terminal case: the DJ is allowed to just talk.
+    let step =
+      parse_step(r#"{"say":"Instrumental, or are vocals fine?","tool_calls":[]}"#).unwrap();
+    assert_eq!(
+      step.say.as_deref(),
+      Some("Instrumental, or are vocals fine?")
+    );
+    assert!(step.calls.is_empty());
+  }
+
+  #[test]
+  fn parses_a_fenced_step_wrapped_in_prose() {
+    // What an agent CLI actually emits.
+    let raw = "Sure! Here's a mellow set for you.\n\n```json\n{\"say\":\"Mellow.\",\"tool_calls\":[{\"name\":\"get_queue\",\"arguments\":{}}]}\n```\n\nLet me know if you want more.";
+    let step = parse_step(raw).unwrap();
+    assert_eq!(step.say.as_deref(), Some("Mellow."));
+    assert_eq!(step.calls[0].name, "get_queue");
+  }
+
+  #[test]
+  fn prefers_the_last_fenced_block_when_the_prompt_shape_is_echoed() {
+    // Regression guard: a CLI that repeats the requested shape before answering
+    // must not have the example parsed as the answer.
+    let raw = concat!(
+      "I'll use this shape:\n```json\n{\"say\":\"what the listener reads\",\"tool_calls\":[]}\n```\n",
+      "Here is the actual set:\n```json\n{\"say\":\"Real answer.\",\"tool_calls\":[{\"name\":\"skip_track\",\"arguments\":{}}]}\n```"
+    );
+    let step = parse_step(raw).unwrap();
+    assert_eq!(step.say.as_deref(), Some("Real answer."));
+    assert_eq!(step.calls.len(), 1);
+  }
+
+  #[test]
+  fn handles_an_unlabelled_fence() {
+    let raw =
+      "```\n{\"say\":\"ok\",\"tool_calls\":[{\"name\":\"get_queue\",\"arguments\":{}}]}\n```";
+    assert_eq!(parse_step(raw).unwrap().calls.len(), 1);
+  }
+
+  #[test]
+  fn a_call_with_no_arguments_key_is_still_a_call() {
+    // Models routinely omit `arguments` for a no-argument tool.
+    let step = parse_step(r#"{"say":"","tool_calls":[{"name":"get_now_playing"}]}"#).unwrap();
+    assert_eq!(step.calls[0].name, "get_now_playing");
+    assert_eq!(step.calls[0].arguments, json!({}));
+  }
+
+  #[test]
+  fn a_bare_tracks_array_is_read_as_the_queue_call_it_means() {
+    // Small local models fall back to this shape constantly; reading it is the
+    // difference between one of them working and doing nothing at all.
+    let step =
+      parse_step(r#"{"say":"ok","tracks":[{"title":"Nude","artist":"Radiohead"}]}"#).unwrap();
+    assert_eq!(step.calls.len(), 1);
+    assert_eq!(step.calls[0].name, "queue_tracks");
+    assert_eq!(step.calls[0].arguments["tracks"][0]["title"], json!("Nude"));
+
+    // But an explicit tool call always wins over it.
+    let both = parse_step(
+      r#"{"say":"ok","tracks":[{"title":"A","artist":"B"}],"tool_calls":[{"name":"skip_track","arguments":{}}]}"#,
+    )
+    .unwrap();
+    assert_eq!(both.calls.len(), 1);
+    assert_eq!(both.calls[0].name, "skip_track");
+  }
+
+  #[test]
+  fn braces_inside_strings_do_not_confuse_the_scanner() {
+    let raw = r#"{"say":"a } brace { inside","tool_calls":[{"name":"get_queue","arguments":{}}]}"#;
+    let step = parse_step(raw).unwrap();
+    assert_eq!(step.say.as_deref(), Some("a } brace { inside"));
+    assert_eq!(step.calls.len(), 1);
+  }
+
+  #[test]
+  fn escaped_quotes_inside_strings_are_handled() {
+    let raw = r#"{"say":"they said \"hi\"","tool_calls":[]}"#;
+    assert_eq!(
+      parse_step(raw).unwrap().say.as_deref(),
+      Some("they said \"hi\"")
+    );
+  }
+
+  #[test]
+  fn a_call_missing_a_name_is_dropped_not_fatal() {
+    let raw = r#"{"say":"ok","tool_calls":[{"arguments":{}},{"name":"get_queue","arguments":{}}]}"#;
+    let step = parse_step(raw).unwrap();
+    assert_eq!(step.calls.len(), 1);
+    assert_eq!(step.calls[0].name, "get_queue");
+  }
+
+  #[test]
+  fn a_reply_with_neither_message_nor_calls_is_an_error() {
+    assert!(parse_step(r#"{"tool_calls":[]}"#).is_err());
+  }
+
+  #[test]
+  fn non_json_output_is_an_error_naming_what_was_seen() {
+    let err = parse_step("I'm afraid I can't do that.")
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains("no JSON object"));
+    assert!(err.contains("can't do that"));
+  }
+
+  #[test]
+  fn truncated_json_reports_a_parse_failure() {
+    let err = parse_step(r#"{"say":"oops","tool_calls":[{"name":"#)
+      .unwrap_err()
+      .to_string();
+    assert!(
+      err.contains("no JSON object") || err.contains("not valid JSON"),
+      "{err}"
+    );
+  }
+
+  #[test]
+  fn the_prompt_offers_every_tool_the_mcp_server_publishes() {
+    // Iterated rather than listed, so a tool added to the table fails this until
+    // the in-TUI DJ can see it too. That inheritance is the point of the design.
+    let prompt = system_prompt();
+    for tool in TOOLS {
+      assert!(prompt.contains(tool.name), "{} is not offered", tool.name);
+    }
+    let names = step_schema()["properties"]["tool_calls"]["items"]["properties"]["name"]["enum"]
+      .as_array()
+      .unwrap()
+      .clone();
+    assert_eq!(names.len(), TOOLS.len(), "the schema must offer them too");
+  }
+
+  #[test]
+  fn a_tool_result_reaches_the_next_step_verbatim() {
+    let request = DjRequest {
+      want: 5,
+      scratch: vec![ToolExchange {
+        name: "queue_tracks".into(),
+        arguments: json!({"tracks": []}),
+        result: "Not found (skipped): Ghost Track — Nobody".into(),
+      }],
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    // How the model learns to stop naming a track that does not exist. It replaces
+    // the old repair round, which had to be told the same thing out of band.
+    assert!(prompt.contains("Ghost Track — Nobody"));
+    assert!(prompt.contains("queue_tracks"));
+  }
+
+  #[test]
+  fn a_must_act_turn_is_told_to_queue_without_asking() {
+    // Nobody is watching an auto-queue refill, so a question there is a hang.
+    let request = DjRequest {
+      want: 6,
+      must_act: true,
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    assert!(prompt.contains("Queue 6 track(s) now"));
+    assert!(prompt.contains("Do not ask any questions"));
+    // And it must not spend one of its two steps on a search it does not need.
+    assert!(prompt.contains("do not spend a step searching"));
+
+    let conversational = DjRequest {
+      want: 6,
+      ..DjRequest::default()
+    };
+    assert!(!user_prompt(&conversational).contains("Do not ask any questions"));
+  }
+
+  #[test]
+  fn conversation_history_is_included_in_order() {
+    let request = DjRequest {
+      history: vec![
+        ("Listener".into(), "something chill".into()),
+        ("DJ".into(), "here you go".into()),
+      ],
+      want: 3,
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    let chill = prompt.find("something chill").unwrap();
+    let here = prompt.find("here you go").unwrap();
+    assert!(chill < here, "history must stay in order");
+  }
+
+  #[test]
+  fn the_last_listener_line_is_the_live_request() {
+    // Load-bearing: there is no separate instruction slot, so what the listener
+    // typed reaches the model *only* as the final history line — which is why the
+    // handler pushes it to the transcript and does not also pass it alongside.
+    let request = DjRequest {
+      history: vec![
+        ("Listener".into(), "something chill".into()),
+        ("DJ".into(), "here you go".into()),
+        ("Listener".into(), "now something faster".into()),
+      ],
+      want: 3,
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    assert_eq!(
+      prompt.matches("now something faster").count(),
+      1,
+      "the ask must appear once, not once per delivery route"
+    );
+    let ask = prompt.find("now something faster").unwrap();
+    assert!(ask > prompt.find("Conversation so far:").unwrap());
+    assert!(
+      ask < prompt.find("Take the next step now").unwrap(),
+      "the newest line has to sit immediately before the ask to read as the request"
+    );
+  }
+
+  #[test]
+  fn the_avoid_library_prompt_asks_for_the_unfamiliar() {
+    let request = DjRequest {
+      want: 6,
+      avoid_library: true,
+      ..DjRequest::default()
+    };
+    let prompt = user_prompt(&request);
+    assert!(prompt.contains("do NOT already own"));
+    // Without this steer the model reaches for the listener's favourites first and
+    // the filter eats the batch.
+    assert!(prompt.contains("newer releases"));
+
+    let off = DjRequest {
+      want: 6,
+      ..DjRequest::default()
+    };
+    assert!(!user_prompt(&off).contains("already own"));
+  }
+
+  #[test]
+  fn real_agent_cli_output_parses_noise_and_all() {
+    // Captured verbatim from `copilot --no-color -p "<the real prompt>"`. It
+    // narrates its own shell activity on *stdout* before the answer, which is
+    // exactly why the parser scans for the last balanced object rather than
+    // trusting the whole stream to be JSON.
+    let raw = "\u{2717} Write dummy\n  \u{2514} noop\n\n\u{25cf} noop (shell)\n  \u{2502}                echo not used\n  \u{2514} 2 lines\u{2026}\n\n{\"say\":\"\",\"tool_calls\":               [{\"name\":\"get_now_playing\",\"arguments\":{}},{\"name\":\"get_queue\",               \"arguments\":{}}]}";
+    let step = parse_step(raw).unwrap();
+    assert_eq!(step.calls.len(), 2);
+    assert_eq!(step.calls[0].name, "get_now_playing");
+    assert_eq!(step.calls[1].name, "get_queue");
+    // An empty `say` is a real answer from a real CLI, and must not become a
+    // blank transcript line.
+    assert_eq!(step.say, None);
+  }
+
+  #[test]
+  fn schema_matches_the_shape_the_prompt_describes() {
+    let schema = step_schema();
+    let required = schema["required"].as_array().unwrap();
+    assert!(required.contains(&json!("say")));
+    assert!(required.contains(&json!("tool_calls")));
+    let call_required = schema["properties"]["tool_calls"]["items"]["required"]
+      .as_array()
+      .unwrap();
+    assert!(call_required.contains(&json!("name")));
+    assert!(call_required.contains(&json!("arguments")));
+    // The prompt's example must be parseable by our own parser.
+    assert!(parse_step(&step_shape_hint()).is_ok());
+  }
+}

--- a/src/infra/dj/brain/openai_compat.rs
+++ b/src/infra/dj/brain/openai_compat.rs
@@ -1,0 +1,262 @@
+//! The OpenAI-compatible brain: one adapter, many providers.
+//!
+//! `POST {base_url}/chat/completions` is spoken by OpenAI, OpenRouter, Ollama,
+//! LM Studio, vLLM, and llama.cpp, so the **local model** case is just a
+//! `base_url` pointing at `http://localhost:11434/v1` with no API key at all.
+//!
+//! Structured output is requested via `response_format`, but degraded gracefully:
+//! plenty of local servers ignore or reject it, and the reply parser is tolerant
+//! enough to read a fenced JSON block out of prose anyway.
+
+use super::{parse_step, step_schema, system_prompt, user_prompt, DjRequest, DjStep};
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+pub const DEFAULT_MODEL: &str = "gpt-4o-mini";
+/// Ollama's OpenAI-compatible endpoint — the most common local-model setup.
+pub const DEFAULT_BASE_URL: &str = "http://localhost:11434/v1";
+const MAX_TOKENS: u32 = 2048;
+
+pub struct OpenAiCompatBrain {
+  /// Optional: a local server usually needs none.
+  api_key: Option<String>,
+  model: String,
+  base_url: String,
+  http: reqwest::Client,
+}
+
+impl OpenAiCompatBrain {
+  pub fn new(api_key: Option<String>, model: Option<String>, base_url: Option<String>) -> Self {
+    Self {
+      api_key: api_key.filter(|key| !key.trim().is_empty()),
+      model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+      base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+      http: super::shared_client(),
+    }
+  }
+
+  pub async fn step(&self, request: &DjRequest) -> Result<DjStep> {
+    // First attempt asks the server to enforce the schema. A server that does not
+    // understand `response_format` typically 400s, so fall back to prompting
+    // alone rather than treating that as a hard failure.
+    match self.attempt(request, true).await {
+      Ok(reply) => Ok(reply),
+      Err(e) if e.to_string().contains("response_format") || e.to_string().contains("400") => {
+        log::debug!("DJ: server rejected response_format, retrying without it: {e}");
+        self.attempt(request, false).await
+      }
+      Err(e) => Err(e),
+    }
+  }
+
+  async fn attempt(&self, request: &DjRequest, structured: bool) -> Result<DjStep> {
+    let mut body = json!({
+      "model": self.model,
+      "max_tokens": MAX_TOKENS,
+      "messages": [
+        { "role": "system", "content": system_prompt() },
+        { "role": "user", "content": user_prompt(request) },
+      ],
+    });
+    if structured {
+      body["response_format"] = json!({
+        "type": "json_schema",
+        "json_schema": { "name": "dj_reply", "strict": true, "schema": step_schema() }
+      });
+    }
+
+    let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+    let mut post = self
+      .http
+      .post(&url)
+      .header("content-type", "application/json");
+    if let Some(key) = &self.api_key {
+      post = post.header("authorization", format!("Bearer {key}"));
+    }
+
+    let response = post
+      .json(&body)
+      .send()
+      .await
+      .map_err(|e| anyhow!("could not reach {url}: {e}"))?;
+
+    let status = response.status();
+    let payload: Value = response
+      .json()
+      .await
+      .map_err(|e| anyhow!("{url} returned a body we could not read ({status}): {e}"))?;
+
+    if !status.is_success() {
+      let message = payload
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("no error message");
+      return Err(anyhow!("{status}: {message}"));
+    }
+
+    let text = payload
+      .get("choices")
+      .and_then(Value::as_array)
+      .and_then(|choices| choices.first())
+      .and_then(|choice| choice.get("message"))
+      .and_then(|message| message.get("content"))
+      .and_then(Value::as_str)
+      .ok_or_else(|| anyhow!("{url} returned no message content"))?;
+
+    parse_step(text)
+  }
+}
+
+/// Hand-written to keep the API key out of logs and panic messages — see the
+/// equivalent note on `AnthropicBrain`.
+impl std::fmt::Debug for OpenAiCompatBrain {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("OpenAiCompatBrain")
+      .field("model", &self.model)
+      .field("base_url", &self.base_url)
+      .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+      .finish()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+  use tokio::net::TcpListener;
+
+  fn request() -> DjRequest {
+    DjRequest {
+      want: 2,
+      ..DjRequest::default()
+    }
+  }
+
+  /// Serve `responses` in order, collecting each request body.
+  async fn serve(
+    responses: Vec<(&'static str, Value)>,
+  ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let handle = tokio::spawn(async move {
+      let mut bodies = Vec::new();
+      for (status, body) in responses {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let (read_half, mut write_half) = stream.split();
+        let mut reader = BufReader::new(read_half);
+        let mut content_length = 0usize;
+        loop {
+          let mut line = String::new();
+          reader.read_line(&mut line).await.unwrap();
+          if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = value.trim().parse().unwrap_or(0);
+          }
+          if line == "\r\n" || line.is_empty() {
+            break;
+          }
+        }
+        let mut request_body = vec![0u8; content_length];
+        if content_length > 0 {
+          reader.read_exact(&mut request_body).await.unwrap();
+        }
+        bodies.push(String::from_utf8_lossy(&request_body).to_string());
+
+        let payload = body.to_string();
+        write_half
+          .write_all(
+            format!(
+              "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{payload}",
+              payload.len()
+            )
+            .as_bytes(),
+          )
+          .await
+          .unwrap();
+        write_half.flush().await.unwrap();
+      }
+      bodies
+    });
+    (base_url, handle)
+  }
+
+  fn completion(text: &str) -> Value {
+    json!({"choices": [{"message": {"role": "assistant", "content": text}}]})
+  }
+
+  #[tokio::test]
+  async fn parses_a_successful_completion() {
+    let (base_url, server) = serve(vec![(
+      "200 OK",
+      completion(r#"{"say":"Local pick.","tracks":[{"title":"Nude","artist":"Radiohead"}]}"#),
+    )])
+    .await;
+    let brain = OpenAiCompatBrain::new(None, None, Some(base_url));
+    let reply = brain.step(&request()).await.unwrap();
+    assert_eq!(reply.say.as_deref(), Some("Local pick."));
+    server.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn a_local_server_needs_no_api_key_header() {
+    let (base_url, server) =
+      serve(vec![("200 OK", completion(r#"{"say":"ok","tracks":[]}"#))]).await;
+    let brain = OpenAiCompatBrain::new(None, None, Some(base_url));
+    let _ = brain.step(&request()).await;
+    // The request went out and was accepted without any credential.
+    assert_eq!(server.await.unwrap().len(), 1);
+  }
+
+  #[tokio::test]
+  async fn a_blank_api_key_is_treated_as_absent() {
+    let brain = OpenAiCompatBrain::new(Some("   ".into()), None, None);
+    assert!(brain.api_key.is_none());
+  }
+
+  #[tokio::test]
+  async fn retries_without_response_format_when_the_server_rejects_it() {
+    // Many local servers 400 on `response_format`; the prompt alone plus the
+    // tolerant parser is enough, so this must not be a hard failure.
+    let (base_url, server) = serve(vec![
+      (
+        "400 Bad Request",
+        json!({"error": {"message": "unknown field response_format"}}),
+      ),
+      (
+        "200 OK",
+        completion(r#"{"say":"second try","tracks":[{"title":"A","artist":"B"}]}"#),
+      ),
+    ])
+    .await;
+    let brain = OpenAiCompatBrain::new(None, None, Some(base_url));
+    let reply = brain.step(&request()).await.unwrap();
+    assert_eq!(reply.say.as_deref(), Some("second try"));
+
+    let bodies = server.await.unwrap();
+    assert_eq!(bodies.len(), 2, "should have retried exactly once");
+    let first: Value = serde_json::from_str(&bodies[0]).unwrap();
+    let second: Value = serde_json::from_str(&bodies[1]).unwrap();
+    assert!(first.get("response_format").is_some());
+    assert!(second.get("response_format").is_none());
+  }
+
+  #[tokio::test]
+  async fn an_unrelated_error_is_not_retried() {
+    let (base_url, server) = serve(vec![(
+      "401 Unauthorized",
+      json!({"error": {"message": "bad token"}}),
+    )])
+    .await;
+    let brain = OpenAiCompatBrain::new(Some("nope".into()), None, Some(base_url));
+    let err = brain.step(&request()).await.unwrap_err().to_string();
+    assert!(err.contains("bad token"), "{err}");
+    assert_eq!(server.await.unwrap().len(), 1, "must not retry a 401");
+  }
+
+  #[test]
+  fn defaults_point_at_ollama() {
+    let brain = OpenAiCompatBrain::new(None, None, None);
+    assert_eq!(brain.base_url, DEFAULT_BASE_URL);
+    assert!(brain.base_url.contains("11434"));
+  }
+}

--- a/src/infra/dj/brain/openai_compat.rs
+++ b/src/infra/dj/brain/openai_compat.rs
@@ -17,6 +17,62 @@ pub const DEFAULT_MODEL: &str = "gpt-4o-mini";
 pub const DEFAULT_BASE_URL: &str = "http://localhost:11434/v1";
 const MAX_TOKENS: u32 = 2048;
 
+/// Which token-limit field this server takes.
+///
+/// `max_tokens` is what every OpenAI-compatible server has always accepted;
+/// OpenAI's newer models require `max_completion_tokens` and reject the old name.
+/// Sending the new one everywhere would break the local servers this backend
+/// exists for, so it is a downgrade the server asks for, not a default.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TokenLimit {
+  MaxTokens,
+  MaxCompletionTokens,
+}
+
+impl TokenLimit {
+  fn field(self) -> &'static str {
+    match self {
+      Self::MaxTokens => "max_tokens",
+      Self::MaxCompletionTokens => "max_completion_tokens",
+    }
+  }
+}
+
+/// A non-success HTTP reply, kept as a type so the retry can read the status.
+///
+/// The retry used to search the *rendered* error for "400" or "response_format",
+/// which both the base URL (`http://localhost:11400/v1`) and the model's own
+/// words could contain — so unrelated failures bought a second, full-price model
+/// call. Only this error means "the server refused something we sent".
+#[derive(Debug)]
+struct RejectedRequest {
+  status: reqwest::StatusCode,
+  message: String,
+}
+
+impl RejectedRequest {
+  /// The two statuses an OpenAI-compatible server uses for a field it will not
+  /// take. A 401, 404, 429, or 5xx is a real failure and retrying is pure waste.
+  fn rejected_a_field(&self) -> bool {
+    self.status == reqwest::StatusCode::BAD_REQUEST
+      || self.status == reqwest::StatusCode::UNPROCESSABLE_ENTITY
+  }
+
+  /// Whether the *server's own* message names this field. Deliberately not the
+  /// rendered error chain, which is what made the old guard misfire.
+  fn blames(&self, field: &str) -> bool {
+    self.message.contains(field)
+  }
+}
+
+impl std::fmt::Display for RejectedRequest {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}: {}", self.status, self.message)
+  }
+}
+
+impl std::error::Error for RejectedRequest {}
+
 pub struct OpenAiCompatBrain {
   /// Optional: a local server usually needs none.
   api_key: Option<String>,
@@ -35,33 +91,64 @@ impl OpenAiCompatBrain {
     }
   }
 
+  /// One turn, downgrading the request only for fields the server actually
+  /// refused.
+  ///
+  /// Both downgrades are one-way and each fires at most once, so a turn costs at
+  /// most three requests and cannot loop.
   pub async fn step(&self, request: &DjRequest) -> Result<DjStep> {
-    // First attempt asks the server to enforce the schema. A server that does not
-    // understand `response_format` typically 400s, so fall back to prompting
-    // alone rather than treating that as a hard failure.
-    match self.attempt(request, true).await {
-      Ok(reply) => Ok(reply),
-      Err(e) if e.to_string().contains("response_format") || e.to_string().contains("400") => {
-        log::debug!("DJ: server rejected response_format, retrying without it: {e}");
-        self.attempt(request, false).await
+    let mut structured = true;
+    let mut tokens = TokenLimit::MaxTokens;
+    loop {
+      let error = match self.attempt(request, structured, tokens).await {
+        Ok(reply) => return Ok(reply),
+        Err(error) => error,
+      };
+
+      // Only the server refusing a field we sent is worth paying for a second
+      // model call. A transport error, a 401, or a reply we could not parse
+      // would fail exactly the same way twice.
+      let Some(rejected) = error.downcast_ref::<RejectedRequest>() else {
+        return Err(error);
+      };
+      if !rejected.rejected_a_field() {
+        return Err(error);
       }
-      Err(e) => Err(e),
+
+      if tokens == TokenLimit::MaxTokens && rejected.blames("max_tokens") {
+        // OpenAI's newer models take `max_completion_tokens` and refuse the old
+        // name outright, so dropping `response_format` here would fix nothing.
+        log::debug!("DJ: server rejected max_tokens, retrying with max_completion_tokens");
+        tokens = TokenLimit::MaxCompletionTokens;
+      } else if structured {
+        // Plenty of local servers reject `response_format`. The prompt alone plus
+        // the tolerant parser is enough, so this is not a hard failure.
+        log::debug!("DJ: server rejected response_format, retrying without it: {error}");
+        structured = false;
+      } else {
+        return Err(error);
+      }
     }
   }
 
-  async fn attempt(&self, request: &DjRequest, structured: bool) -> Result<DjStep> {
+  async fn attempt(
+    &self,
+    request: &DjRequest,
+    structured: bool,
+    tokens: TokenLimit,
+  ) -> Result<DjStep> {
     let mut body = json!({
       "model": self.model,
-      "max_tokens": MAX_TOKENS,
       "messages": [
         { "role": "system", "content": system_prompt() },
         { "role": "user", "content": user_prompt(request) },
       ],
     });
+    body[tokens.field()] = json!(MAX_TOKENS);
     if structured {
       body["response_format"] = json!({
         "type": "json_schema",
-        "json_schema": { "name": "dj_reply", "strict": true, "schema": step_schema() }
+        "json_schema": { "name": "dj_reply", "schema": step_schema() }
       });
     }
 
@@ -92,7 +179,13 @@ impl OpenAiCompatBrain {
         .and_then(|error| error.get("message"))
         .and_then(Value::as_str)
         .unwrap_or("no error message");
-      return Err(anyhow!("{status}: {message}"));
+      return Err(
+        RejectedRequest {
+          status,
+          message: message.to_string(),
+        }
+        .into(),
+      );
     }
 
     let text = payload
@@ -238,6 +331,55 @@ mod tests {
     let second: Value = serde_json::from_str(&bodies[1]).unwrap();
     assert!(first.get("response_format").is_some());
     assert!(second.get("response_format").is_none());
+  }
+
+  #[tokio::test]
+  async fn a_rejected_max_tokens_is_retried_with_max_completion_tokens() {
+    // OpenAI's newer models refuse `max_tokens` outright. Dropping
+    // `response_format` instead would fail the same way a second time.
+    let (base_url, server) = serve(vec![
+      (
+        "400 Bad Request",
+        json!({"error": {"message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}),
+      ),
+      (
+        "200 OK",
+        completion(r#"{"say":"newer model","tool_calls":[]}"#),
+      ),
+    ])
+    .await;
+    let brain = OpenAiCompatBrain::new(None, None, Some(base_url));
+    let reply = brain.step(&request()).await.unwrap();
+    assert_eq!(reply.say.as_deref(), Some("newer model"));
+
+    let bodies = server.await.unwrap();
+    assert_eq!(bodies.len(), 2, "should have retried exactly once");
+    let second: Value = serde_json::from_str(&bodies[1]).unwrap();
+    assert!(second.get("max_completion_tokens").is_some());
+    assert!(second.get("max_tokens").is_none());
+    assert!(
+      second.get("response_format").is_some(),
+      "the token field was the complaint, so the schema request survives"
+    );
+  }
+
+  #[tokio::test]
+  async fn a_reply_that_merely_mentions_400_is_not_retried() {
+    // The retry reads the HTTP status, not the rendered error. This reply parses
+    // to an error whose text contains both old triggers, and it must still cost
+    // exactly one model call.
+    let (base_url, server) = serve(vec![(
+      "200 OK",
+      completion("sorry, I hit error 400 on response_format"),
+    )])
+    .await;
+    let brain = OpenAiCompatBrain::new(None, None, Some(base_url));
+    assert!(brain.step(&request()).await.is_err());
+    assert_eq!(
+      server.await.unwrap().len(),
+      1,
+      "an unparseable reply is not a rejected field"
+    );
   }
 
   #[tokio::test]

--- a/src/infra/dj/mod.rs
+++ b/src/infra/dj/mod.rs
@@ -19,21 +19,39 @@
 // pulled in by the media sources. Enabled on its own, everything here is
 // legitimately unreachable, so scope the allow to that case rather than blanket
 // it (cf. `#[cfg_attr(not(feature = "scripting"), allow(dead_code))]` in
-// `infra::network`). The condition grows an `ai-dj` arm when that front door
-// lands.
+// `infra::network`). Deliberately still `not(mcp-server)` rather than
+// `not(any(mcp-server, ai-dj))`: an `ai-dj` build has the DJ's brains but not yet
+// the screen that drives them, so the allow has to stay active there too. It
+// grows its `ai-dj` arm when that screen lands.
 #![cfg_attr(not(feature = "mcp-server"), allow(dead_code))]
 
+/// The in-TUI DJ's model backends.
+// Nothing drives them yet; the DJ screen, the next PR in this stack, is the consumer.
+#[cfg(feature = "ai-dj")]
+#[allow(dead_code)]
+pub mod brain;
 pub mod brief;
 /// How a tool call reaches the live player. Shared by both front doors, and
 /// gated on having one: it constructs `IoEvent::DjToolCall`, which bare
 /// `dj-core` does not compile.
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 pub mod exec;
 /// The avoid-library filter's two lookups. Shared: the in-TUI DJ filters with it
 /// by default, and the MCP front door uses it to mark `search_tracks` results as
 /// owned and to honour `queue_tracks(exclude_owned)`.
 pub mod library;
 pub mod resolve;
+/// Turn assembly for the in-TUI DJ.
+// Nothing drives it yet; the DJ screen, the next PR in this stack, is the consumer.
+#[cfg(feature = "ai-dj")]
+#[allow(dead_code)]
+pub mod session;
+/// What AI the listener has, and which of its models: the data behind the DJ's
+/// setup picker.
+// Nothing draws it yet; the DJ screen, the next PR in this stack, is the consumer.
+#[cfg(feature = "ai-dj")]
+#[allow(dead_code)]
+pub mod setup;
 /// The tool surface, shared by both front doors: the MCP server publishes it
 /// verbatim, and the in-TUI DJ's agent loop drives the same table.
 pub mod tools;

--- a/src/infra/dj/session.rs
+++ b/src/infra/dj/session.rs
@@ -1,0 +1,589 @@
+//! Assembling a DJ turn: build the brain, build the brief, snapshot the context.
+//!
+//! This is the glue between config and [`super::agent`], which runs the turn. It
+//! is used from the **service** lane — a brain call is slow (up to a couple of
+//! minutes for an agent CLI) and touches only `App` plus its own HTTP client or
+//! subprocess, so parking it on the serial pump would freeze every other event
+//! behind it.
+//!
+//! Resolution deliberately does *not* happen here: it needs the real Spotify
+//! client, which the service lane's `Network` does not have. The loop's tool
+//! calls cross to the serial lane through `IoEvent::DjToolCall` instead.
+
+use super::brain::{
+  agent_cli::{AgentCliBrain, PromptDelivery},
+  anthropic::AnthropicBrain,
+  openai_compat::OpenAiCompatBrain,
+  DjBrain, DjRequest, ToolExchange,
+};
+use super::brief::{self, TasteBrief};
+use super::{DjLine, DjSpeaker};
+use crate::core::app::App;
+use crate::core::user_config::BehaviorConfig;
+use crate::infra::history::RecapPeriod;
+use anyhow::{anyhow, Result};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+/// Environment variable that wins over `behavior.dj_api_key` at request time.
+///
+/// Mirrors how the Subsonic password is handled: the config field exists for
+/// convenience, but the env var is the recommended route because it never lands
+/// on disk.
+pub const API_KEY_ENV: &str = "SPOTATUI_DJ_API_KEY";
+
+/// Where agent CLIs are run from.
+///
+/// **Not** the user's current directory. Coding agents read `CLAUDE.md` /
+/// `AGENTS.md` and project files from their working directory, so an agent
+/// launched inside a repository answers with that repository on its mind.
+fn agent_scratch_dir() -> std::path::PathBuf {
+  crate::core::user_config::default_app_config_dir()
+    .unwrap_or_else(std::env::temp_dir)
+    .join("dj-scratch")
+}
+
+/// The API-key precedence rule: the env var wins, the config field is the
+/// fallback, and a blank env var counts as unset.
+///
+/// Split out so the tests can drive both branches without calling `set_var`:
+/// `setenv`/`getenv` are not thread-safe (which is why they are `unsafe` in edition
+/// 2024), and every test in this binary shares one process. A test that exported
+/// `SPOTATUI_DJ_API_KEY` for a moment raced every other thread reading it —
+/// including the picker's own `detect_backends`.
+fn resolve_api_key_with(env_key: Option<&str>, behavior: &BehaviorConfig) -> Option<String> {
+  env_key
+    .filter(|key| !key.trim().is_empty())
+    .map(str::to_string)
+    .or_else(|| behavior.dj_api_key.clone())
+}
+
+pub fn period_from_config(value: &str) -> RecapPeriod {
+  match value {
+    "7d" => RecapPeriod::SevenDays,
+    "month" => RecapPeriod::Month,
+    "year" => RecapPeriod::Year,
+    "all" => RecapPeriod::All,
+    // Validated on load, so anything else is already impossible; default rather
+    // than panic if that ever changes.
+    _ => RecapPeriod::ThirtyDays,
+  }
+}
+
+/// Build the configured brain, or explain why it cannot be built.
+pub fn build_brain(behavior: &BehaviorConfig) -> Result<DjBrain> {
+  let from_env = std::env::var(API_KEY_ENV).ok();
+  build_brain_with(from_env.as_deref(), behavior)
+}
+
+/// [`build_brain`] with the environment passed in rather than read.
+///
+/// Same reason as [`resolve_api_key_with`]: "no key anywhere" is a case the tests
+/// have to be able to produce, and producing it by unsetting a process-global was
+/// a data race against every other test thread.
+fn build_brain_with(env_key: Option<&str>, behavior: &BehaviorConfig) -> Result<DjBrain> {
+  match behavior.dj_backend.as_str() {
+    "agent_cli" => {
+      let (command, delivery) = resolve_agent_command(behavior);
+      Ok(DjBrain::AgentCli(AgentCliBrain::new(
+        command,
+        delivery,
+        Duration::from_secs(behavior.dj_agent_timeout_secs),
+        agent_scratch_dir(),
+      )?))
+    }
+    "anthropic" => {
+      let key = resolve_api_key_with(env_key, behavior).unwrap_or_default();
+      Ok(DjBrain::Anthropic(AnthropicBrain::new(
+        key,
+        behavior.dj_model.clone(),
+        behavior.dj_base_url.clone(),
+      )?))
+    }
+    "openai_compat" => Ok(DjBrain::OpenAiCompat(OpenAiCompatBrain::new(
+      resolve_api_key_with(env_key, behavior),
+      behavior.dj_model.clone(),
+      behavior.dj_base_url.clone(),
+    ))),
+    other => Err(anyhow!(
+      "unknown behavior.dj_backend '{other}'; expected agent_cli, anthropic, or openai_compat"
+    )),
+  }
+}
+
+/// Which preset, if any, this configured argv is "just the default shape" of.
+///
+/// Two shapes count. A bare binary name (`["codex"]`) is the documented
+/// convenience. An argv byte-equal to what that preset produces with no model
+/// (`["claude", "-p"]`) counts too, because that is the argv *spotatui shipped*
+/// and then wrote to disk itself on the first unrelated `save_config` — it is not
+/// something the user typed. Anything else is theirs, including its model flag.
+///
+/// This is what keeps the "an explicit multi-part command is never rewritten"
+/// invariant honest while still letting a default install pick a model: with
+/// `dj_agent_model` unset the resolved argv is unchanged either way.
+fn expandable_preset(command: &[String]) -> Option<&'static super::brain::agent_cli::AgentPreset> {
+  let first = command.first()?.trim();
+  let preset = super::brain::agent_cli::preset(first)?;
+  if command.len() == 1 || command == preset.argv(None).as_slice() {
+    Some(preset)
+  } else {
+    None
+  }
+}
+
+/// Does spotatui own this install's `dj_agent_command`?
+///
+/// The single answer to "is this argv ours to rewrite", shared by the three places
+/// that would otherwise each invent their own and disagree:
+///
+/// - [`resolve_agent_command`] threads `dj_agent_model` in as a model flag only
+///   when this is `true`;
+/// - `setup::active_label` names that model in the DJ title only when this is
+///   `true`, so the title cannot advertise a model the CLI never receives;
+/// - `setup::detect_backends` gives a `false` command a picker row of its own,
+///   because a hand-written argv has no preset row and Enter would otherwise
+///   replace it with `["claude"]`.
+///
+/// A `false` here means the argv is the user's: it is passed through verbatim,
+/// including whatever model flag they put in it themselves.
+pub(crate) fn owns_agent_command(behavior: &BehaviorConfig) -> bool {
+  expandable_preset(&behavior.dj_agent_command).is_some()
+}
+
+/// Expand a bare agent name to its known argv, so `dj_agent_command: ["codex"]`
+/// just works instead of silently running `codex` with no subcommand, and thread
+/// `dj_agent_model` through as that CLI's own model flag.
+///
+/// An explicit multi-part command is always honoured as written — the presets are
+/// a convenience, never an override, and a hand-written argv keeps ownership of
+/// its own flags including the model one.
+fn resolve_agent_command(behavior: &BehaviorConfig) -> (Vec<String>, PromptDelivery) {
+  let configured_delivery = behavior
+    .dj_agent_prompt_via
+    .as_deref()
+    .and_then(PromptDelivery::from_config_str);
+  if let Some(preset) = expandable_preset(&behavior.dj_agent_command) {
+    let model = behavior
+      .dj_agent_model
+      .as_deref()
+      .map(str::trim)
+      .filter(|model| !model.is_empty());
+    // The preset's delivery mode wins unless the user set one explicitly, since
+    // the two have to agree for the CLI to receive the prompt at all.
+    return (
+      preset.argv(model),
+      configured_delivery.unwrap_or(preset.delivery),
+    );
+  }
+  (
+    behavior.dj_agent_command.clone(),
+    configured_delivery.unwrap_or_default(),
+  )
+}
+
+/// Build the taste brief, off the async runtime and off the `App` lock.
+pub async fn build_taste_brief(app: &Arc<Mutex<App>>, period: RecapPeriod) -> Result<TasteBrief> {
+  // `load_listens` is blocking and reads the whole (unbounded, append-only) file.
+  let listens = tokio::task::spawn_blocking(crate::infra::history::load_listens)
+    .await
+    .map_err(|e| anyhow!("listening-history task failed: {e}"))?
+    .map_err(|e| anyhow!("could not read listening history: {e}"))?;
+
+  let mut summary = brief::build_brief(&listens, period);
+  {
+    let app = app.lock().await;
+    summary.now_playing = super::current_track_label(&app);
+    summary.vibe = app.dj.vibe.clone();
+  }
+  Ok(summary)
+}
+
+/// Everything a brain call needs, snapshotted off the `App` lock.
+pub struct TurnContext {
+  pub brief: TasteBrief,
+  pub history: Vec<(String, String)>,
+  pub want: usize,
+  /// Whether the listener has the avoid-library filter on. Reaches the prompt so
+  /// the model aims away from their favourites, and reaches the resolve step so it
+  /// enforces what the prompt asked for.
+  pub avoid_library: bool,
+}
+
+impl TurnContext {
+  /// Dedupe keys for the recently-played window, for the loop's queue policy.
+  pub fn recent_keys(&self) -> Vec<String> {
+    self.brief.recent_keys.clone()
+  }
+}
+
+/// How many transcript lines the brain gets.
+///
+/// Sized for a back-and-forth, not a single request and answer: now that the DJ
+/// can ask a question, the reply to it is worthless without the several turns of
+/// preference-narrowing that led there.
+const HISTORY_LINES: usize = 24;
+
+/// Turn the transcript into `(speaker, text)` pairs for the brain, oldest last.
+///
+/// Pure and separate from [`turn_context`] so the mapping is unit-testable: the
+/// async path pulls in the taste brief, which reads the user's real listening
+/// history file.
+///
+/// `extra` is appended as a final `Listener` line. It is for instructions that are
+/// deliberately *absent* from the transcript (the vibe shift); anything the
+/// listener actually typed is already in `transcript` and must not be passed here,
+/// or the brain sees it twice.
+fn history_from_transcript(transcript: &[DjLine], extra: Option<&str>) -> Vec<(String, String)> {
+  let mut history = transcript
+    .iter()
+    // Machine notes ("queued 5 tracks") are for the user, not the model.
+    .filter(|line| line.speaker != DjSpeaker::System)
+    .map(|line| {
+      let speaker = match line.speaker {
+        DjSpeaker::User => "Listener",
+        _ => "DJ",
+      };
+      (speaker.to_string(), line.text.clone())
+    })
+    .rev()
+    .take(HISTORY_LINES)
+    .collect::<Vec<_>>();
+  history.reverse();
+  if let Some(line) = extra {
+    history.push(("Listener".to_string(), line.to_string()));
+  }
+  history
+}
+
+/// Snapshot the conversation and settings for one turn.
+pub async fn turn_context(
+  app: &Arc<Mutex<App>>,
+  extra_instruction: Option<&str>,
+) -> Result<TurnContext> {
+  let (period, want, history, avoid_library) = {
+    let app = app.lock().await;
+    let behavior = &app.user_config.behavior;
+    (
+      period_from_config(&behavior.dj_history_period),
+      behavior.dj_batch_size,
+      history_from_transcript(&app.dj.transcript, extra_instruction),
+      // The live toggle, not the config default: the config only seeds it.
+      app.dj.avoid_library,
+    )
+  };
+
+  let brief = build_taste_brief(app, period).await?;
+  Ok(TurnContext {
+    brief,
+    history,
+    want,
+    avoid_library,
+  })
+}
+
+impl TurnContext {
+  /// One step's request: the standing context, plus whatever the loop has run so
+  /// far this turn.
+  pub fn to_request(&self, scratch: Vec<ToolExchange>, must_act: bool) -> DjRequest {
+    DjRequest {
+      brief: self.brief.clone(),
+      history: self.history.clone(),
+      scratch,
+      want: self.want,
+      avoid_library: self.avoid_library,
+      must_act,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::user_config::UserConfig;
+
+  fn behavior(backend: &str) -> BehaviorConfig {
+    let mut config = UserConfig::new();
+    config.behavior.dj_backend = backend.to_string();
+    config.behavior
+  }
+
+  #[test]
+  fn builds_each_configured_backend() {
+    assert!(matches!(
+      build_brain(&behavior("agent_cli")).unwrap(),
+      DjBrain::AgentCli(_)
+    ));
+    assert!(matches!(
+      build_brain(&behavior("openai_compat")).unwrap(),
+      DjBrain::OpenAiCompat(_)
+    ));
+  }
+
+  #[test]
+  fn anthropic_without_a_key_fails_with_the_env_var_named() {
+    // `None` for the environment rather than `remove_var`: a machine that exports
+    // the key would otherwise fail this for the wrong reason, and unsetting it for a
+    // moment would race every other test thread reading the same variable.
+    let err = build_brain_with(None, &behavior("anthropic"))
+      .unwrap_err()
+      .to_string();
+    assert!(err.contains(API_KEY_ENV), "{err}");
+  }
+
+  #[test]
+  fn an_unknown_backend_is_reported_with_the_valid_options() {
+    let err = build_brain(&behavior("telepathy")).unwrap_err().to_string();
+    assert!(err.contains("agent_cli"));
+    assert!(err.contains("openai_compat"));
+  }
+
+  #[test]
+  fn the_env_var_wins_over_the_config_field() {
+    // The environment is a parameter here, not a global. `set_var` around a live
+    // test binary is a data race against every other thread that reads it, and the
+    // picker's own detection reads exactly this variable.
+    let mut behavior = behavior("openai_compat");
+    behavior.dj_api_key = Some("from-config".to_string());
+    assert_eq!(
+      resolve_api_key_with(Some("from-env"), &behavior).as_deref(),
+      Some("from-env")
+    );
+  }
+
+  #[test]
+  fn a_blank_env_var_falls_back_to_the_config_field() {
+    let mut behavior = behavior("openai_compat");
+    behavior.dj_api_key = Some("from-config".to_string());
+    assert_eq!(
+      resolve_api_key_with(Some("   "), &behavior).as_deref(),
+      Some("from-config"),
+      "an exported-but-empty variable is not a key"
+    );
+    assert_eq!(
+      resolve_api_key_with(None, &behavior).as_deref(),
+      Some("from-config"),
+      "and neither is an unset one"
+    );
+  }
+
+  #[test]
+  fn every_configured_period_string_maps_to_a_recap_period() {
+    for (value, expected) in [
+      ("7d", RecapPeriod::SevenDays),
+      ("30d", RecapPeriod::ThirtyDays),
+      ("month", RecapPeriod::Month),
+      ("year", RecapPeriod::Year),
+      ("all", RecapPeriod::All),
+    ] {
+      assert_eq!(period_from_config(value), expected);
+    }
+  }
+
+  #[test]
+  fn a_bare_agent_name_expands_to_its_preset_argv() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec!["codex".to_string()];
+    let (argv, _) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["codex", "exec", "-"]);
+  }
+
+  #[test]
+  fn a_bare_agy_name_also_adopts_its_arg_delivery() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec!["agy".to_string()];
+    // Unset, which is a state the real load path can now produce, so the preset's
+    // own mode is adopted; `agy` reads the prompt from argv and ignores stdin, and
+    // getting this wrong means it receives nothing at all.
+    behavior.dj_agent_prompt_via = None;
+    let (argv, delivery) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["agy", "-p"]);
+    assert_eq!(delivery, PromptDelivery::Arg);
+  }
+
+  #[test]
+  fn an_explicit_prompt_delivery_still_overrides_the_preset() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec!["agy".to_string()];
+    behavior.dj_agent_prompt_via = Some("stdin".to_string());
+    let (_, delivery) = resolve_agent_command(&behavior);
+    assert_eq!(delivery, PromptDelivery::Stdin);
+  }
+
+  #[test]
+  fn an_explicit_command_is_never_rewritten_by_a_preset() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec!["claude".to_string(), "--custom".to_string()];
+    let (argv, _) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["claude", "--custom"]);
+  }
+
+  #[test]
+  fn an_unknown_bare_name_is_left_alone() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec!["my-own-agent".to_string()];
+    let (argv, _) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["my-own-agent"]);
+  }
+
+  #[test]
+  fn an_install_with_no_model_configured_resolves_exactly_the_argv_it_did_before() {
+    // The guarantee: adding the model flag must change nothing for anyone who
+    // never picked a model.
+    let behavior = behavior("agent_cli");
+    assert_eq!(behavior.dj_agent_model, None, "the shipped default");
+    let (argv, delivery) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["claude", "-p"]);
+    assert_eq!(delivery, PromptDelivery::Stdin);
+  }
+
+  #[test]
+  fn the_shipped_default_command_still_accepts_a_model_because_it_is_the_preset_shape() {
+    // `["claude", "-p"]` is on disk in every existing install, written there by an
+    // automatic `save_config` rather than typed, so it has to stay expandable.
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_model = Some("haiku".to_string());
+    let (argv, _) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["claude", "--model", "haiku", "-p"]);
+  }
+
+  #[test]
+  fn ownership_is_exactly_which_commands_receive_a_model_flag() {
+    // The picker and the DJ title both branch on `owns_agent_command`, so it has to
+    // BE the rule `resolve_agent_command` follows rather than merely resemble it.
+    // Both halves are asserted here for that reason: the helper's answer, and the
+    // argv that answer is supposed to predict.
+    for (command, owned) in [
+      (vec!["claude"], true),
+      (vec!["claude", "-p"], true),
+      (vec!["claude", "--verbose", "-p"], false),
+      (vec!["my-own-agent"], false),
+    ] {
+      let mut behavior = behavior("agent_cli");
+      behavior.dj_agent_command = command.iter().map(|part| part.to_string()).collect();
+      assert_eq!(owns_agent_command(&behavior), owned, "{command:?}");
+
+      behavior.dj_agent_model = Some("haiku".to_string());
+      let (argv, _) = resolve_agent_command(&behavior);
+      assert_eq!(
+        argv.contains(&"haiku".to_string()),
+        owned,
+        "{command:?} disagrees with the argv it resolves to"
+      );
+    }
+  }
+
+  #[test]
+  fn a_hand_written_command_never_gains_a_model_flag() {
+    let mut behavior = behavior("agent_cli");
+    behavior.dj_agent_command = vec![
+      "claude".to_string(),
+      "--verbose".to_string(),
+      "-p".to_string(),
+    ];
+    behavior.dj_agent_model = Some("haiku".to_string());
+    let (argv, _) = resolve_agent_command(&behavior);
+    assert_eq!(argv, vec!["claude", "--verbose", "-p"]);
+  }
+
+  #[test]
+  fn a_typed_prompt_reaches_the_brain_exactly_once() {
+    // Regression guard: the handler pushes the listener's line and the brain reads
+    // it from the transcript. When `ask_dj` also pushed it and it was *also* passed
+    // as an extra line, one request arrived three times over.
+    let transcript = vec![DjLine::user("play something like Remind Me to Forget")];
+    let history = history_from_transcript(&transcript, None);
+    assert_eq!(
+      history,
+      vec![(
+        "Listener".to_string(),
+        "play something like Remind Me to Forget".to_string()
+      )]
+    );
+  }
+
+  #[test]
+  fn machine_notes_are_kept_out_of_the_history() {
+    let transcript = vec![
+      DjLine::user("something chill"),
+      DjLine::dj("Six downtempo cuts."),
+      DjLine::system("queued 6"),
+    ];
+    let history = history_from_transcript(&transcript, None);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].0, "Listener");
+    assert_eq!(history[1].0, "DJ");
+  }
+
+  #[test]
+  fn an_extra_instruction_lands_last_and_is_attributed_to_the_listener() {
+    // The vibe shift's steer: never in the transcript, so it has to be appended.
+    let transcript = vec![DjLine::user("something chill")];
+    let history = history_from_transcript(&transcript, Some("Change direction."));
+    assert_eq!(history.len(), 2);
+    assert_eq!(
+      history.last().unwrap(),
+      &("Listener".to_string(), "Change direction.".to_string())
+    );
+  }
+
+  #[test]
+  fn the_history_window_keeps_the_newest_lines_oldest_first() {
+    // Built off the constant, so raising the window does not silently stop this
+    // testing a window at all.
+    let total = HISTORY_LINES + 5;
+    let transcript = (0..total)
+      .map(|i| DjLine::user(format!("line {i}")))
+      .collect::<Vec<_>>();
+    let history = history_from_transcript(&transcript, None);
+    assert_eq!(history.len(), HISTORY_LINES);
+    assert_eq!(history.first().unwrap().1, "line 5", "oldest kept, first");
+    assert_eq!(
+      history.last().unwrap().1,
+      format!("line {}", total - 1),
+      "newest kept, last"
+    );
+  }
+
+  #[test]
+  fn each_step_carries_the_filter_flag_and_the_results_so_far() {
+    let context = context_with_filter();
+    let first = context.to_request(vec![], false);
+    assert!(first.avoid_library, "the prompt has to know");
+    assert!(first.scratch.is_empty(), "nothing has run yet");
+    assert!(!first.must_act);
+
+    // The context is reusable across steps — the loop calls it once per step, and
+    // only the scratch grows.
+    let second = context.to_request(
+      vec![ToolExchange {
+        name: "get_queue".into(),
+        arguments: serde_json::json!({}),
+        result: "empty".into(),
+      }],
+      true,
+    );
+    assert_eq!(second.scratch.len(), 1);
+    assert!(second.must_act);
+  }
+
+  fn context_with_filter() -> TurnContext {
+    TurnContext {
+      brief: TasteBrief::default(),
+      history: vec![],
+      want: 6,
+      avoid_library: true,
+    }
+  }
+
+  #[test]
+  fn the_agent_scratch_dir_is_not_the_current_directory() {
+    // Regression guard for the polluted-context trap: an agent run in a repo
+    // reads its CLAUDE.md and answers about code instead of music.
+    let scratch = agent_scratch_dir();
+    let cwd = std::env::current_dir().unwrap();
+    assert_ne!(scratch, cwd);
+    assert!(scratch.ends_with("dj-scratch"));
+  }
+}

--- a/src/infra/dj/session.rs
+++ b/src/infra/dj/session.rs
@@ -45,7 +45,12 @@ fn agent_scratch_dir() -> std::path::PathBuf {
 }
 
 /// The API-key precedence rule: the env var wins, the config field is the
-/// fallback, and a blank env var counts as unset.
+/// fallback, and a blank value from either counts as unset.
+///
+/// Blank has to mean unset on both sides, because `setup::anthropic_key_present`
+/// reads them that way when it decides whether the picker shows a key as present.
+/// A blank config key that got through here would be sent as an empty bearer
+/// token, which fails less clearly than no credential at all.
 ///
 /// Split out so the tests can drive both branches without calling `set_var`:
 /// `setenv`/`getenv` are not thread-safe (which is why they are `unsafe` in edition
@@ -55,8 +60,13 @@ fn agent_scratch_dir() -> std::path::PathBuf {
 fn resolve_api_key_with(env_key: Option<&str>, behavior: &BehaviorConfig) -> Option<String> {
   env_key
     .filter(|key| !key.trim().is_empty())
+    .or_else(|| {
+      behavior
+        .dj_api_key
+        .as_deref()
+        .filter(|key| !key.trim().is_empty())
+    })
     .map(str::to_string)
-    .or_else(|| behavior.dj_api_key.clone())
 }
 
 pub fn period_from_config(value: &str) -> RecapPeriod {
@@ -365,6 +375,20 @@ mod tests {
       resolve_api_key_with(None, &behavior).as_deref(),
       Some("from-config"),
       "and neither is an unset one"
+    );
+  }
+
+  #[test]
+  fn a_blank_config_key_is_no_key_at_all() {
+    // The picker reads it that way, so this has to agree: a config key of spaces
+    // showing as "not ready" while the session sent it as a bearer token is a
+    // failure with no visible cause.
+    let mut behavior = behavior("openai_compat");
+    behavior.dj_api_key = Some("   ".to_string());
+    assert_eq!(resolve_api_key_with(None, &behavior), None);
+    assert_eq!(
+      resolve_api_key_with(Some("from-env"), &behavior).as_deref(),
+      Some("from-env")
     );
   }
 

--- a/src/infra/dj/setup.rs
+++ b/src/infra/dj/setup.rs
@@ -1,0 +1,1524 @@
+//! "Which AI do you have, and which of its models?" — the data behind the DJ's
+//! setup picker.
+//!
+//! Two cost problems hide behind the same words, and this module exists because
+//! the fix is different for each. The `anthropic` backend bills an API key per
+//! token, so the answer there is a cheaper model id. The default `agent_cli`
+//! backend spends the user's Claude Pro/Max (or ChatGPT) subscription, where a
+//! continuous auto-queue is a fresh prompt every few tracks and the heaviest model
+//! exhausts a Pro plan in a handful of turns. Which backend is in use therefore
+//! changes what "cheaper" even means, and the picker has to say so per row.
+//!
+//! **Nothing here spawns a process or makes a request.** Detection stats `PATH`;
+//! see [`on_path`].
+
+use crate::core::user_config::BehaviorConfig;
+use std::path::{Path, PathBuf};
+
+use super::brain::agent_cli;
+
+/// Is `name` an executable file on any `PATH` entry?
+///
+/// Stat only, never a spawn. This runs on the render thread when the picker opens,
+/// and asking a coding agent CLI to print its version costs hundreds of
+/// milliseconds per binary; four of those would be a visible stall.
+pub fn on_path(name: &str) -> bool {
+  let Some(path) = std::env::var_os("PATH") else {
+    return false;
+  };
+  binary_in_dirs(name, &std::env::split_paths(&path).collect::<Vec<_>>())
+}
+
+/// Split out from [`on_path`] so the tests can point at a directory they built,
+/// rather than mutating the process environment (which races other tests).
+pub(crate) fn binary_in_dirs(name: &str, dirs: &[PathBuf]) -> bool {
+  dirs.iter().any(|dir| is_executable(&dir.join(name)))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+  use std::os::unix::fs::PermissionsExt;
+  std::fs::metadata(path)
+    .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+    .unwrap_or(false)
+}
+
+/// On Windows the extension is what makes a file runnable, and `PATHEXT` is the
+/// list. `is_file()` on the bare name would miss `claude.cmd`, which is how npm
+/// shims land.
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+  if path.is_file() {
+    return true;
+  }
+  let exts = std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT;.COM".to_string());
+  exts.split(';').any(|ext| {
+    let mut candidate = path.as_os_str().to_owned();
+    candidate.push(ext);
+    Path::new(&candidate).is_file()
+  })
+}
+
+/// One row of the picker's first step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BackendOption {
+  /// The `behavior.dj_backend` value this row selects.
+  pub backend: &'static str,
+  /// For `agent_cli` rows, the preset key, which is also the binary name. `None`
+  /// for the HTTP backends **and** for the one row below that carries the user's
+  /// own command; [`BackendOption::command`] is what tells those two apart.
+  pub agent: Option<&'static str>,
+  /// The user's own `dj_agent_command`, on the single row that shows it back to
+  /// them, and `None` on every row spotatui owns.
+  ///
+  /// This is the explicit discriminator rather than a third meaning smuggled into
+  /// `agent`: `agent: None` has always meant "an HTTP backend" and both
+  /// [`models_for`] and [`apply_choice`] branch on it, so an unhandled third state
+  /// there would write `dj_model` for a CLI. `Some` means "an agent CLI whose argv
+  /// is the user's, and which this picker must not rewrite".
+  pub command: Option<Vec<String>>,
+  /// What the row is called.
+  pub label: String,
+  /// What it bills against, or what is still missing. The whole reason the picker
+  /// exists is that "rides your Pro plan" and "$5 per MTok" are not
+  /// interchangeable, so this is never empty.
+  pub note: String,
+  /// Usable right now with no further setup: the binary is on `PATH`, or the key is
+  /// present. A `false` row is still selectable, because "I am about to install it"
+  /// is a real answer.
+  pub ready: bool,
+}
+
+impl BackendOption {
+  /// Does this row run an agent CLI, whether one of spotatui's presets or the
+  /// user's own command?
+  ///
+  /// The question every "which config field does this row write" decision actually
+  /// asks. `agent.is_some()` alone answers it wrongly for the user's own command,
+  /// which would send it down the HTTP branch and write `dj_model`.
+  fn is_agent(&self) -> bool {
+    self.agent.is_some() || self.command.is_some()
+  }
+}
+
+/// Agent CLIs the picker offers even when they are not installed, so a user can
+/// see what spotatui supports.
+///
+/// `gemini` is deliberately absent: Google superseded the Gemini CLI with
+/// Antigravity's `agy`. It stays in [`agent_cli::PRESETS`] so an existing config
+/// keeps working, and detection still offers it when the binary is actually
+/// installed, but spotatui does not advertise it any more.
+const RECOMMENDED_AGENTS: &[&str] = &["claude", "codex", "agy", "copilot", "opencode"];
+
+/// What each known agent bills against. Paired with detection rather than baked
+/// into the label, because "not on PATH" is appended to it.
+fn agent_note(key: &str) -> &'static str {
+  match key {
+    "claude" => "uses your Claude Pro/Max plan",
+    "codex" => "uses your ChatGPT plan",
+    "agy" => "uses your Antigravity plan",
+    "copilot" => "uses your GitHub Copilot plan",
+    "opencode" => "uses whatever provider opencode is logged into",
+    "gemini" => "legacy Gemini CLI, superseded by agy",
+    // An unadvertised preset someone added: say the one thing that is true of
+    // every agent CLI rather than inventing a plan name.
+    _ => "uses that CLI's own subscription",
+  }
+}
+
+/// Mirrors `session::resolve_api_key`'s precedence without pulling the session
+/// module into the picker: the env var wins, the config field is the fallback.
+///
+/// The environment is a parameter rather than a read, for the same reason
+/// `session::resolve_api_key_with` takes one: the test that needs "no key anywhere"
+/// used to produce it with `remove_var`, which is a data race against every other
+/// thread in the test binary.
+fn anthropic_key_present(env_key: Option<&str>, behavior: &BehaviorConfig) -> bool {
+  env_key.is_some_and(|key| !key.trim().is_empty())
+    || behavior
+      .dj_api_key
+      .as_ref()
+      .is_some_and(|key| !key.trim().is_empty())
+}
+
+/// The note on the row that carries the user's own command.
+const OWN_COMMAND_NOTE: &str = "your own command, run exactly as written";
+
+/// The suffix appended to an agent row whose binary is missing. A const because
+/// the tests assert on it, and a note that silently stopped saying this would
+/// otherwise still look right.
+const NOT_INSTALLED: &str = " · not on PATH";
+
+/// Which backends this machine can actually run, in the order the picker shows
+/// them.
+///
+/// Driven off [`agent_cli::PRESETS`] rather than a second list of names, so
+/// detection cannot drift from what `session::resolve_agent_command` supports.
+pub fn detect_backends(behavior: &BehaviorConfig) -> Vec<BackendOption> {
+  let env_key = std::env::var(super::session::API_KEY_ENV).ok();
+  detect_backends_with(behavior, env_key.as_deref(), on_path)
+}
+
+/// [`detect_backends`] with both pieces of ambient state passed in.
+///
+/// Same seam as [`binary_in_dirs`], one level up: `ready` and the
+/// [`NOT_INSTALLED`] suffix are the whole point of detection, and asserting on them
+/// through the real `PATH` would make the test say something different on every
+/// machine (green here, green on a CI runner with none of these CLIs installed,
+/// green with the readiness check deleted).
+pub(crate) fn detect_backends_with(
+  behavior: &BehaviorConfig,
+  env_key: Option<&str>,
+  probe: impl Fn(&str) -> bool,
+) -> Vec<BackendOption> {
+  let mut rows: Vec<BackendOption> = own_command_row(behavior, &probe).into_iter().collect();
+
+  rows.extend(
+    agent_cli::PRESETS
+      .iter()
+      .filter(|preset| RECOMMENDED_AGENTS.contains(&preset.key) || probe(preset.key))
+      .map(|preset| {
+        let ready = probe(preset.key);
+        BackendOption {
+          backend: "agent_cli",
+          agent: Some(preset.key),
+          command: None,
+          label: format!("{} (no API key)", preset.key),
+          note: if ready {
+            agent_note(preset.key).to_string()
+          } else {
+            format!("{}{NOT_INSTALLED}", agent_note(preset.key))
+          },
+          ready,
+        }
+      }),
+  );
+
+  let has_key = anthropic_key_present(env_key, behavior);
+  rows.push(BackendOption {
+    backend: "anthropic",
+    agent: None,
+    command: None,
+    label: "anthropic (API key)".to_string(),
+    note: if has_key {
+      "Anthropic API, pay per token".to_string()
+    } else {
+      format!(
+        "needs {} (or behavior.dj_api_key)",
+        super::session::API_KEY_ENV
+      )
+    },
+    ready: has_key,
+  });
+
+  // Always offered and always ready: "is Ollama running" is a question only a
+  // request can answer, and this module makes no requests.
+  rows.push(BackendOption {
+    backend: "openai_compat",
+    agent: None,
+    command: None,
+    label: "openai_compat (local or self-hosted)".to_string(),
+    note: "any OpenAI-compatible endpoint, e.g. Ollama on localhost".to_string(),
+    ready: true,
+  });
+
+  rows
+}
+
+/// The row for a `dj_agent_command` spotatui does not own, or `None` when it does.
+///
+/// Without it such a command has no row at all, so the picker opens on row 0
+/// (`claude`) and two Enters replace the whole command with `["claude"]` — a config
+/// the docs explicitly invite ("Any other headless command works too"), silently
+/// overwritten by a modal that never showed it. It goes **first** so that is the
+/// row the cursor opens on.
+fn own_command_row(
+  behavior: &BehaviorConfig,
+  probe: impl Fn(&str) -> bool,
+) -> Option<BackendOption> {
+  if behavior.dj_backend != "agent_cli" || super::session::owns_agent_command(behavior) {
+    return None;
+  }
+  let program = behavior.dj_agent_command.first()?.trim();
+  if program.is_empty() {
+    return None;
+  }
+  // Only a bare name is a `PATH` question. `/opt/bin/my-agent` or `npx` wrappers
+  // are already answered, and dimming them with "not on PATH" would be a lie.
+  let ready = if program.contains(std::path::is_separator) {
+    true
+  } else {
+    probe(program)
+  };
+  Some(BackendOption {
+    backend: "agent_cli",
+    agent: None,
+    command: Some(behavior.dj_agent_command.clone()),
+    label: format!("{} (keep)", behavior.dj_agent_command.join(" ")),
+    note: if ready {
+      OWN_COMMAND_NOTE.to_string()
+    } else {
+      format!("{OWN_COMMAND_NOTE}{NOT_INSTALLED}")
+    },
+    ready,
+  })
+}
+
+/// One row of the picker's second step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelOption {
+  /// What gets written. `None` means "write nothing": no model flag for an agent
+  /// CLI, `dj_model: null` for an HTTP backend. This row has to exist so a user can
+  /// get back to the shipped behaviour after picking once.
+  pub value: Option<String>,
+  pub label: String,
+  /// Price or quota note, which is the entire point of showing a list rather than
+  /// asking for a string.
+  pub note: String,
+  /// Opens the free-text step instead of committing.
+  pub custom: bool,
+}
+
+/// Public aliases the `claude` CLI accepts, cheapest first.
+///
+/// Cheapest FIRST, and the cursor starts on row 0 on purpose. This is the whole
+/// reason the picker exists: `claude -p` spends the user's Claude Pro/Max quota,
+/// and a continuous auto-queue is a fresh prompt every few tracks. `haiku` is the
+/// alias that survives that on a Pro plan; anyone who wants `opus` is one row down.
+const CLAUDE_CLI_MODELS: &[(&str, &str)] = &[
+  ("haiku", "cheapest, easiest on a Pro plan"),
+  ("sonnet", "balanced"),
+  ("opus", "heaviest, a Pro plan hits its limit fast"),
+  ("fable", "heaviest"),
+];
+
+/// Anthropic API model ids with list price per million tokens (input/output).
+///
+/// Row 0 is also [`crate::infra::dj::brain::anthropic::DEFAULT_MODEL`], so the
+/// picker's starting cursor and the code's own fallback cannot disagree.
+const ANTHROPIC_MODELS: &[(&str, &str)] = &[
+  ("claude-haiku-4-5", "$1/$5 per MTok, 200K ctx"),
+  ("claude-sonnet-5", "$3/$15 per MTok, 1M ctx"),
+  ("claude-opus-5", "$5/$25 per MTok, 1M ctx"),
+  ("claude-opus-4-8", "$5/$25 per MTok, 1M ctx"),
+  ("claude-fable-5", "$10/$50 per MTok, 1M ctx"),
+];
+
+/// Antigravity's models as `agy models` printed them when this was written.
+///
+/// A snapshot, not a contract: Google changes this list server-side, which is why
+/// the "Custom…" row is always there. Spotatui does not run `agy models` itself,
+/// because a subprocess on the render path is exactly what the DJ's two-lane rule
+/// exists to prevent.
+const AGY_MODELS: &[(&str, &str)] = &[
+  ("gemini-3.6-flash-low", "cheapest"),
+  ("gemini-3.6-flash-medium", ""),
+  ("gemini-3.6-flash-high", ""),
+  ("gemini-3.5-flash-low", ""),
+  ("gemini-3.1-pro-low", ""),
+  ("gemini-3.1-pro-high", "heaviest"),
+  ("claude-sonnet-4-6", ""),
+  ("claude-opus-4-6-thinking", "heaviest"),
+  ("gpt-oss-120b-medium", ""),
+];
+
+/// Which config field carries this row's model, trimmed to a real value.
+///
+/// The two fields are different namespaces and never merge: `dj_agent_model` is a
+/// CLI alias spent against a subscription, `dj_model` is an API model id billed per
+/// token.
+fn current_model(row: &BackendOption, behavior: &BehaviorConfig) -> Option<String> {
+  let field = if row.is_agent() {
+    &behavior.dj_agent_model
+  } else {
+    &behavior.dj_model
+  };
+  field
+    .as_deref()
+    .map(str::trim)
+    .filter(|model| !model.is_empty())
+    .map(str::to_string)
+}
+
+/// The model an HTTP backend falls back on with `dj_model` unset.
+fn builtin_default(backend: &str) -> &'static str {
+  if backend == "anthropic" {
+    super::brain::anthropic::DEFAULT_MODEL
+  } else {
+    super::brain::openai_compat::DEFAULT_MODEL
+  }
+}
+
+/// What the free-text step starts with, so the common edit is a one-character fix
+/// rather than a retype.
+fn custom_prefill(row: &BackendOption, behavior: &BehaviorConfig) -> String {
+  match current_model(row, behavior) {
+    Some(model) => model,
+    // "No model flag at all" is a real state for an agent CLI, so there is nothing
+    // to prefill; the HTTP backends always have a model id in play, and starting
+    // from it makes a near-miss a one-word edit.
+    None if row.is_agent() => String::new(),
+    None => builtin_default(row.backend).to_string(),
+  }
+}
+
+/// The second step's rows for a chosen backend, plus which row the cursor starts
+/// on.
+///
+/// Every backend spotatui can *configure* ends with a "use the backend's own
+/// default" row and a free-text row, so no such backend is a dead end and every one
+/// of them can be returned to the shipped behaviour. The single exception is the
+/// row standing for a command spotatui does not own, which gets one row and no
+/// model choice at all: there is nothing to escape to, because a model written
+/// there would never reach the CLI. See the early return below.
+///
+/// There is deliberately no probe behind this: `agy models` and
+/// `GET /v1/models` would each be a new flag/shape for spotatui to track, and a
+/// stale suggestion costs one fast local error message ("There's an issue with the
+/// selected model") while the free-text row is always right there.
+pub fn models_for(row: &BackendOption, behavior: &BehaviorConfig) -> (Vec<ModelOption>, usize) {
+  // The user's own command: one row, and it changes nothing. There is deliberately
+  // no suggestion list and no free-text row here, because
+  // `session::resolve_agent_command` provably drops the model flag for an argv
+  // spotatui does not own — offering a model would write a `dj_agent_model` that
+  // never reaches the CLI, which is exactly the lie `active_label` was fixed to stop
+  // telling. Whatever model this command uses is in the command.
+  if row.command.is_some() {
+    return (
+      vec![ModelOption {
+        value: None,
+        label: "Keep this command as it is".to_string(),
+        note: "spotatui adds no model flag to a command it does not own".to_string(),
+        custom: false,
+      }],
+      0,
+    );
+  }
+
+  let suggestions: &[(&str, &str)] = match row.agent {
+    Some("claude") => CLAUDE_CLI_MODELS,
+    Some("agy") => AGY_MODELS,
+    // `codex` and the legacy `gemini`: which ids their subscription accepts is not
+    // knowable from here, so free text is the honest answer.
+    Some(_) => &[],
+    None if row.backend == "anthropic" => ANTHROPIC_MODELS,
+    // `openai_compat`: a local model list is only knowable from the endpoint, and
+    // this module makes no requests.
+    None => &[],
+  };
+
+  let mut rows: Vec<ModelOption> = suggestions
+    .iter()
+    .map(|(value, note)| ModelOption {
+      value: Some(value.to_string()),
+      label: value.to_string(),
+      note: note.to_string(),
+      custom: false,
+    })
+    .collect();
+
+  // Computed before the escape hatches are appended, so `unwrap_or(0)` lands on the
+  // cheapest suggestion where there is one and on "use the default" where there is
+  // not. That fallback is only correct when nothing is configured, hence the row
+  // added just below.
+  let current = current_model(row, behavior);
+  let mut cursor = rows
+    .iter()
+    .position(|option| option.value == current)
+    .unwrap_or(0);
+
+  // A model the user typed at the "Custom…" step (`claude-sonnet-4-5-20250929`)
+  // matches no curated suggestion, and only the suggestions carry a value. Without
+  // a row of its own the cursor would fall back to row 0 — the cheapest suggestion —
+  // so reopening the picker to *check* what is set and pressing Enter would replace
+  // it with something else, silently. Inserted before the escape hatches so "use the
+  // default" is still second-to-last and "Custom…" still last.
+  if let Some(model) = current.filter(|model| {
+    !rows
+      .iter()
+      .any(|option| option.value.as_deref() == Some(model.as_str()))
+  }) {
+    rows.push(ModelOption {
+      value: Some(model.clone()),
+      label: model,
+      note: "currently configured".to_string(),
+      custom: false,
+    });
+    cursor = rows.len() - 1;
+  }
+
+  if row.is_agent() {
+    rows.push(ModelOption {
+      value: None,
+      label: "Use the CLI's default".to_string(),
+      note: "no model flag".to_string(),
+      custom: false,
+    });
+  } else {
+    rows.push(ModelOption {
+      value: None,
+      label: format!(
+        "Use the built-in default ({})",
+        builtin_default(row.backend)
+      ),
+      note: String::new(),
+      custom: false,
+    });
+  }
+  rows.push(ModelOption {
+    value: None,
+    label: "Custom…".to_string(),
+    // `opencode` rejects a bare model name, so the one CLI whose format is not
+    // guessable says so here rather than failing at the first turn.
+    note: match row.agent {
+      Some("opencode") => "type a model name, as provider/model".to_string(),
+      _ => "type a model name".to_string(),
+    },
+    custom: true,
+  });
+
+  (rows, cursor)
+}
+
+/// Which picker row the current config already names, so reopening reads as "here
+/// is what you have" rather than "start again".
+fn is_active_row(row: &BackendOption, behavior: &BehaviorConfig) -> bool {
+  if row.backend != behavior.dj_backend {
+    return false;
+  }
+  match (&row.command, row.agent) {
+    // The user's own command matches the config it was built from, and nothing else.
+    (Some(command), _) => command == &behavior.dj_agent_command,
+    // `owns_agent_command` as well as the name: `["claude", "--verbose", "-p"]`
+    // starts with `claude` but is not the `claude` preset row, and claiming it here
+    // is what would let Enter rewrite it.
+    (None, Some(agent)) => {
+      super::session::owns_agent_command(behavior)
+        && behavior
+          .dj_agent_command
+          .first()
+          .is_some_and(|first| first.trim() == agent)
+    }
+    (None, None) => true,
+  }
+}
+
+/// `claude/haiku`, `anthropic/claude-haiku-4-5`, or `None` when the backend is not
+/// one spotatui knows.
+///
+/// Reports what config names, which is also exactly what the picker writes. Shared
+/// by `ui::ai_dj::title` and the picker's initial cursor, so the screen and the
+/// picker can never disagree about what is active.
+pub fn active_label(behavior: &BehaviorConfig) -> Option<String> {
+  let (name, model) = match behavior.dj_backend.as_str() {
+    "agent_cli" => {
+      let agent = behavior.dj_agent_command.first()?.trim();
+      if agent.is_empty() {
+        return None;
+      }
+      // Only an argv spotatui owns actually receives `--model`:
+      // `session::resolve_agent_command` drops the flag for a hand-written command,
+      // so naming `dj_agent_model` here would put a model in the title that the CLI
+      // is never told about — the invisible-mode bug this title exists to prevent,
+      // in the title itself.
+      let model = super::session::owns_agent_command(behavior)
+        .then(|| behavior.dj_agent_model.clone())
+        .flatten();
+      (agent.to_string(), model)
+    }
+    "anthropic" | "openai_compat" => (behavior.dj_backend.clone(), behavior.dj_model.clone()),
+    // Load validates `dj_backend`, so this is only reachable from a config built in
+    // code. Saying nothing beats inventing a name for it.
+    _ => return None,
+  };
+  let model = model
+    .map(|model| model.trim().to_string())
+    .filter(|model| !model.is_empty());
+  Some(match model {
+    Some(model) => format!("{name}/{model}"),
+    None => name,
+  })
+}
+
+/// Which of the picker's three steps is on screen.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DjSetupStep {
+  #[default]
+  Backend,
+  Model,
+  /// Free-text model entry. A typing surface, so the key routing for this step is
+  /// deliberately different from the other two.
+  Custom,
+}
+
+/// The picker. Lives on `DjState`, so it must be `Clone + Debug`.
+#[derive(Clone, Debug)]
+pub struct DjSetup {
+  pub step: DjSetupStep,
+  /// Built once when the picker opens. Detection stats `PATH`, and re-statting on
+  /// every keypress would be syscalls for nothing.
+  pub backends: Vec<BackendOption>,
+  pub backend_index: usize,
+  pub models: Vec<ModelOption>,
+  pub model_index: usize,
+  /// Free-text buffer for the "Custom…" row.
+  pub custom: String,
+}
+
+impl DjSetup {
+  /// Open on the row that is already active.
+  pub fn new(behavior: &BehaviorConfig) -> Self {
+    let backends = detect_backends(behavior);
+    let backend_index = backends
+      .iter()
+      .position(|row| is_active_row(row, behavior))
+      .unwrap_or(0);
+    Self {
+      step: DjSetupStep::Backend,
+      backends,
+      backend_index,
+      models: Vec::new(),
+      model_index: 0,
+      custom: String::new(),
+    }
+  }
+
+  /// How many rows the current step has. The free-text step has none, which is
+  /// what makes every navigation method a no-op there.
+  fn rows(&self) -> usize {
+    match self.step {
+      DjSetupStep::Backend => self.backends.len(),
+      DjSetupStep::Model => self.models.len(),
+      DjSetupStep::Custom => 0,
+    }
+  }
+
+  pub fn move_down(&mut self) {
+    let last = self.rows().saturating_sub(1);
+    match self.step {
+      DjSetupStep::Backend => self.backend_index = (self.backend_index + 1).min(last),
+      DjSetupStep::Model => self.model_index = (self.model_index + 1).min(last),
+      DjSetupStep::Custom => {}
+    }
+  }
+
+  pub fn move_up(&mut self) {
+    match self.step {
+      DjSetupStep::Backend => self.backend_index = self.backend_index.saturating_sub(1),
+      DjSetupStep::Model => self.model_index = self.model_index.saturating_sub(1),
+      DjSetupStep::Custom => {}
+    }
+  }
+
+  /// Jump straight to row `n` (1-based), reporting whether there was such a row.
+  ///
+  /// The caller acts on `true` by advancing: the rows are numbered on screen, and a
+  /// digit shortcut that still needs an Enter saves nothing.
+  pub fn select_row(&mut self, n: usize) -> bool {
+    if n == 0 || n > self.rows() {
+      return false;
+    }
+    match self.step {
+      DjSetupStep::Backend => self.backend_index = n - 1,
+      DjSetupStep::Model => self.model_index = n - 1,
+      DjSetupStep::Custom => return false,
+    }
+    true
+  }
+
+  /// Enter the model step for the selected backend.
+  pub fn enter_model_step(&mut self, behavior: &BehaviorConfig) {
+    let Some(row) = self.selected_backend().cloned() else {
+      return;
+    };
+    let (models, index) = models_for(&row, behavior);
+    self.models = models;
+    self.model_index = index;
+    self.step = DjSetupStep::Model;
+  }
+
+  /// Enter the free-text step, prefilled.
+  pub fn enter_custom_step(&mut self, behavior: &BehaviorConfig) {
+    self.custom = self
+      .selected_backend()
+      .map(|row| custom_prefill(row, behavior))
+      .unwrap_or_default();
+    self.step = DjSetupStep::Custom;
+  }
+
+  pub fn selected_backend(&self) -> Option<&BackendOption> {
+    self.backends.get(self.backend_index)
+  }
+
+  pub fn selected_model(&self) -> Option<&ModelOption> {
+    self.models.get(self.model_index)
+  }
+
+  /// The config edit this picker would make, or `None` if it is not finished.
+  ///
+  /// Pure, so the handler tests can assert on the decision without a filesystem.
+  pub fn choice(&self) -> Option<DjSetupChoice> {
+    let backend = self.selected_backend()?;
+    let model = match self.step {
+      // A backend on its own is not an answer: which model is the half the user
+      // came for.
+      DjSetupStep::Backend => return None,
+      DjSetupStep::Model => {
+        let row = self.selected_model()?;
+        if row.custom {
+          return None;
+        }
+        row.value.clone()
+      }
+      // An empty buffer means "use the default" rather than an error, so the
+      // free-text step is never a dead end either.
+      DjSetupStep::Custom => {
+        let typed = self.custom.trim();
+        (!typed.is_empty()).then(|| typed.to_string())
+      }
+    };
+    Some(DjSetupChoice {
+      backend: backend.backend.to_string(),
+      agent_command: match &backend.command {
+        // Reported so `describe` can name the command, not written: `keep_command`
+        // tells `apply_choice` to leave every command field exactly as it found it.
+        Some(command) => Some(command.clone()),
+        None => backend.agent.map(|agent| vec![agent.to_string()]),
+      },
+      keep_command: backend.command.is_some(),
+      model,
+      ready: backend.ready,
+    })
+  }
+}
+
+/// The config edit a completed picker makes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DjSetupChoice {
+  pub backend: String,
+  /// A **bare** preset name for `agent_cli` (`["claude"]`), never a full argv, so
+  /// `session::resolve_agent_command` keeps ownership of the flags and can keep
+  /// inserting the model flag in the right place as the presets change. `None` for
+  /// the HTTP backends, which leave `dj_agent_command` alone.
+  pub agent_command: Option<Vec<String>>,
+  /// The chosen row was the user's own `dj_agent_command`, so this choice writes
+  /// **no** command and **no** model: it only records that the question was
+  /// answered. Without it, the row would fall into the `Some(command)` arm of
+  /// [`apply_choice`] and clear `dj_agent_prompt_via` and `dj_agent_model` behind
+  /// the user's back — for `agy`, whose delivery mode is `arg`, clearing the
+  /// delivery drops the prompt entirely.
+  pub keep_command: bool,
+  /// Goes to `dj_agent_model` for `agent_cli`, `dj_model` for the HTTP backends.
+  pub model: Option<String>,
+  /// Whether the chosen backend is usable right now, for the confirmation message.
+  pub ready: bool,
+}
+
+impl DjSetupChoice {
+  /// `claude/haiku`, `anthropic/claude-haiku-4-5`, `codex`.
+  pub fn describe(&self) -> String {
+    let name = self
+      .agent_command
+      .as_ref()
+      .and_then(|command| command.first().cloned())
+      .unwrap_or_else(|| self.backend.clone());
+    match &self.model {
+      Some(model) => format!("{name}/{model}"),
+      None => name,
+    }
+  }
+}
+
+/// Write a finished choice into config. Pure and unit-testable: no IO, no save.
+///
+/// Clears the *other* backend's model field as well. A stale `dj_agent_model` left
+/// behind by a switch to `anthropic` would silently reappear on the next switch
+/// back, which is exactly the invisible-mode bug `ui::ai_dj::title` exists to
+/// prevent.
+pub fn apply_choice(behavior: &mut BehaviorConfig, choice: &DjSetupChoice) {
+  behavior.dj_backend = choice.backend.clone();
+  // "Keep what I wrote" is an answer, and the only correct way to honour it is to
+  // write nothing at all — not even the identical command back, since the
+  // `Some(command)` arm below also clears the delivery mode and the model.
+  if choice.keep_command {
+    return;
+  }
+  match &choice.agent_command {
+    Some(command) => {
+      behavior.dj_agent_command = command.clone();
+      // Cleared so the preset decides. This is what makes `agy` work at all: it
+      // ignores stdin, and every existing install has `stdin` on disk from an
+      // earlier automatic save, which would silently drop the prompt.
+      behavior.dj_agent_prompt_via = None;
+      behavior.dj_agent_model = choice.model.clone();
+      behavior.dj_model = None;
+    }
+    None => {
+      behavior.dj_model = choice.model.clone();
+      behavior.dj_agent_model = None;
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::user_config::UserConfig;
+  use crate::infra::dj::session::API_KEY_ENV;
+
+  fn behavior() -> BehaviorConfig {
+    UserConfig::new().behavior
+  }
+
+  /// A per-process scratch dir with one file in it, `mode` deciding whether it
+  /// counts as a binary.
+  ///
+  /// Per-process for the same reason `agent_cli`'s stub table is: a fixed path
+  /// collides with a previous `cargo test` run that is still finishing.
+  #[cfg(unix)]
+  fn dir_containing(name: &str, mode: u32) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!(
+      "spotatui-dj-detect-{}-{name}-{mode:o}",
+      std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, "#!/bin/sh\ntrue\n").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).unwrap();
+    dir
+  }
+
+  /// Detection with nothing ambient: no API key, and every agent CLI installed.
+  ///
+  /// The environment is passed, never mutated. `remove_var`/`set_var` around a live
+  /// test binary is a data race with the sibling tests in `session.rs` that read the
+  /// same variable on other threads, and `setenv`/`getenv` are not thread-safe —
+  /// which is why edition 2024 makes them `unsafe`.
+  fn detect_installed(behavior: &BehaviorConfig) -> Vec<BackendOption> {
+    detect_backends_with(behavior, None, |_| true)
+  }
+
+  #[test]
+  fn detection_ignores_a_binary_that_is_not_on_path() {
+    assert!(!binary_in_dirs(
+      "spotatui-definitely-not-a-real-binary",
+      &[std::env::temp_dir()]
+    ));
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn detection_finds_an_executable_on_a_path_entry() {
+    let dir = dir_containing("pretend-agent", 0o755);
+    assert!(binary_in_dirs("pretend-agent", &[dir]));
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn a_non_executable_file_with_the_right_name_is_not_a_binary() {
+    // A README or a config named `claude` must not read as an installed CLI.
+    let dir = dir_containing("inert-agent", 0o644);
+    assert!(!binary_in_dirs("inert-agent", &[dir]));
+  }
+
+  #[test]
+  fn every_offered_agent_row_names_a_real_preset() {
+    // The drift guard: a row whose agent has no preset would resolve to a bare
+    // binary name with no subcommand and no delivery flag.
+    for row in detect_backends(&behavior()) {
+      if let Some(agent) = row.agent {
+        assert!(
+          agent_cli::preset(agent).is_some(),
+          "row {agent} has no preset"
+        );
+        assert_eq!(row.backend, "agent_cli");
+      }
+      assert!(!row.note.is_empty(), "{} has no note", row.label);
+    }
+  }
+
+  #[test]
+  fn the_deprecated_gemini_agent_is_not_advertised_but_still_resolves() {
+    // Asserted against the list, not against detection: `RECOMMENDED_AGENTS
+    // .contains(key) || probe(key)` is trivially true for anything installed, so
+    // comparing "offered" with "on PATH" would hold even with gemini put back on the
+    // advertised list — and the binary happens to be installed on the machine this
+    // was written on.
+    assert!(
+      !RECOMMENDED_AGENTS.contains(&"gemini"),
+      "the legacy CLI must not be advertised"
+    );
+    assert!(
+      agent_cli::preset("gemini").is_some(),
+      "but an existing config that names it still has to resolve"
+    );
+    assert!(
+      !detect_backends_with(&behavior(), None, |_| false)
+        .iter()
+        .any(|row| row.agent == Some("gemini")),
+      "so it appears only when the binary is actually there"
+    );
+  }
+
+  #[test]
+  fn an_agent_row_is_offered_but_dimmed_when_its_binary_is_missing() {
+    // "I am about to install it" is a real answer, so a missing CLI is still a row —
+    // it just has to say so. Driven off an injected probe rather than the real PATH:
+    // with `on_path` this assertion says something different on every machine, and
+    // passes on a bare CI runner even with the readiness check deleted.
+    let rows = detect_backends_with(&behavior(), None, |_| false);
+    let agents: Vec<_> = rows.iter().filter(|row| row.agent.is_some()).collect();
+    assert_eq!(
+      agents.len(),
+      RECOMMENDED_AGENTS.len(),
+      "nothing installed still offers every recommended CLI"
+    );
+    for row in agents {
+      assert!(!row.ready, "{} claims to be usable", row.label);
+      assert!(row.note.ends_with(NOT_INSTALLED), "{}", row.note);
+    }
+  }
+
+  #[test]
+  fn an_agent_row_is_ready_and_says_only_what_it_bills_when_the_binary_is_there() {
+    for row in detect_installed(&behavior()) {
+      if row.agent.is_none() {
+        continue;
+      }
+      assert!(
+        row.ready,
+        "{} is installed but not offered as ready",
+        row.label
+      );
+      assert!(!row.note.contains(NOT_INSTALLED), "{}", row.note);
+    }
+  }
+
+  #[test]
+  fn the_anthropic_row_is_offered_without_a_key_and_says_what_is_missing() {
+    let mut behavior = behavior();
+    behavior.dj_api_key = None;
+    let rows = detect_backends_with(&behavior, None, |_| true);
+    let row = rows
+      .iter()
+      .find(|row| row.backend == "anthropic")
+      .expect("the anthropic row is always offered");
+    assert!(!row.ready);
+    assert!(row.note.contains(API_KEY_ENV), "{}", row.note);
+
+    // And the other way round, from the same injected environment rather than from
+    // whatever this machine happens to export.
+    let rows = detect_backends_with(&behavior, Some("sk-ant-not-a-real-key"), |_| true);
+    let row = rows
+      .iter()
+      .find(|row| row.backend == "anthropic")
+      .expect("the anthropic row is always offered");
+    assert!(row.ready);
+    assert!(!row.note.contains(API_KEY_ENV), "{}", row.note);
+  }
+
+  #[test]
+  fn a_blank_exported_key_does_not_count_as_a_key() {
+    assert!(!anthropic_key_present(Some("   "), &behavior()));
+    let mut behavior = behavior();
+    behavior.dj_api_key = Some("from-config".to_string());
+    assert!(anthropic_key_present(None, &behavior));
+  }
+
+  /// One picker row, found the way the picker itself finds it.
+  fn row(matches: impl Fn(&BackendOption) -> bool) -> BackendOption {
+    detect_backends(&behavior())
+      .into_iter()
+      .find(|row| matches(row))
+      .expect("the row is offered")
+  }
+
+  fn agent_row(agent: &'static str) -> BackendOption {
+    row(|row| row.agent == Some(agent))
+  }
+
+  fn backend_row(backend: &'static str) -> BackendOption {
+    row(|row| row.agent.is_none() && row.backend == backend)
+  }
+
+  /// Drive the picker to the model step for one row, the way the handler does.
+  fn at_model_step(behavior: &BehaviorConfig, wanted: &BackendOption) -> DjSetup {
+    let mut setup = DjSetup::new(behavior);
+    setup.backend_index = setup
+      .backends
+      .iter()
+      .position(|row| row == wanted)
+      .expect("the row is offered");
+    setup.enter_model_step(behavior);
+    setup
+  }
+
+  #[test]
+  fn the_claude_model_list_starts_on_the_cheapest_alias() {
+    // The reason the picker exists: `claude -p` spends a Pro/Max quota per turn, so
+    // the cursor must not land the user on the model that exhausts it.
+    let (models, cursor) = models_for(&agent_row("claude"), &behavior());
+    assert_eq!(models[cursor].value.as_deref(), Some("haiku"));
+  }
+
+  #[test]
+  fn the_claude_model_list_reopens_on_the_alias_already_chosen() {
+    let mut behavior = behavior();
+    behavior.dj_agent_model = Some("opus".to_string());
+    let (models, cursor) = models_for(&agent_row("claude"), &behavior);
+    assert_eq!(models[cursor].value.as_deref(), Some("opus"));
+  }
+
+  #[test]
+  fn the_model_list_keeps_a_model_that_is_not_one_of_its_suggestions() {
+    // The reopen-to-check case. A model typed at the "Custom…" step matches no
+    // curated row, and every escape-hatch row has `value: None`, so without a row of
+    // its own the cursor falls back to row 0 — `haiku` — and a reflexive Enter
+    // replaces a deliberate choice with the cheapest suggestion.
+    let mut behavior = behavior();
+    behavior.dj_agent_model = Some("claude-sonnet-4-5-20250929".to_string());
+    let (models, cursor) = models_for(&agent_row("claude"), &behavior);
+    assert_eq!(
+      models[cursor].value.as_deref(),
+      Some("claude-sonnet-4-5-20250929"),
+      "the cursor must open on what is configured, not on row 0"
+    );
+    assert_eq!(models[cursor].note, "currently configured");
+    // And it lands in front of the escape hatches, so they keep their positions.
+    assert!(models.last().expect("never empty").custom);
+    assert!(models[models.len() - 2].value.is_none());
+
+    // The same for an API model id that has aged out of the priced list.
+    let mut behavior = behavior;
+    behavior.dj_backend = "anthropic".to_string();
+    behavior.dj_model = Some("claude-3-5-sonnet-20241022".to_string());
+    let (models, cursor) = models_for(&backend_row("anthropic"), &behavior);
+    assert_eq!(
+      models[cursor].value.as_deref(),
+      Some("claude-3-5-sonnet-20241022")
+    );
+  }
+
+  #[test]
+  fn the_anthropic_model_list_starts_on_the_default_model() {
+    // Read from the const rather than repeated, so the picker cannot drift from the
+    // model the brain would have used anyway.
+    let (models, cursor) = models_for(&backend_row("anthropic"), &behavior());
+    assert_eq!(
+      models[cursor].value.as_deref(),
+      Some(crate::infra::dj::brain::anthropic::DEFAULT_MODEL)
+    );
+  }
+
+  #[test]
+  fn the_anthropic_model_list_prices_every_row() {
+    // A model list without prices is just as opaque as the config field it replaces.
+    let (models, _) = models_for(&backend_row("anthropic"), &behavior());
+    for option in models.iter().filter(|option| option.value.is_some()) {
+      assert!(
+        option.note.contains("per MTok"),
+        "{} has no price",
+        option.label
+      );
+    }
+  }
+
+  #[test]
+  fn every_model_list_ends_with_a_free_text_row() {
+    // The no-dead-end guarantee. There is no probe behind these lists, so a stale
+    // suggestion set must never be the only way to name a model.
+    //
+    // Both configs, because the default one cannot produce the own-command row, and
+    // that row is the single deliberate exception to the guarantee. Iterating only
+    // the default config would let the exception widen silently to a backend that
+    // does need an escape hatch, which is the failure this test exists to catch.
+    for behavior in [behavior(), hand_written()] {
+      for backend in detect_backends(&behavior) {
+        let (models, cursor) = models_for(&backend, &behavior);
+        assert!(
+          cursor < models.len(),
+          "{} starts out of range",
+          backend.label
+        );
+        let last = models.last().expect("never empty");
+
+        if backend.command.is_some() {
+          // The exception, asserted rather than skipped: one row, and it is not a
+          // model choice, because a model named here would never reach the CLI.
+          assert_eq!(
+            models.len(),
+            1,
+            "{} offers a model flag it cannot pass",
+            backend.label
+          );
+          assert!(!last.custom && last.value.is_none(), "{}", backend.label);
+          continue;
+        }
+
+        assert!(last.custom, "{} cannot type a model name", backend.label);
+        let default_row = &models[models.len() - 2];
+        assert!(
+          default_row.value.is_none() && !default_row.custom,
+          "{} cannot return to its own default",
+          backend.label
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn a_cli_with_no_known_models_still_offers_its_own_default_and_free_text() {
+    // Which ids `codex` accepts is not knowable without asking it, and asking costs
+    // a subprocess. Two rows is the honest answer, not an empty list.
+    let (models, cursor) = models_for(&agent_row("codex"), &behavior());
+    assert_eq!(models.len(), 2);
+    assert_eq!(cursor, 0, "the cursor starts on 'use the CLI's default'");
+    assert!(models[0].value.is_none());
+    assert!(models[1].custom);
+  }
+
+  #[test]
+  fn the_picker_opens_on_the_backend_already_configured() {
+    let mut behavior = behavior();
+    behavior.dj_backend = "anthropic".to_string();
+    let setup = DjSetup::new(&behavior);
+    assert_eq!(
+      setup.selected_backend().map(|row| row.backend),
+      Some("anthropic"),
+      "reopening should read as 'here is what you have'"
+    );
+  }
+
+  #[test]
+  fn choosing_an_agent_writes_a_bare_command_so_the_preset_keeps_ownership() {
+    let mut behavior = behavior();
+    let setup = at_model_step(&behavior, &agent_row("agy"));
+    let choice = setup.choice().expect("a model row is selected");
+    apply_choice(&mut behavior, &choice);
+
+    // Bare, not `["agy", "--model", …, "-p"]`: the argv shape is the preset's job,
+    // and only the preset knows the model flag has to precede the delivery flag.
+    assert_eq!(behavior.dj_agent_command, vec!["agy".to_string()]);
+    assert_eq!(
+      behavior.dj_agent_model.as_deref(),
+      Some("gemini-3.6-flash-low")
+    );
+    assert_eq!(behavior.dj_backend, "agent_cli");
+  }
+
+  #[test]
+  fn choosing_an_agent_clears_the_prompt_delivery_so_the_preset_decides() {
+    // `agy` ignores stdin entirely, and every existing install has `stdin` on disk
+    // from an automatic save. Leaving it there would deliver the prompt nowhere.
+    let mut behavior = behavior();
+    behavior.dj_agent_prompt_via = Some("stdin".to_string());
+    let setup = at_model_step(&behavior, &agent_row("agy"));
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(behavior.dj_agent_prompt_via, None);
+  }
+
+  #[test]
+  fn choosing_an_http_backend_writes_dj_model_not_dj_agent_model() {
+    let mut behavior = behavior();
+    let setup = at_model_step(&behavior, &backend_row("anthropic"));
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(
+      behavior.dj_model.as_deref(),
+      Some(crate::infra::dj::brain::anthropic::DEFAULT_MODEL)
+    );
+    assert_eq!(behavior.dj_agent_model, None);
+    // An API backend has no argv to speak of, so the agent command is left alone.
+    assert_eq!(
+      behavior.dj_agent_command,
+      crate::core::user_config::default_dj_agent_command()
+    );
+  }
+
+  #[test]
+  fn switching_backends_clears_the_other_backends_model() {
+    // `haiku` and `claude-haiku-4-5` are different namespaces. A leftover would
+    // reappear on the next switch back, as a mode nobody chose.
+    let mut behavior = behavior();
+    let setup = at_model_step(&behavior, &agent_row("claude"));
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(behavior.dj_agent_model.as_deref(), Some("haiku"));
+
+    let setup = at_model_step(&behavior, &backend_row("anthropic"));
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(behavior.dj_agent_model, None);
+    assert!(behavior.dj_model.is_some());
+
+    let setup = at_model_step(&behavior, &agent_row("claude"));
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(behavior.dj_model, None);
+  }
+
+  #[test]
+  fn the_use_the_default_row_clears_the_model_instead_of_writing_one() {
+    let mut behavior = behavior();
+    behavior.dj_agent_model = Some("opus".to_string());
+    let mut setup = at_model_step(&behavior, &agent_row("claude"));
+    // The row before "Custom…" is always "use the default".
+    setup.model_index = setup.models.len() - 2;
+    apply_choice(&mut behavior, &setup.choice().unwrap());
+    assert_eq!(
+      behavior.dj_agent_model, None,
+      "picking once must not be a one-way door"
+    );
+  }
+
+  #[test]
+  fn the_free_text_row_is_not_itself_an_answer() {
+    let mut setup = at_model_step(&behavior(), &agent_row("claude"));
+    setup.model_index = setup.models.len() - 1;
+    assert!(
+      setup.choice().is_none(),
+      "'Custom…' opens the typing step, it does not commit"
+    );
+  }
+
+  #[test]
+  fn a_typed_model_commits_and_an_empty_one_falls_back_to_the_default() {
+    let behavior = behavior();
+    let mut setup = at_model_step(&behavior, &agent_row("codex"));
+    setup.enter_custom_step(&behavior);
+    setup.custom = "  gpt-5-codex  ".to_string();
+    assert_eq!(
+      setup.choice().unwrap().model.as_deref(),
+      Some("gpt-5-codex"),
+      "trimmed, because a trailing space in argv is a different model name"
+    );
+
+    setup.custom = "   ".to_string();
+    assert_eq!(
+      setup.choice().unwrap().model,
+      None,
+      "an empty buffer means 'use the default', not an error"
+    );
+  }
+
+  #[test]
+  fn the_free_text_step_for_an_http_backend_starts_from_its_built_in_default() {
+    // `openai_compat` has no suggestion list, so the buffer is the only place the
+    // model id can come from; starting empty would make the common case a retype.
+    let behavior = behavior();
+    let mut setup = at_model_step(&behavior, &backend_row("openai_compat"));
+    setup.enter_custom_step(&behavior);
+    assert_eq!(
+      setup.custom,
+      crate::infra::dj::brain::openai_compat::DEFAULT_MODEL
+    );
+  }
+
+  #[test]
+  fn a_backend_on_its_own_is_not_a_finished_choice() {
+    let setup = DjSetup::new(&behavior());
+    assert_eq!(setup.step, DjSetupStep::Backend);
+    assert!(setup.choice().is_none(), "the model is half the question");
+  }
+
+  #[test]
+  fn navigation_saturates_at_both_ends() {
+    let mut setup = DjSetup::new(&behavior());
+    let rows = setup.backends.len();
+    for _ in 0..rows + 5 {
+      setup.move_down();
+    }
+    assert_eq!(setup.backend_index, rows - 1);
+    for _ in 0..rows + 5 {
+      setup.move_up();
+    }
+    assert_eq!(setup.backend_index, 0);
+    assert!(!setup.select_row(rows + 1), "out of range is a no-op");
+    assert!(setup.select_row(2));
+    assert_eq!(setup.backend_index, 1);
+  }
+
+  #[test]
+  fn active_label_reports_the_backend_and_model_pair() {
+    let mut behavior = behavior();
+    assert_eq!(active_label(&behavior).as_deref(), Some("claude"));
+
+    behavior.dj_agent_model = Some("haiku".to_string());
+    assert_eq!(active_label(&behavior).as_deref(), Some("claude/haiku"));
+
+    behavior.dj_backend = "anthropic".to_string();
+    behavior.dj_model = Some("claude-sonnet-5".to_string());
+    assert_eq!(
+      active_label(&behavior).as_deref(),
+      Some("anthropic/claude-sonnet-5")
+    );
+  }
+
+  /// The config `docs/ai-dj.md` invites: "Any other headless command works too."
+  ///
+  /// `arg` delivery and a model are both set, because both are things the picker
+  /// used to quietly discard for this config.
+  fn hand_written() -> BehaviorConfig {
+    let mut behavior = behavior();
+    behavior.dj_agent_command = vec!["my-agent".to_string(), "--headless".to_string()];
+    behavior.dj_agent_prompt_via = Some("arg".to_string());
+    behavior.dj_agent_model = Some("haiku".to_string());
+    behavior
+  }
+
+  #[test]
+  fn a_hand_written_command_gets_the_first_row_and_survives_two_enters() {
+    let behavior = hand_written();
+    let mut setup = DjSetup::new(&behavior);
+    let row = setup.selected_backend().expect("a row is selected").clone();
+    assert_eq!(
+      row.command.as_ref(),
+      Some(&behavior.dj_agent_command),
+      "the picker has to open on the command it found, not on `claude`"
+    );
+    assert!(row.label.contains("my-agent --headless"), "{}", row.label);
+
+    // One row, and it is not a model choice. `resolve_agent_command` drops the model
+    // flag for an argv spotatui does not own, so any suggestion here would write a
+    // `dj_agent_model` the CLI is never told about.
+    let (models, cursor) = models_for(&row, &behavior);
+    assert_eq!(models.len(), 1, "{models:?}");
+    assert_eq!(cursor, 0);
+    assert!(models[0].value.is_none() && !models[0].custom);
+
+    let mut after = behavior.clone();
+    setup.enter_model_step(&behavior);
+    apply_choice(
+      &mut after,
+      &setup.choice().expect("the single row is an answer"),
+    );
+    assert_eq!(after.dj_agent_command, behavior.dj_agent_command);
+    assert_eq!(
+      after.dj_agent_prompt_via, behavior.dj_agent_prompt_via,
+      "clearing it would hand an arg-delivery CLI its prompt on stdin, i.e. nowhere"
+    );
+    assert_eq!(after.dj_agent_model, behavior.dj_agent_model);
+    assert_eq!(after.dj_model, behavior.dj_model);
+  }
+
+  #[test]
+  fn the_title_omits_a_model_the_cli_is_never_told_about() {
+    let mut behavior = behavior();
+    behavior.dj_agent_command = vec![
+      "claude".to_string(),
+      "--verbose".to_string(),
+      "-p".to_string(),
+    ];
+    behavior.dj_agent_model = Some("haiku".to_string());
+    assert_eq!(
+      active_label(&behavior).as_deref(),
+      Some("claude"),
+      "the spawned argv has no --model, so the title must not advertise one"
+    );
+
+    // The very same field is reported once the command is one spotatui owns, which
+    // is what makes the title and the resolved argv the same statement.
+    behavior.dj_agent_command = vec!["claude".to_string()];
+    assert_eq!(active_label(&behavior).as_deref(), Some("claude/haiku"));
+  }
+
+  #[test]
+  fn the_picker_always_opens_on_a_row_that_preserves_what_is_configured() {
+    // One invariant over six configs: the row the cursor opens on either names
+    // exactly what is configured, or is the row that explicitly preserves it.
+    // Anything else is a modal that misreports the config and then overwrites it on
+    // Enter — which is the same user-visible failure whether the mismatch is in the
+    // backend list, the model list, or the title.
+    //
+    // Every expectation below is a literal. Deriving them from the helper the code
+    // under test uses (`session::owns_agent_command`) would let a bug in it cancel
+    // out on both sides.
+    let mut bare = behavior();
+    bare.dj_agent_command = vec!["claude".to_string()];
+    let mut preset_and_model = bare.clone();
+    preset_and_model.dj_agent_model = Some("opus".to_string());
+    let mut typed_model = bare.clone();
+    typed_model.dj_agent_model = Some("claude-sonnet-4-5-20250929".to_string());
+    let mut flagged_preset = behavior();
+    flagged_preset.dj_agent_command = vec![
+      "claude".to_string(),
+      "--verbose".to_string(),
+      "-p".to_string(),
+    ];
+    flagged_preset.dj_agent_model = Some("haiku".to_string());
+    let mut api = behavior();
+    api.dj_backend = "anthropic".to_string();
+    api.dj_model = Some("claude-opus-5".to_string());
+
+    struct Case {
+      name: &'static str,
+      behavior: BehaviorConfig,
+      /// The row the picker must open on: `(backend, agent, is it the user's own
+      /// command?)`.
+      row: (&'static str, Option<&'static str>, bool),
+      /// The model row the cursor must land on.
+      model: Option<&'static str>,
+      /// What the DJ title says before the picker runs, and after Enter, Enter.
+      /// Equal for every config that already names something.
+      title: (&'static str, &'static str),
+      /// Whether Enter, Enter has to leave every config field exactly as it was.
+      untouched: bool,
+    }
+
+    for case in [
+      Case {
+        name: "a fresh default install",
+        behavior: behavior(),
+        row: ("agent_cli", Some("claude"), false),
+        model: Some("haiku"),
+        title: ("claude", "claude/haiku"),
+        untouched: false,
+      },
+      Case {
+        name: "a bare preset name",
+        behavior: bare,
+        row: ("agent_cli", Some("claude"), false),
+        model: Some("haiku"),
+        title: ("claude", "claude/haiku"),
+        untouched: false,
+      },
+      Case {
+        name: "a preset with a chosen alias",
+        behavior: preset_and_model,
+        row: ("agent_cli", Some("claude"), false),
+        model: Some("opus"),
+        title: ("claude/opus", "claude/opus"),
+        untouched: true,
+      },
+      Case {
+        name: "a model typed at the Custom step",
+        behavior: typed_model,
+        row: ("agent_cli", Some("claude"), false),
+        model: Some("claude-sonnet-4-5-20250929"),
+        title: (
+          "claude/claude-sonnet-4-5-20250929",
+          "claude/claude-sonnet-4-5-20250929",
+        ),
+        untouched: true,
+      },
+      Case {
+        name: "a hand-written multi-part command",
+        behavior: hand_written(),
+        row: ("agent_cli", None, true),
+        model: None,
+        // No model, either side: this argv never receives the `--model` flag, so
+        // `dj_agent_model: haiku` is set but not in effect.
+        title: ("my-agent", "my-agent"),
+        untouched: true,
+      },
+      Case {
+        name: "a preset name with a flag added by hand",
+        behavior: flagged_preset,
+        row: ("agent_cli", None, true),
+        model: None,
+        // The trap case: it starts with `claude`, so the preset row would happily
+        // claim it and Enter would drop `--verbose`.
+        title: ("claude", "claude"),
+        untouched: true,
+      },
+      Case {
+        name: "an API backend with a model id",
+        behavior: api,
+        row: ("anthropic", None, false),
+        model: Some("claude-opus-5"),
+        title: ("anthropic/claude-opus-5", "anthropic/claude-opus-5"),
+        untouched: true,
+      },
+    ] {
+      let Case {
+        name,
+        behavior,
+        row: (backend, agent, own_command),
+        model,
+        title,
+        untouched,
+      } = case;
+      assert_eq!(
+        active_label(&behavior).as_deref(),
+        Some(title.0),
+        "{name}: the title misreports the config before the picker even opens"
+      );
+
+      let mut setup = DjSetup::new(&behavior);
+      let row = setup
+        .selected_backend()
+        .unwrap_or_else(|| panic!("{name}: nothing selected"));
+      assert_eq!(row.backend, backend, "{name}");
+      assert_eq!(row.agent, agent, "{name}");
+      assert_eq!(
+        row.command.as_ref(),
+        own_command.then_some(&behavior.dj_agent_command),
+        "{name}"
+      );
+
+      setup.enter_model_step(&behavior);
+      let selected = setup
+        .selected_model()
+        .unwrap_or_else(|| panic!("{name}: no model row"));
+      assert_eq!(selected.value.as_deref(), model, "{name}");
+
+      let mut after = behavior.clone();
+      apply_choice(
+        &mut after,
+        &setup
+          .choice()
+          .unwrap_or_else(|| panic!("{name}: the open row is not an answer")),
+      );
+      assert_eq!(
+        active_label(&after).as_deref(),
+        Some(title.1),
+        "{name}: the title after the picker ran"
+      );
+      if untouched {
+        assert_eq!(after.dj_backend, behavior.dj_backend, "{name}");
+        assert_eq!(
+          after.dj_agent_command, behavior.dj_agent_command,
+          "{name}: the command was rewritten"
+        );
+        assert_eq!(after.dj_agent_model, behavior.dj_agent_model, "{name}");
+        assert_eq!(after.dj_model, behavior.dj_model, "{name}");
+        assert_eq!(
+          after.dj_agent_prompt_via, behavior.dj_agent_prompt_via,
+          "{name}: prompt delivery was cleared"
+        );
+      } else {
+        // Nothing was configured to preserve, so the picker is free to suggest, and
+        // deliberately does: cheapest first, which is the reason it exists. What it
+        // still may not change is which CLI is being run.
+        assert_eq!(
+          after.dj_agent_command.first(),
+          behavior.dj_agent_command.first(),
+          "{name}"
+        );
+        assert_eq!(after.dj_agent_model.as_deref(), model, "{name}");
+      }
+    }
+  }
+
+  #[test]
+  fn active_label_says_nothing_for_a_backend_it_does_not_know() {
+    let mut behavior = behavior();
+    behavior.dj_backend = "carrier-pigeon".to_string();
+    assert_eq!(active_label(&behavior), None);
+  }
+
+  #[test]
+  fn describe_names_the_agent_rather_than_the_backend() {
+    // "agent_cli/haiku" would tell the listener nothing about which CLI is running.
+    let choice = DjSetupChoice {
+      backend: "agent_cli".to_string(),
+      agent_command: Some(vec!["claude".to_string()]),
+      keep_command: false,
+      model: Some("haiku".to_string()),
+      ready: true,
+    };
+    assert_eq!(choice.describe(), "claude/haiku");
+    let choice = DjSetupChoice {
+      model: None,
+      ..choice
+    };
+    assert_eq!(choice.describe(), "claude");
+  }
+}

--- a/src/infra/dj/setup.rs
+++ b/src/infra/dj/setup.rs
@@ -173,26 +173,26 @@ pub(crate) fn detect_backends_with(
 ) -> Vec<BackendOption> {
   let mut rows: Vec<BackendOption> = own_command_row(behavior, &probe).into_iter().collect();
 
-  rows.extend(
-    agent_cli::PRESETS
-      .iter()
-      .filter(|preset| RECOMMENDED_AGENTS.contains(&preset.key) || probe(preset.key))
-      .map(|preset| {
-        let ready = probe(preset.key);
-        BackendOption {
-          backend: "agent_cli",
-          agent: Some(preset.key),
-          command: None,
-          label: format!("{} (no API key)", preset.key),
-          note: if ready {
-            agent_note(preset.key).to_string()
-          } else {
-            format!("{}{NOT_INSTALLED}", agent_note(preset.key))
-          },
-          ready,
-        }
-      }),
-  );
+  // One probe per preset, not two: `on_path` re-reads `PATH` and stats every
+  // directory in it, and the picker opens on a keypress.
+  rows.extend(agent_cli::PRESETS.iter().filter_map(|preset| {
+    let ready = probe(preset.key);
+    if !ready && !RECOMMENDED_AGENTS.contains(&preset.key) {
+      return None;
+    }
+    Some(BackendOption {
+      backend: "agent_cli",
+      agent: Some(preset.key),
+      command: None,
+      label: format!("{} (no API key)", preset.key),
+      note: if ready {
+        agent_note(preset.key).to_string()
+      } else {
+        format!("{}{NOT_INSTALLED}", agent_note(preset.key))
+      },
+      ready,
+    })
+  }));
 
   let has_key = anthropic_key_present(env_key, behavior);
   rows.push(BackendOption {
@@ -288,8 +288,8 @@ pub struct ModelOption {
 const CLAUDE_CLI_MODELS: &[(&str, &str)] = &[
   ("haiku", "cheapest, easiest on a Pro plan"),
   ("sonnet", "balanced"),
-  ("opus", "heaviest, a Pro plan hits its limit fast"),
-  ("fable", "heaviest"),
+  ("opus", "heavy, a Pro plan hits its limit fast"),
+  ("fable", "heaviest, hits it faster still"),
 ];
 
 /// Anthropic API model ids with list price per million tokens (input/output).
@@ -316,9 +316,9 @@ const AGY_MODELS: &[(&str, &str)] = &[
   ("gemini-3.6-flash-high", ""),
   ("gemini-3.5-flash-low", ""),
   ("gemini-3.1-pro-low", ""),
-  ("gemini-3.1-pro-high", "heaviest"),
+  ("gemini-3.1-pro-high", "heaviest Gemini"),
   ("claude-sonnet-4-6", ""),
-  ("claude-opus-4-6-thinking", "heaviest"),
+  ("claude-opus-4-6-thinking", "heaviest of all"),
   ("gpt-oss-120b-medium", ""),
 ];
 

--- a/src/infra/network/dj.rs
+++ b/src/infra/network/dj.rs
@@ -260,8 +260,9 @@ impl Network {
       app.extend_native_queue_from_dj(std::mem::take(&mut report.resolved))
     };
     // After the block, not inside it: the network layer's helper takes the lock
-    // itself.
-    self.show_status_message(format!("MCP: {summary}"), 5).await;
+    // itself. "DJ:", not "MCP:", because this handler serves both front doors and
+    // `DjToolCall` does not carry which one asked.
+    self.show_status_message(format!("DJ: {summary}"), 5).await;
 
     let mut text = format!("Queued {accepted} track(s):\n{}", queued_labels.join("\n"));
     // Report the misses explicitly: MCP clients feed execution detail back to

--- a/src/infra/network/dj.rs
+++ b/src/infra/network/dj.rs
@@ -8,18 +8,18 @@
 use super::Network;
 use crate::core::plugin_api::TrackInfo;
 use crate::infra::dj::resolve::{self, ResolveReport};
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 use crate::infra::dj::tools::{DjToolCall, QueueItem, ToolOutcome};
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 use crate::infra::dj::MAX_BATCH;
 use crate::infra::dj::{library, DjLibrary, DjLine, DjSuggestion};
 use crate::infra::network::IoEvent;
 use rspotify::model::track::FullTrack;
 use serde::Deserialize;
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 use serde_json::json;
 use std::collections::HashSet;
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 use tokio::sync::oneshot;
 
 #[derive(Deserialize, Debug)]
@@ -28,7 +28,7 @@ struct TracksResponse {
 }
 
 /// The tool handlers behind `DjToolCall`, shared by both front doors.
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 impl Network {
   /// Run a DJ tool call that needs the catalogue, and answer the waiting caller.
   ///
@@ -431,7 +431,7 @@ impl Network {
 /// `"; "` between reasons: that is already the separator *within* a bucket, and a
 /// track label is `"Title — Artist"`, so neither semicolons nor dashes can
 /// separate the groups unambiguously.
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 fn nothing_queued_detail(report: &ResolveReport) -> String {
   let mut reasons = Vec::new();
   if !report.unresolved.is_empty() {
@@ -457,7 +457,7 @@ fn nothing_queued_detail(report: &ResolveReport) -> String {
 
 /// What `search_tracks` was able to work out about ownership for one page of
 /// results.
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 struct Ownership {
   /// Track IDs the listener already has.
   owned: HashSet<String>,
@@ -472,7 +472,7 @@ impl Network {
   /// Look up exact Spotify URIs so the queue shows real titles rather than raw
   /// URIs. Non-Spotify URIs are queued as-is, since only their own source can
   /// describe them.
-  #[cfg_attr(not(feature = "mcp-server"), allow(dead_code))]
+  #[cfg_attr(not(any(feature = "mcp-server", feature = "ai-dj")), allow(dead_code))]
   async fn tracks_for_uris(&self, uris: &[String]) -> (Vec<TrackInfo>, Vec<String>) {
     let mut resolved = Vec::new();
     let mut missing = Vec::new();
@@ -692,7 +692,7 @@ impl Network {
 }
 
 /// Tests for the shared tool handlers, which exist under either front door.
-#[cfg(all(test, feature = "mcp-server"))]
+#[cfg(all(test, any(feature = "mcp-server", feature = "ai-dj")))]
 mod tests {
   use super::*;
   use crate::core::app::App;

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mcp-server")]
+#[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
 pub mod dj;
 pub mod friends;
 pub mod ids;
@@ -291,7 +291,7 @@ pub enum IoEvent {
   /// rather than silently dropping the response channel.
   ///
   /// Boxed because the payload is much larger than the other variants.
-  #[cfg(feature = "mcp-server")]
+  #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
   DjToolCall(
     Box<(
       crate::infra::dj::tools::DjToolCall,
@@ -304,7 +304,7 @@ pub enum IoEvent {
   /// so that marking results as owned never crawls *inside* a latency-sensitive
   /// tool call; the resolve step builds the index inline if it is not warm yet.
   /// The in-TUI DJ will dispatch it too, when the filter is switched on.
-  #[cfg(feature = "mcp-server")]
+  #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
   DjIndexLibrary,
 }
 
@@ -431,7 +431,7 @@ impl Network {
     // Bypasses the gate but NOT onto the service lane: the handler needs the real
     // Spotify client, and answers an unauthenticated caller itself so the MCP
     // client gets a diagnosable error instead of a dropped channel.
-    #[cfg(feature = "mcp-server")]
+    #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
     if matches!(io_event, IoEvent::DjToolCall(_)) {
       return true;
     }
@@ -840,12 +840,12 @@ impl Network {
       IoEvent::FetchCoverArt(request) => {
         self.fetch_cover_art(request).await;
       }
-      #[cfg(feature = "mcp-server")]
+      #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
       IoEvent::DjToolCall(payload) => {
         let (call, responder) = *payload;
         self.run_dj_tool_call(call, responder).await;
       }
-      #[cfg(feature = "mcp-server")]
+      #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
       IoEvent::DjIndexLibrary => {
         self.dj_index_library().await;
       }
@@ -1670,7 +1670,7 @@ mod tests {
   /// `Network` with `None` for it. It must bypass the gate so the handler can
   /// answer an unauthenticated caller with a diagnosable message instead of
   /// dropping the `oneshot` an MCP client is blocked on.
-  #[cfg(feature = "mcp-server")]
+  #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
   #[test]
   fn dj_tool_calls_bypass_auth_but_stay_on_the_serial_lane() {
     let (tx, _rx) = tokio::sync::oneshot::channel();

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -429,8 +429,9 @@ impl Network {
       return true;
     }
     // Bypasses the gate but NOT onto the service lane: the handler needs the real
-    // Spotify client, and answers an unauthenticated caller itself so the MCP
-    // client gets a diagnosable error instead of a dropped channel.
+    // Spotify client, and answers an unauthenticated caller itself so whichever
+    // front door asked — an MCP client or the in-TUI DJ — gets a diagnosable
+    // error instead of a dropped channel.
     #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
     if matches!(io_event, IoEvent::DjToolCall(_)) {
       return true;
@@ -1669,7 +1670,8 @@ mod tests {
   /// track name needs the real Spotify client, and the service lane builds its
   /// `Network` with `None` for it. It must bypass the gate so the handler can
   /// answer an unauthenticated caller with a diagnosable message instead of
-  /// dropping the `oneshot` an MCP client is blocked on.
+  /// dropping the `oneshot`. Both front doors block on that channel: an MCP
+  /// client through the server, and the in-TUI DJ through its own tool loop.
   #[cfg(any(feature = "mcp-server", feature = "ai-dj"))]
   #[test]
   fn dj_tool_calls_bypass_auth_but_stay_on_the_serial_lane() {


### PR DESCRIPTION
# Summary

PR 3 of the stack. Part of #196.

Declares the `ai-dj` cargo feature and lands its engine room, with nothing
driving it yet: the point is that the next PR is pure TUI.

- Three model backends: a locally installed agent CLI run as a subprocess
  (`claude`, `codex`, `agy`, `copilot`, `opencode`, anything headless, no API
  key), the Anthropic Messages API, and any OpenAI-compatible endpoint
  including local models via Ollama / LM Studio
- The data behind the first-run setup picker: which agents are installed,
  which models each one offers, and how the choice reaches the backend (a CLI
  flag for agent CLIs, a model id for the APIs)
- Turn/session assembly: how a conversation is snapshotted for a brain call
- Ten `dj_*` keys on BehaviorConfig with full load/save round-trip tests

The three new modules carry scoped allows that the DJ screen removes in the
next PR, and the network cfg gates widen to their final
`any(mcp-server, ai-dj)` form so the ai-dj feature builds on its own.

# Testing

- cargo clippy -D warnings on: telemetry / telemetry,mcp-server /
  telemetry,ai-dj / telemetry,mcp-server,ai-dj / all-sources minus audio-viz
- cargo test on telemetry,ai-dj (732 passed) and telemetry,mcp-server,ai-dj
  (779 passed); 106 tests inside the new modules
- cargo check --locked

# Additional notes

brain/, session.rs, and setup.rs are byte-identical to the feature branch;
review effort is best spent on the backend boundary (brain/mod.rs) and the
setup picker data.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional AI DJ mode for generating music selections and recommendations.
  * Supports agent-based tools, Anthropic, and OpenAI-compatible services, including local endpoints.
  * Added setup controls for providers, models, commands, prompt delivery, and timeouts.
  * Added configurable taste, listening history, batch size, and library-avoidance settings.
  * Added presets for common AI agents, including Claude, Codex, Copilot, Gemini, and OpenCode.

* **Testing**
  * Expanded coverage for provider configuration, setup flows, request handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->