### PR TITLE
Adaptive theme from cover art

### DIFF
--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -754,7 +754,7 @@ const LYRICS_SCROLL_ANIM: Duration = Duration::from_millis(300);
 /// Symmetric acceleration/deceleration so the whole-row steps a terminal can
 /// show land evenly spaced in time (a first-frame jump followed by a slow
 /// tail reads as stutter, not smoothness).
-fn ease_in_out_cubic(t: f64) -> f64 {
+pub(crate) fn ease_in_out_cubic(t: f64) -> f64 {
   if t < 0.5 {
     4.0 * t * t * t
   } else {
@@ -1482,6 +1482,17 @@ pub struct App {
   /// keys are discarded.
   #[cfg(feature = "cover-art")]
   pub desired_cover_art_key: Option<String>,
+  /// Accent colors extracted from the current cover art. Stored even while
+  /// Adaptive Theme is off, so toggling it on recolors immediately without a
+  /// refetch. Cleared together with the art itself.
+  #[cfg(feature = "cover-art")]
+  pub cover_art_palette: Option<crate::core::cover_theme::AlbumPalette>,
+  /// Whether an album-derived theme is applied, and the user theme to restore.
+  #[cfg(feature = "cover-art")]
+  pub cover_theme_state: crate::core::cover_theme::CoverThemeState,
+  /// In-flight fade of the live theme, advanced by `update_on_tick`.
+  #[cfg(feature = "cover-art")]
+  pub theme_transition: Option<crate::core::cover_theme::ThemeTransition>,
   /// AI DJ session state: transcript, auto-queue toggle, vibe, and the
   /// generation counter that invalidates in-flight background work.
   #[cfg(feature = "dj-core")]
@@ -2180,6 +2191,12 @@ impl Default for App {
       cover_art_status: CoverArtStatus::default(),
       #[cfg(feature = "cover-art")]
       desired_cover_art_key: None,
+      #[cfg(feature = "cover-art")]
+      cover_art_palette: None,
+      #[cfg(feature = "cover-art")]
+      cover_theme_state: crate::core::cover_theme::CoverThemeState::default(),
+      #[cfg(feature = "cover-art")]
+      theme_transition: None,
       #[cfg(feature = "dj-core")]
       dj: crate::infra::dj::DjState::default(),
       friends: Vec::new(),
@@ -3580,9 +3597,184 @@ impl App {
     }
   }
 
+  /// The user's own theme: the restore target while an album-derived theme is
+  /// applied (or fading out), otherwise the live theme. Settings rows must be
+  /// built from this, never from the live theme, or album accents would leak
+  /// into `custom_theme` and persist on the next settings save.
+  #[cfg(feature = "cover-art")]
+  pub fn user_theme(&self) -> crate::core::user_config::Theme {
+    use crate::core::cover_theme::CoverThemeState;
+    match self.cover_theme_state {
+      CoverThemeState::Active { base } | CoverThemeState::Restoring { base } => base,
+      CoverThemeState::Inactive => self.user_config.theme,
+    }
+  }
+
+  #[cfg(not(feature = "cover-art"))]
+  pub fn user_theme(&self) -> crate::core::user_config::Theme {
+    self.user_config.theme
+  }
+
+  /// Whether an adaptive-theme fade is animating (drives the fast tick rate).
+  #[cfg(feature = "cover-art")]
+  pub fn theme_fade_active(&self) -> bool {
+    self.theme_transition.is_some()
+  }
+
+  #[cfg(not(feature = "cover-art"))]
+  pub fn theme_fade_active(&self) -> bool {
+    false
+  }
+
+  /// Store freshly decoded cover art together with the palette extracted from
+  /// it. The single entry point that keeps the adaptive theme in sync with the
+  /// art: `None` for the palette fades back to the user's own theme.
+  #[cfg(feature = "cover-art")]
+  pub fn store_cover_art(
+    &mut self,
+    key: String,
+    img: image::DynamicImage,
+    palette: Option<crate::core::cover_theme::AlbumPalette>,
+  ) {
+    self.cover_art.store_decoded(key, img);
+    match palette {
+      Some(palette) => self.set_cover_art_palette(palette),
+      None => self.clear_cover_art_palette(),
+    }
+  }
+
+  /// Drop the stored cover art together with its palette; the adaptive theme
+  /// follows the art and fades back to the user's own theme.
+  #[cfg(feature = "cover-art")]
+  pub fn clear_cover_art(&mut self) {
+    self.cover_art.clear();
+    self.clear_cover_art_palette();
+  }
+
+  /// Store the palette extracted from freshly loaded cover art and, when
+  /// Adaptive Theme is on, fade the UI accents toward it.
+  #[cfg(feature = "cover-art")]
+  fn set_cover_art_palette(&mut self, palette: crate::core::cover_theme::AlbumPalette) {
+    self.cover_art_palette = Some(palette);
+    self.apply_cover_theme();
+  }
+
+  /// Drop the stored palette and fade back to the user's own theme. A cheap
+  /// no-op when nothing is applied, so it is safe on every tick of the
+  /// "no art" path.
+  #[cfg(feature = "cover-art")]
+  fn clear_cover_art_palette(&mut self) {
+    self.cover_art_palette = None;
+    self.restore_cover_theme();
+  }
+
+  /// Fade toward the theme derived from the stored palette, capturing the
+  /// user's theme as the restore base on first application.
+  #[cfg(feature = "cover-art")]
+  fn apply_cover_theme(&mut self) {
+    use crate::core::cover_theme::{derive_theme, CoverThemeState};
+    if !self.user_config.behavior.cover_art_theme {
+      return;
+    }
+    let Some(palette) = self.cover_art_palette else {
+      return;
+    };
+    // Re-applying while active or mid-restore keeps the original base; only
+    // from Inactive is the live theme really the user's own (a fade-out in
+    // flight leaves a blend in `user_config.theme` that must not be captured).
+    let base = self.user_theme();
+    self.cover_theme_state = CoverThemeState::Active { base };
+    let target = derive_theme(&base, &palette);
+    self.begin_theme_transition(target);
+  }
+
+  /// Fade back to the user's own theme, if an album theme is applied.
+  #[cfg(feature = "cover-art")]
+  fn restore_cover_theme(&mut self) {
+    use crate::core::cover_theme::CoverThemeState;
+    if let CoverThemeState::Active { base } = self.cover_theme_state {
+      self.cover_theme_state = if self.begin_theme_transition(base) {
+        CoverThemeState::Restoring { base }
+      } else {
+        CoverThemeState::Inactive
+      };
+    }
+  }
+
+  /// Start fading the live theme toward `target`. Returns false when the
+  /// theme is already there (nothing to animate). A transition already headed
+  /// to the same target is left to finish rather than restarted.
+  #[cfg(feature = "cover-art")]
+  fn begin_theme_transition(&mut self, target: crate::core::user_config::Theme) -> bool {
+    use crate::core::cover_theme::ThemeTransition;
+    if let Some(transition) = &self.theme_transition {
+      if transition.target() == target {
+        return true;
+      }
+    }
+    if self.user_config.theme == target {
+      self.theme_transition = None;
+      return false;
+    }
+    self.theme_transition = Some(ThemeTransition::new(self.user_config.theme, target));
+    true
+  }
+
+  /// Reconcile the adaptive theme after `apply_settings_changes` rewrote
+  /// `user_config.theme` from the settings rows (which every save does, for
+  /// every row). The rows carry the user's own colors, so that rewrite is the
+  /// new base; what was actually on screen (`live_before`) is put back so the
+  /// fade continues from there. `enabled_before` is the Adaptive Theme flag
+  /// before the save, so a flip re-applies or restores.
+  #[cfg(feature = "cover-art")]
+  fn reconcile_cover_theme_after_settings(
+    &mut self,
+    live_before: crate::core::user_config::Theme,
+    enabled_before: bool,
+  ) {
+    use crate::core::cover_theme::CoverThemeState;
+    match self.cover_theme_state {
+      CoverThemeState::Inactive => {}
+      previous => {
+        let base = self.user_config.theme;
+        self.cover_theme_state = CoverThemeState::Active { base };
+        self.user_config.theme = live_before;
+        self.theme_transition = None;
+        if matches!(previous, CoverThemeState::Restoring { .. }) {
+          self.restore_cover_theme();
+        } else {
+          self.apply_cover_theme();
+        }
+      }
+    }
+    if self.user_config.behavior.cover_art_theme != enabled_before {
+      if self.user_config.behavior.cover_art_theme {
+        self.apply_cover_theme();
+      } else {
+        self.restore_cover_theme();
+      }
+    }
+  }
+
   pub fn update_on_tick(&mut self, elapsed: Duration) {
     // Increment global animation tick (wraps after ~9.4 quintillion ticks, effectively never)
     self.animation_tick = self.animation_tick.wrapping_add(1);
+
+    // Advance an adaptive-theme fade. Real elapsed time, not tick count, so
+    // the fade speed is independent of the configured tick rates.
+    #[cfg(feature = "cover-art")]
+    if let Some(transition) = self.theme_transition.as_mut() {
+      transition.advance(elapsed);
+      self.user_config.theme = transition.current();
+      if transition.is_complete() {
+        self.theme_transition = None;
+        // A finished fade-out means the user's own theme is back in place.
+        if let crate::core::cover_theme::CoverThemeState::Restoring { .. } = self.cover_theme_state
+        {
+          self.cover_theme_state = crate::core::cover_theme::CoverThemeState::Inactive;
+        }
+      }
+    }
 
     // Periodic party sync: host broadcasts state about every 2 seconds.
     // Keep this before early-return paths so sync still happens during native-streaming fast paths.
@@ -7618,6 +7810,10 @@ impl App {
         },
       ],
       SettingsCategory::Theme => {
+        // The user's own colors, not the live theme: while an album-derived
+        // theme is applied the live theme is a blend, and rows built from it
+        // would be written back into custom_theme on save.
+        let user_theme = self.user_theme();
         vec![
           SettingItem {
             id: "theme.preset".to_string(),
@@ -7629,13 +7825,13 @@ impl App {
             id: "theme.active".to_string(),
             name: "Active Color".to_string(),
             description: "Color for active elements".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.active)),
+            value: SettingValue::Color(color_to_string(user_theme.active)),
           },
           SettingItem {
             id: "theme.banner".to_string(),
             name: "Banner Color".to_string(),
             description: "Color for banner text".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.banner)),
+            value: SettingValue::Color(color_to_string(user_theme.banner)),
           },
           SettingItem {
             id: "behavior.banner_gradient".to_string(),
@@ -7644,89 +7840,97 @@ impl App {
               .to_string(),
             value: SettingValue::Bool(self.user_config.behavior.banner_gradient),
           },
+          #[cfg(feature = "cover-art")]
+          SettingItem {
+            id: "behavior.cover_art_theme".to_string(),
+            name: "Adaptive Theme".to_string(),
+            description: "Recolor UI accents from the current cover art, fading on track change"
+              .to_string(),
+            value: SettingValue::Bool(self.user_config.behavior.cover_art_theme),
+          },
           SettingItem {
             id: "theme.hint".to_string(),
             name: "Hint Color".to_string(),
             description: "Color for hints".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.hint)),
+            value: SettingValue::Color(color_to_string(user_theme.hint)),
           },
           SettingItem {
             id: "theme.hovered".to_string(),
             name: "Hovered Color".to_string(),
             description: "Color for hovered elements".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.hovered)),
+            value: SettingValue::Color(color_to_string(user_theme.hovered)),
           },
           SettingItem {
             id: "theme.selected".to_string(),
             name: "Selected Color".to_string(),
             description: "Color for selected items".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.selected)),
+            value: SettingValue::Color(color_to_string(user_theme.selected)),
           },
           SettingItem {
             id: "theme.inactive".to_string(),
             name: "Inactive Color".to_string(),
             description: "Color for inactive elements".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.inactive)),
+            value: SettingValue::Color(color_to_string(user_theme.inactive)),
           },
           SettingItem {
             id: "theme.text".to_string(),
             name: "Text Color".to_string(),
             description: "Default text color".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.text)),
+            value: SettingValue::Color(color_to_string(user_theme.text)),
           },
           SettingItem {
             id: "theme.error_text".to_string(),
             name: "Error Text Color".to_string(),
             description: "Color for error messages".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.error_text)),
+            value: SettingValue::Color(color_to_string(user_theme.error_text)),
           },
           SettingItem {
             id: "theme.error_border".to_string(),
             name: "Error Border Color".to_string(),
             description: "Border color for error messages".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.error_border)),
+            value: SettingValue::Color(color_to_string(user_theme.error_border)),
           },
           SettingItem {
             id: "theme.playbar_background".to_string(),
             name: "Playbar Background".to_string(),
             description: "Background color for playbar".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_background)),
+            value: SettingValue::Color(color_to_string(user_theme.playbar_background)),
           },
           SettingItem {
             id: "theme.playbar_progress".to_string(),
             name: "Playbar Progress".to_string(),
             description: "Color for playbar progress".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_progress)),
+            value: SettingValue::Color(color_to_string(user_theme.playbar_progress)),
           },
           SettingItem {
             id: "theme.playbar_progress_text".to_string(),
             name: "Playbar Progress Text".to_string(),
             description: "Color for playbar progress text".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_progress_text)),
+            value: SettingValue::Color(color_to_string(user_theme.playbar_progress_text)),
           },
           SettingItem {
             id: "theme.playbar_text".to_string(),
             name: "Playbar Text".to_string(),
             description: "Color for playbar text".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.playbar_text)),
+            value: SettingValue::Color(color_to_string(user_theme.playbar_text)),
           },
           SettingItem {
             id: "theme.highlighted_lyrics".to_string(),
             name: "Lyrics Highlight".to_string(),
             description: "Color for current lyrics line".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.highlighted_lyrics)),
+            value: SettingValue::Color(color_to_string(user_theme.highlighted_lyrics)),
           },
           SettingItem {
             id: "theme.background".to_string(),
             name: "Background".to_string(),
             description: "Color for the background".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.background)),
+            value: SettingValue::Color(color_to_string(user_theme.background)),
           },
           SettingItem {
             id: "theme.header".to_string(),
             name: "Header".to_string(),
             description: "Color for the header".to_string(),
-            value: SettingValue::Color(color_to_string(self.user_config.theme.header)),
+            value: SettingValue::Color(color_to_string(user_theme.header)),
           },
         ]
       }
@@ -7742,6 +7946,20 @@ impl App {
     use crate::core::user_config::{parse_theme_item, ThemePreset};
 
     let mut settings_error: Option<String> = None;
+    // What is actually on screen right now, put back by the reconciliation at
+    // the end so an adaptive-theme fade continues from it.
+    #[cfg(feature = "cover-art")]
+    let cover_theme_live_before = self.user_config.theme;
+    #[cfg(feature = "cover-art")]
+    let cover_art_theme_before = self.user_config.behavior.cover_art_theme;
+    // Run the arms against the user's own colors rather than the live blend:
+    // settings_items holds only the current category's rows, so a save from
+    // another category rewrites no theme field at all, and analysis_bar has no
+    // row in any category. Whatever survives the arms IS the new base theme.
+    #[cfg(feature = "cover-art")]
+    {
+      self.user_config.theme = self.user_theme();
+    }
     for setting in &self.settings_items {
       match setting.id.as_str() {
         // Behavior settings
@@ -8012,6 +8230,12 @@ impl App {
         "behavior.draw_cover_art" => {
           if let SettingValue::Bool(v) = setting.value {
             self.user_config.behavior.draw_cover_art = v;
+          }
+        }
+        #[cfg(feature = "cover-art")]
+        "behavior.cover_art_theme" => {
+          if let SettingValue::Bool(v) = setting.value {
+            self.user_config.behavior.cover_art_theme = v;
           }
         }
         #[cfg(feature = "cover-art")]
@@ -8426,6 +8650,8 @@ impl App {
         _ => {}
       }
     }
+    #[cfg(feature = "cover-art")]
+    self.reconcile_cover_theme_after_settings(cover_theme_live_before, cover_art_theme_before);
     if let Some(message) = settings_error {
       self.set_status_message(message, 4);
     }
@@ -10473,5 +10699,221 @@ mod tests {
 
     assert!(matches!(rx.try_recv(), Ok(IoEvent::GetCurrentPlayback)));
     assert!(app.is_fetching_current_playback);
+  }
+
+  #[cfg(feature = "cover-art")]
+  mod cover_theme_tests {
+    use super::*;
+    use crate::core::cover_theme::{derive_theme, AlbumPalette, CoverThemeState};
+    use crate::core::user_config::ThemePreset;
+
+    const PALETTE: AlbumPalette = AlbumPalette {
+      primary: (200, 30, 40),
+      secondary: (30, 60, 220),
+    };
+
+    fn app_with_adaptive_on() -> App {
+      let mut app = App::default();
+      app.user_config.behavior.cover_art_theme = true;
+      app
+    }
+
+    #[test]
+    fn palette_application_fades_in_and_clear_restores_the_user_theme() {
+      let mut app = app_with_adaptive_on();
+      let user = app.user_config.theme;
+
+      app.set_cover_art_palette(PALETTE);
+      assert!(matches!(
+        app.cover_theme_state,
+        CoverThemeState::Active { .. }
+      ));
+      assert!(app.theme_transition.is_some());
+
+      // A tick longer than the fade completes it: accents changed, the
+      // structural colors kept.
+      app.update_on_tick(Duration::from_secs(2));
+      assert!(app.theme_transition.is_none());
+      assert_ne!(app.user_config.theme.active, user.active);
+      assert_eq!(app.user_config.theme.text, user.text);
+      assert_eq!(app.user_config.theme.background, user.background);
+
+      app.clear_cover_art_palette();
+      assert!(matches!(
+        app.cover_theme_state,
+        CoverThemeState::Restoring { .. }
+      ));
+      app.update_on_tick(Duration::from_secs(2));
+      assert_eq!(app.user_config.theme, user);
+      assert_eq!(app.cover_theme_state, CoverThemeState::Inactive);
+    }
+
+    #[test]
+    fn palette_is_stored_but_not_applied_while_disabled() {
+      let mut app = App::default();
+      assert!(!app.user_config.behavior.cover_art_theme);
+      let user = app.user_config.theme;
+
+      app.set_cover_art_palette(PALETTE);
+
+      assert_eq!(app.cover_theme_state, CoverThemeState::Inactive);
+      assert!(app.theme_transition.is_none());
+      assert_eq!(app.user_config.theme, user);
+      assert_eq!(app.cover_art_palette, Some(PALETTE));
+    }
+
+    #[test]
+    fn user_theme_reports_the_base_while_an_album_theme_is_applied() {
+      let mut app = app_with_adaptive_on();
+      let user = app.user_config.theme;
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+
+      assert_ne!(app.user_config.theme, user);
+      assert_eq!(app.user_theme(), user);
+    }
+
+    #[test]
+    fn settings_rewrite_becomes_the_new_base_and_rederives() {
+      let mut app = app_with_adaptive_on();
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+      let displayed = app.user_config.theme;
+
+      // What apply_settings_changes does on save: the arms rewrite the live
+      // theme with the user's own colors (here: a new preset), then the
+      // reconciliation runs.
+      let new_user = ThemePreset::Dracula.to_theme();
+      app.user_config.theme = new_user;
+      app.reconcile_cover_theme_after_settings(displayed, true);
+
+      assert!(
+        matches!(app.cover_theme_state, CoverThemeState::Active { base } if base == new_user)
+      );
+      app.update_on_tick(Duration::from_secs(2));
+      assert_eq!(app.user_config.theme, derive_theme(&new_user, &PALETTE));
+      assert_eq!(app.user_theme(), new_user);
+    }
+
+    #[test]
+    fn toggle_off_restores_and_toggle_on_reapplies_the_stored_palette() {
+      let mut app = app_with_adaptive_on();
+      let user = app.user_config.theme;
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+
+      // Toggle off the way a settings save does: through
+      // apply_settings_changes, which resets the live theme to the base
+      // before the arms run.
+      app.settings_items = vec![SettingItem {
+        id: "behavior.cover_art_theme".to_string(),
+        name: "Adaptive Theme".to_string(),
+        description: String::new(),
+        value: SettingValue::Bool(false),
+      }];
+      app.apply_settings_changes();
+      app.update_on_tick(Duration::from_secs(2));
+      assert_eq!(app.user_config.theme, user);
+      assert_eq!(app.cover_theme_state, CoverThemeState::Inactive);
+
+      // Toggling back on recolors immediately from the stored palette.
+      app.settings_items[0].value = SettingValue::Bool(true);
+      app.apply_settings_changes();
+      assert!(matches!(
+        app.cover_theme_state,
+        CoverThemeState::Active { .. }
+      ));
+      assert!(app.theme_transition.is_some());
+    }
+
+    #[test]
+    fn save_from_another_category_keeps_the_base_theme() {
+      let mut app = app_with_adaptive_on();
+      let user = app.user_config.theme;
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+      assert_ne!(app.user_config.theme, user);
+
+      // A save from the Behavior category: settings_items holds only that
+      // category's rows, so no theme.* arm rewrites `user_config.theme` with
+      // the user's own colors. The base must not drift to the blend.
+      app.settings_items = vec![SettingItem {
+        id: "behavior.seek_milliseconds".to_string(),
+        name: "Seek Duration (ms)".to_string(),
+        description: String::new(),
+        value: SettingValue::Number(app.user_config.behavior.seek_milliseconds as i64),
+      }];
+      app.apply_settings_changes();
+
+      assert_eq!(app.user_theme(), user, "base drifted to the blended theme");
+
+      app.clear_cover_art_palette();
+      app.update_on_tick(Duration::from_secs(2));
+      assert_eq!(
+        app.user_config.theme, user,
+        "did not restore the user theme"
+      );
+    }
+
+    #[test]
+    fn track_change_during_restore_keeps_the_original_base() {
+      let mut app = app_with_adaptive_on();
+      let user = app.user_config.theme;
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+
+      // Art clears (fade-out starts) and new art arrives mid-fade: the base
+      // captured must be the user's theme, not the half-restored blend.
+      app.clear_cover_art_palette();
+      app.update_on_tick(Duration::from_millis(100));
+      assert!(matches!(
+        app.cover_theme_state,
+        CoverThemeState::Restoring { .. }
+      ));
+      app.set_cover_art_palette(AlbumPalette {
+        primary: (30, 200, 90),
+        secondary: (200, 30, 40),
+      });
+      match app.cover_theme_state {
+        CoverThemeState::Active { base } => assert_eq!(base, user),
+        other => panic!("expected Active, got {other:?}"),
+      }
+    }
+
+    #[test]
+    fn custom_theme_save_does_not_leak_album_analysis_bar_into_base() {
+      let mut app = app_with_adaptive_on();
+      app.user_config.current_preset = ThemePreset::Custom;
+      app.user_config.custom_theme = app.user_config.theme;
+      let user = app.user_config.theme;
+
+      app.set_cover_art_palette(PALETTE);
+      app.update_on_tick(Duration::from_secs(2));
+      // analysis_bar is album-colored while applied, and has no settings row
+      // in any category, so a save must not treat the live value as the
+      // user's choice.
+      assert_ne!(app.user_config.theme.analysis_bar, user.analysis_bar);
+
+      // Settings -> Theme, save without changing anything.
+      app.settings_category = crate::core::app::SettingsCategory::Theme;
+      app.load_settings_for_category();
+      app.apply_settings_changes();
+      assert_eq!(app.user_theme().analysis_bar, user.analysis_bar);
+
+      // Turning adaptive theming off (a real settings save) restores the
+      // user's analysis_bar.
+      app.settings_items = vec![SettingItem {
+        id: "behavior.cover_art_theme".to_string(),
+        name: "Adaptive Theme".to_string(),
+        description: String::new(),
+        value: SettingValue::Bool(false),
+      }];
+      app.apply_settings_changes();
+      app.update_on_tick(Duration::from_secs(2));
+      assert_eq!(
+        app.user_config.theme.analysis_bar, user.analysis_bar,
+        "album accent stuck in analysis_bar after adaptive theme off"
+      );
+    }
   }
 }

--- a/src/core/cover_theme.rs
+++ b/src/core/cover_theme.rs
@@ -1,0 +1,488 @@
+//! Adaptive theming from album art: extract the dominant colors of the
+//! decoded cover image, derive a UI theme from them, and fade the live theme
+//! between targets on track change.
+//!
+//! Everything here is pure pixel/color math on data the cover-art pipeline
+//! already decodes, so it behaves identically on every platform and terminal.
+
+use ratatui::style::Color;
+use std::time::Duration;
+
+use crate::core::app::ease_in_out_cubic;
+use crate::core::user_config::Theme;
+
+/// How long a theme fade takes. Long enough to read as a transition, short
+/// enough that the theme settles before the track's intro is over.
+const THEME_FADE_SECS: f32 = 0.8;
+
+/// Cover art is downsampled so no side exceeds this before analysis; one pass
+/// over at most 64x64 pixels keeps extraction well under a millisecond.
+const SAMPLE_DIM: u32 = 64;
+
+/// Minimum share of sampled pixels (1/50 = 2%) a color region needs before it
+/// can be picked as the secondary accent, so single stray pixels never drive
+/// the theme.
+const SECONDARY_MIN_SHARE: u32 = 50;
+
+/// Accent colors extracted from one cover image, before any legibility
+/// adjustment (that happens in [`derive_theme`], which knows the base theme's
+/// background).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AlbumPalette {
+  pub primary: (u8, u8, u8),
+  pub secondary: (u8, u8, u8),
+}
+
+/// Whether an album-derived theme is applied. `base` is the user's own theme,
+/// kept while album accents are on screen (or fading out) so it can be
+/// restored, and so settings changes know what the user's real colors are.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum CoverThemeState {
+  #[default]
+  Inactive,
+  Active {
+    base: Theme,
+  },
+  /// Fading back to `base`; flips to `Inactive` when the fade completes.
+  Restoring {
+    base: Theme,
+  },
+}
+
+/// An in-flight fade of the live theme. Driven by real elapsed time rather
+/// than tick count, so its speed is independent of the configured tick rates.
+#[derive(Clone, Copy, Debug)]
+pub struct ThemeTransition {
+  from: Theme,
+  to: Theme,
+  progress: f32,
+}
+
+impl ThemeTransition {
+  pub fn new(from: Theme, to: Theme) -> Self {
+    Self {
+      from,
+      to,
+      progress: 0.0,
+    }
+  }
+
+  pub fn advance(&mut self, elapsed: Duration) {
+    self.progress = (self.progress + elapsed.as_secs_f32() / THEME_FADE_SECS).min(1.0);
+  }
+
+  pub fn current(&self) -> Theme {
+    let eased = ease_in_out_cubic(f64::from(self.progress)) as f32;
+    lerp_theme(&self.from, &self.to, eased)
+  }
+
+  pub fn is_complete(&self) -> bool {
+    self.progress >= 1.0
+  }
+
+  pub fn target(&self) -> Theme {
+    self.to
+  }
+}
+
+#[derive(Clone, Default)]
+struct Bin {
+  count: u32,
+  r: u64,
+  g: u64,
+  b: u64,
+}
+
+struct Candidate {
+  rgb: (u8, u8, u8),
+  hsv: (f32, f32, f32),
+  count: u32,
+  score: f32,
+}
+
+/// Extract the two accent colors that best represent `img`.
+///
+/// Pixels are pooled into 4-bits-per-channel buckets and each bucket is scored
+/// by `count * (0.15 + saturation) * mid-brightness preference`: a colorful
+/// region beats a larger near-black or near-white one (borders, text, vinyl
+/// grooves), which is what makes the result feel like "the album's color"
+/// rather than its literal average. Returns `None` when the image has no
+/// opaque pixels.
+pub fn extract_palette(img: &image::DynamicImage) -> Option<AlbumPalette> {
+  let thumb = img.thumbnail(SAMPLE_DIM, SAMPLE_DIM).into_rgba8();
+
+  // 4 bits per channel: keys are a dense 0..4096 index, so a flat array beats
+  // hashing per pixel.
+  let mut bins = vec![Bin::default(); 4096];
+  let mut total: u32 = 0;
+  for px in thumb.pixels() {
+    if px[3] < 128 {
+      continue;
+    }
+    let (r, g, b) = (px[0], px[1], px[2]);
+    let key = (usize::from(r >> 4) << 8) | (usize::from(g >> 4) << 4) | usize::from(b >> 4);
+    let bin = &mut bins[key];
+    bin.count += 1;
+    bin.r += u64::from(r);
+    bin.g += u64::from(g);
+    bin.b += u64::from(b);
+    total += 1;
+  }
+  if total == 0 {
+    return None;
+  }
+
+  let mut candidates: Vec<Candidate> = bins
+    .iter()
+    .filter(|bin| bin.count > 0)
+    .map(|bin| {
+      let n = u64::from(bin.count);
+      let rgb = ((bin.r / n) as u8, (bin.g / n) as u8, (bin.b / n) as u8);
+      let hsv = rgb_to_hsv(rgb);
+      let brightness_weight = (1.0 - (hsv.2 - 0.62).abs()).max(0.15);
+      let score = bin.count as f32 * (0.15 + hsv.1) * brightness_weight;
+      Candidate {
+        rgb,
+        hsv,
+        count: bin.count,
+        score,
+      }
+    })
+    .collect();
+  // Tie-break on the color value so equal scores (common in synthetic images)
+  // resolve deterministically under the unstable sort.
+  candidates.sort_unstable_by(|a, b| b.score.total_cmp(&a.score).then_with(|| a.rgb.cmp(&b.rgb)));
+
+  let primary = &candidates[0];
+
+  // Secondary: a hue clearly different from the primary, falling back to a
+  // brightness contrast (covers monochrome art), falling back to the primary
+  // itself ([`derive_theme`] keeps the on-screen accents distinct).
+  let eligible: Vec<&Candidate> = candidates
+    .iter()
+    .skip(1)
+    .filter(|c| c.count * SECONDARY_MIN_SHARE >= total)
+    .collect();
+  let secondary_rgb = eligible
+    .iter()
+    .find(|c| c.hsv.1 >= 0.15 && hue_distance(c.hsv.0, primary.hsv.0) >= 60.0)
+    .or_else(|| {
+      eligible
+        .iter()
+        .find(|c| (c.hsv.2 - primary.hsv.2).abs() >= 0.2)
+    })
+    .map(|c| c.rgb)
+    .unwrap_or(primary.rgb);
+
+  Some(AlbumPalette {
+    primary: primary.rgb,
+    secondary: secondary_rgb,
+  })
+}
+
+/// Build the theme shown while `palette`'s album is playing: `base` with only
+/// the accent fields replaced. Text, background, borders and error colors stay
+/// the user's own, so legibility never depends on what the art happens to be.
+pub fn derive_theme(base: &Theme, palette: &AlbumPalette) -> Theme {
+  let dark_bg = background_is_dark(base);
+  let primary = accent_color(palette.primary, dark_bg);
+  let mut secondary = accent_color(palette.secondary, dark_bg);
+  // Monochrome art repeats the primary, and the brightness clamp can land two
+  // distinct accents on the same color; keep hovered visually distinct from
+  // selected either way.
+  if secondary == primary {
+    secondary = contrast_variant(primary, dark_bg);
+  }
+  Theme {
+    active: primary,
+    banner: primary,
+    hovered: secondary,
+    selected: primary,
+    playbar_progress: primary,
+    highlighted_lyrics: primary,
+    analysis_bar: primary,
+    ..*base
+  }
+}
+
+fn background_is_dark(base: &Theme) -> bool {
+  match base.background {
+    Color::Rgb(r, g, b) => luma((r, g, b)) < 0.5,
+    // Reset / named backgrounds follow the terminal palette, which we can't
+    // read; assume dark, the overwhelmingly common case for TUIs.
+    _ => true,
+  }
+}
+
+/// Clamp an extracted color's brightness so it stays readable against the
+/// base background: lifted on dark backgrounds, dimmed on light ones.
+fn accent_color(rgb: (u8, u8, u8), dark_bg: bool) -> Color {
+  let (h, s, v) = rgb_to_hsv(rgb);
+  let v = if dark_bg { v.max(0.55) } else { v.min(0.55) };
+  let (r, g, b) = hsv_to_rgb((h, s, v));
+  Color::Rgb(r, g, b)
+}
+
+/// A brightness variant of an already-clamped accent that stays on the legal
+/// side of the clamp, so it cannot collapse back into the original.
+fn contrast_variant(color: Color, dark_bg: bool) -> Color {
+  let Color::Rgb(r, g, b) = color else {
+    return color;
+  };
+  let (h, s, v) = rgb_to_hsv((r, g, b));
+  let v = if dark_bg {
+    // Legal range [0.55, 1.0].
+    if v > 0.775 {
+      v - 0.225
+    } else {
+      v + 0.225
+    }
+  } else {
+    // Legal range [0.0, 0.55].
+    if v < 0.325 {
+      v + 0.225
+    } else {
+      v - 0.225
+    }
+  };
+  let (r, g, b) = hsv_to_rgb((h, s, v.clamp(0.0, 1.0)));
+  Color::Rgb(r, g, b)
+}
+
+fn luma((r, g, b): (u8, u8, u8)) -> f32 {
+  (0.2126 * f32::from(r) + 0.7152 * f32::from(g) + 0.0722 * f32::from(b)) / 255.0
+}
+
+fn hue_distance(a: f32, b: f32) -> f32 {
+  let d = (a - b).abs() % 360.0;
+  d.min(360.0 - d)
+}
+
+/// Thin adapters over `csscolorparser` (already linked via `colorgrad`), so
+/// this module carries no color-space math of its own. Same conventions:
+/// h in [0..360], s/v in [0..1].
+fn rgb_to_hsv((r, g, b): (u8, u8, u8)) -> (f32, f32, f32) {
+  let [h, s, v, _] = colorgrad::Color::from_rgba8(r, g, b, 255).to_hsva();
+  (h, s, v)
+}
+
+fn hsv_to_rgb((h, s, v): (f32, f32, f32)) -> (u8, u8, u8) {
+  let [r, g, b, _] = colorgrad::Color::from_hsva(h, s, v, 1.0).to_rgba8();
+  (r, g, b)
+}
+
+/// Interpolate between two colors. Only RGB pairs can blend; when either end
+/// is a named ANSI color or `Reset` (whose actual RGB the terminal owns), the
+/// color snaps at the halfway point instead.
+fn lerp_color(from: Color, to: Color, t: f32) -> Color {
+  match (from, to) {
+    (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => {
+      let [r, g, b, _] = colorgrad::Color::from_rgba8(r1, g1, b1, 255)
+        .interpolate_rgb(&colorgrad::Color::from_rgba8(r2, g2, b2, 255), t)
+        .to_rgba8();
+      Color::Rgb(r, g, b)
+    }
+    _ => {
+      if t < 0.5 {
+        from
+      } else {
+        to
+      }
+    }
+  }
+}
+
+fn lerp_theme(from: &Theme, to: &Theme, t: f32) -> Theme {
+  Theme {
+    analysis_bar: lerp_color(from.analysis_bar, to.analysis_bar, t),
+    analysis_bar_text: lerp_color(from.analysis_bar_text, to.analysis_bar_text, t),
+    active: lerp_color(from.active, to.active, t),
+    banner: lerp_color(from.banner, to.banner, t),
+    error_border: lerp_color(from.error_border, to.error_border, t),
+    error_text: lerp_color(from.error_text, to.error_text, t),
+    hint: lerp_color(from.hint, to.hint, t),
+    hovered: lerp_color(from.hovered, to.hovered, t),
+    inactive: lerp_color(from.inactive, to.inactive, t),
+    playbar_background: lerp_color(from.playbar_background, to.playbar_background, t),
+    playbar_progress: lerp_color(from.playbar_progress, to.playbar_progress, t),
+    playbar_progress_text: lerp_color(from.playbar_progress_text, to.playbar_progress_text, t),
+    playbar_text: lerp_color(from.playbar_text, to.playbar_text, t),
+    selected: lerp_color(from.selected, to.selected, t),
+    text: lerp_color(from.text, to.text, t),
+    background: lerp_color(from.background, to.background, t),
+    header: lerp_color(from.header, to.header, t),
+    highlighted_lyrics: lerp_color(from.highlighted_lyrics, to.highlighted_lyrics, t),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use image::{DynamicImage, Rgba, RgbaImage};
+
+  fn solid(r: u8, g: u8, b: u8) -> DynamicImage {
+    DynamicImage::ImageRgba8(RgbaImage::from_pixel(32, 32, Rgba([r, g, b, 255])))
+  }
+
+  #[test]
+  fn solid_image_yields_that_color_as_primary() {
+    let palette = extract_palette(&solid(200, 30, 40)).unwrap();
+    assert_eq!(palette.primary, (200, 30, 40));
+  }
+
+  #[test]
+  fn two_tone_image_yields_hue_distinct_secondary() {
+    let img = DynamicImage::ImageRgba8(RgbaImage::from_fn(32, 32, |x, _| {
+      if x < 16 {
+        Rgba([200, 30, 40, 255])
+      } else {
+        Rgba([30, 60, 220, 255])
+      }
+    }));
+    let palette = extract_palette(&img).unwrap();
+    let (pr, _, pb) = palette.primary;
+    let (sr, _, sb) = palette.secondary;
+    // One accent red-dominant, the other blue-dominant, in either order.
+    assert!(
+      (pr > pb && sb > sr) || (pb > pr && sr > sb),
+      "expected one red and one blue accent, got {palette:?}"
+    );
+  }
+
+  #[test]
+  fn grayscale_image_still_yields_a_palette() {
+    let palette = extract_palette(&solid(128, 128, 128)).unwrap();
+    assert_eq!(palette.primary, (128, 128, 128));
+    // With no second color to offer, the palette repeats the primary;
+    // derive_theme keeps the on-screen accents distinct.
+    assert_eq!(palette.secondary, palette.primary);
+    let derived = derive_theme(&Theme::default(), &palette);
+    assert_ne!(derived.hovered, derived.selected);
+  }
+
+  #[test]
+  fn fully_transparent_image_yields_none() {
+    let img = DynamicImage::ImageRgba8(RgbaImage::from_pixel(16, 16, Rgba([10, 10, 10, 0])));
+    assert!(extract_palette(&img).is_none());
+  }
+
+  #[test]
+  fn colorful_region_beats_larger_dark_region() {
+    // 75% near-black border, 25% saturated orange: the orange should win.
+    let img = DynamicImage::ImageRgba8(RgbaImage::from_fn(32, 32, |x, _| {
+      if x < 8 {
+        Rgba([240, 140, 20, 255])
+      } else {
+        Rgba([12, 12, 12, 255])
+      }
+    }));
+    let palette = extract_palette(&img).unwrap();
+    assert_eq!(palette.primary, (240, 140, 20));
+  }
+
+  #[test]
+  fn derive_replaces_accents_and_keeps_base_text_and_background() {
+    let base = Theme::default();
+    let palette = AlbumPalette {
+      primary: (200, 30, 40),
+      secondary: (30, 60, 220),
+    };
+    let derived = derive_theme(&base, &palette);
+    assert_ne!(derived.active, base.active);
+    assert_eq!(derived.text, base.text);
+    assert_eq!(derived.background, base.background);
+    assert_eq!(derived.error_border, base.error_border);
+    assert_eq!(derived.inactive, base.inactive);
+  }
+
+  #[test]
+  fn derive_lifts_dark_accents_on_dark_background() {
+    let base = Theme::default(); // background: Reset -> assumed dark
+    let palette = AlbumPalette {
+      primary: (10, 10, 60), // very dark navy
+      secondary: (10, 10, 60),
+    };
+    let derived = derive_theme(&base, &palette);
+    match derived.active {
+      Color::Rgb(r, g, b) => {
+        let v = f32::from(r.max(g).max(b)) / 255.0;
+        assert!(v >= 0.54, "accent stayed too dark: {r},{g},{b}");
+      }
+      other => panic!("expected RGB accent, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn derive_dims_bright_accents_on_light_background() {
+    let base = Theme {
+      background: Color::Rgb(250, 250, 250),
+      ..Theme::default()
+    };
+    let palette = AlbumPalette {
+      primary: (255, 240, 100), // bright yellow
+      secondary: (255, 240, 100),
+    };
+    let derived = derive_theme(&base, &palette);
+    match derived.active {
+      Color::Rgb(r, g, b) => {
+        let v = f32::from(r.max(g).max(b)) / 255.0;
+        assert!(v <= 0.56, "accent stayed too bright: {r},{g},{b}");
+      }
+      other => panic!("expected RGB accent, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn derived_accents_stay_distinct_after_clamping() {
+    let base = Theme::default();
+    // Monochrome palette: both accents clamp to the same brightness floor.
+    let palette = AlbumPalette {
+      primary: (128, 128, 128),
+      secondary: (52, 52, 52),
+    };
+    let derived = derive_theme(&base, &palette);
+    assert_ne!(derived.hovered, derived.selected);
+  }
+
+  #[test]
+  fn lerp_color_blends_rgb_and_snaps_named_at_half() {
+    let from = Color::Rgb(0, 0, 0);
+    let to = Color::Rgb(255, 255, 255);
+    assert_eq!(lerp_color(from, to, 0.0), from);
+    assert_eq!(lerp_color(from, to, 1.0), to);
+    match lerp_color(from, to, 0.5) {
+      Color::Rgb(r, g, b) => {
+        assert!((127..=128).contains(&r));
+        assert_eq!(r, g);
+        assert_eq!(g, b);
+      }
+      other => panic!("expected RGB midpoint, got {other:?}"),
+    }
+    assert_eq!(lerp_color(Color::Cyan, to, 0.4), Color::Cyan);
+    assert_eq!(lerp_color(Color::Cyan, to, 0.6), to);
+  }
+
+  #[test]
+  fn transition_advances_with_elapsed_time_and_completes() {
+    let from = Theme::default();
+    let to = derive_theme(
+      &from,
+      &AlbumPalette {
+        primary: (200, 30, 40),
+        secondary: (30, 60, 220),
+      },
+    );
+    let mut transition = ThemeTransition::new(from, to);
+    assert_eq!(transition.current(), from);
+
+    transition.advance(Duration::from_millis(400));
+    assert!(!transition.is_complete());
+    let mid = transition.current();
+    assert_ne!(mid, from);
+    assert_ne!(mid, to);
+
+    transition.advance(Duration::from_millis(500));
+    assert!(transition.is_complete());
+    assert_eq!(transition.current(), to);
+  }
+}

--- a/src/core/migrations.rs
+++ b/src/core/migrations.rs
@@ -178,6 +178,9 @@ fn set_private_dir_permissions(path: &Path) -> Result<()> {
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
       .with_context(|| format!("setting private permissions on {}", path.display()))?;
   }
+  // Windows scopes %APPDATA% to the user already; nothing to tighten.
+  #[cfg(not(unix))]
+  let _ = path;
 
   Ok(())
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,8 @@
 pub mod app;
 pub mod auth;
 pub mod config;
+#[cfg(feature = "cover-art")]
+pub mod cover_theme;
 pub mod first_run;
 pub mod format;
 pub mod layout;

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -110,7 +110,7 @@ pub struct UserTheme {
   pub highlighted_lyrics: Option<String>,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Theme {
   #[allow(dead_code)]
   pub analysis_bar: Color,
@@ -849,6 +849,8 @@ pub struct BehaviorConfigString {
   pub draw_cover_art_forced: Option<bool>,
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: Option<u16>,
+  #[cfg(feature = "cover-art")]
+  pub cover_art_theme: Option<bool>,
   #[cfg(feature = "mcp-server")]
   pub mcp_enabled: Option<bool>,
   #[cfg(feature = "ai-dj")]
@@ -963,6 +965,10 @@ pub struct BehaviorConfig {
   pub draw_cover_art_forced: bool,
   #[cfg(feature = "cover-art")]
   pub playbar_cover_art_size_percent: u16,
+  /// Recolor the UI accents from the current track's cover art, fading on
+  /// track change. Off by default so a chosen preset stays untouched.
+  #[cfg(feature = "cover-art")]
+  pub cover_art_theme: bool,
   /// Whether to open the local MCP control socket so `spotatui mcp` (and through
   /// it Claude Code, Codex, or any MCP client) can drive playback.
   ///
@@ -1415,6 +1421,8 @@ impl UserConfig {
         draw_cover_art_forced: false,
         #[cfg(feature = "cover-art")]
         playbar_cover_art_size_percent: 100,
+        #[cfg(feature = "cover-art")]
+        cover_art_theme: false,
         #[cfg(feature = "mcp-server")]
         mcp_enabled: false,
         #[cfg(feature = "ai-dj")]
@@ -1857,6 +1865,10 @@ impl UserConfig {
     if let Some(playbar_cover_art_size_percent) = behavior_config.playbar_cover_art_size_percent {
       self.behavior.playbar_cover_art_size_percent =
         clamp_playbar_cover_art_size_percent(playbar_cover_art_size_percent);
+    }
+    #[cfg(feature = "cover-art")]
+    if let Some(cover_art_theme) = behavior_config.cover_art_theme {
+      self.behavior.cover_art_theme = cover_art_theme;
     }
     #[cfg(feature = "mcp-server")]
     if let Some(mcp_enabled) = behavior_config.mcp_enabled {
@@ -2432,6 +2444,8 @@ impl UserConfig {
       draw_cover_art_forced: Some(self.behavior.draw_cover_art_forced),
       #[cfg(feature = "cover-art")]
       playbar_cover_art_size_percent: Some(self.behavior.playbar_cover_art_size_percent),
+      #[cfg(feature = "cover-art")]
+      cover_art_theme: Some(self.behavior.cover_art_theme),
       #[cfg(feature = "mcp-server")]
       mcp_enabled: Some(self.behavior.mcp_enabled),
       #[cfg(feature = "ai-dj")]
@@ -2663,6 +2677,15 @@ impl UserConfig {
   #[cfg(feature = "cover-art")]
   pub fn do_draw_cover_art(&self, full_image_support: bool) -> bool {
     self.behavior.draw_cover_art && (self.behavior.draw_cover_art_forced || full_image_support)
+  }
+
+  /// Whether anything needs the cover art fetched and decoded: the art pane,
+  /// or the adaptive theme, which extracts its palette from the decoded image
+  /// even when the pane itself is hidden (disabled, or a terminal without
+  /// image support). Draw sites keep their own `do_draw_cover_art` gate.
+  #[cfg(feature = "cover-art")]
+  pub fn needs_cover_art(&self, full_image_support: bool) -> bool {
+    self.do_draw_cover_art(full_image_support) || self.behavior.cover_art_theme
   }
 }
 

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1291,20 +1291,27 @@ impl PlaybackNetwork for Network {
       }
     };
 
+    // Dominant-color extraction for the adaptive theme: one pass over a 64x64
+    // thumbnail, but still done here, off the App lock, like the decode above.
+    let palette = result
+      .as_ref()
+      .ok()
+      .and_then(crate::core::cover_theme::extract_palette);
+
     let mut app = self.app.lock().await;
     if app.desired_cover_art_key.as_deref() != Some(key.as_str()) {
       return;
     }
     match result {
       Ok(img) => {
-        app.cover_art.store_decoded(key, img);
+        app.store_cover_art(key, img, palette);
         app.cover_art_status = CoverArtStatus::Loaded;
       }
       Err(err) => {
         log::warn!("cover art load failed: {err}");
         // Drop any stale art so the pane shows the "unavailable" placeholder
         // rather than the previous track's image.
-        app.cover_art.clear();
+        app.clear_cover_art();
         app.cover_art_status = CoverArtStatus::Failed;
       }
     }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -204,6 +204,8 @@ fn cover_art_request_for(
       path,
     });
   }
+  #[cfg(not(feature = "local-files"))]
+  let _ = app;
 
   snapshot
     .metadata
@@ -889,7 +891,8 @@ pub async fn start_ui(
         || current_route.active_block == ActiveBlock::Analysis
         || (current_route.id == RouteId::LyricsView
           && app.lyrics_status == crate::core::app::LyricsStatus::Found)
-        || app.liked_song_animation_frame.is_some();
+        || app.liked_song_animation_frame.is_some()
+        || app.theme_fade_active();
       let current_tick_rate = if animation_active {
         app.user_config.behavior.animation_tick_rate_milliseconds
       } else {
@@ -1100,7 +1103,7 @@ pub async fn start_ui(
             use crate::core::app::CoverArtStatus;
             let enabled = app
               .user_config
-              .do_draw_cover_art(app.cover_art.full_image_support());
+              .needs_cover_art(app.cover_art.full_image_support());
             let desired = if enabled {
               snapshot
                 .as_ref()
@@ -1124,7 +1127,7 @@ pub async fn start_ui(
                 // No art to show (radio, art disabled, nothing playing): drop
                 // any stale image once, so the pane shows the placeholder.
                 if last_cover_art_key.take().is_some() || app.cover_art.available() {
-                  app.cover_art.clear();
+                  app.clear_cover_art();
                 }
                 app.cover_art_status = if enabled && snapshot.is_some() {
                   CoverArtStatus::Unavailable


### PR DESCRIPTION
# Summary

Adds an Adaptive Theme option (Settings > Theme, off by default): UI accent colors are derived from the current track's cover art and fade in on track change, fading back to the user's own theme when art clears. Text, background, borders, and error colors stay untouched so legibility never depends on the art.

- New `core/cover_theme` module (cfg `cover-art`): dominant-color extraction from the decoded cover (scored 4-bit color bins, saturation and mid-brightness weighted), theme derivation with a legibility clamp against the base background, and a time-based fade driven from `update_on_tick`.
- Palette extraction runs in the network layer off the App lock, alongside the existing decode; `App::store_cover_art` / `App::clear_cover_art` keep the palette paired with the art at one chokepoint.
- Settings saves reconcile with an in-flight fade so album accents never leak into `custom_theme`, and a save from another category keeps the base theme intact.
- The art fetch gate is now `UserConfig::needs_cover_art`, so theming works with the art pane hidden (disabled or no terminal image support). Color-space math reuses `csscolorparser` (via the existing `colorgrad` dep) instead of hand-rolled conversions, and the fade shares `ease_in_out_cubic` with the lyrics animation.

# Testing

Ran:
- cargo fmt --all
- cargo clippy --no-default-features --features telemetry -- -D warnings
- cargo clippy --no-default-features --features telemetry,cover-art -- -D warnings
- cargo check --no-default-features --features telemetry,cover-art --tests

Still to run before merge (test binaries with `cover-art` cannot run from the agent harness):
- cargo test --no-default-features --features telemetry,cover-art cover_theme (12 new unit tests for extraction/derivation/lerp plus 8 state-machine tests in app.rs)
- Smoke test with the full `cargo run` build

# Additional notes

- Also fixes two latent unused-variable lints (`migrations.rs` on non-Unix, `runner.rs` without `local-files`) that only surface in feature/platform combos CI does not build.
- Known follow-up: the fade animates `user_config.theme` in place, the same field `ScriptEffect::SetTheme` writes, so a Lua theme write during a fade gets overwritten. A resolution-point `App::theme()` would fix this but touches every theme read site, so it is left for a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional adaptive theme that derives accent colors from album cover art.
  * Added smooth transitions between album-based themes as tracks change.
  * Restores the saved user theme when adaptive theming or cover art is disabled or unavailable.
  * Added an Adaptive Theme setting, disabled by default.
* **Bug Fixes**
  * Prevented album-derived colors from replacing the user’s saved theme.
  * Improved stale cover-art handling when artwork cannot be loaded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->