### PR TITLE
feat(visualizer): add cava visualizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,7 +5941,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tui-bar-graph",
- "tui-equalizer",
  "unicode-width",
  "url",
  "vergen",
@@ -6838,15 +6837,6 @@ dependencies = [
  "document-features",
  "ratatui-core",
  "strum 0.28.0",
-]
-
-[[package]]
-name = "tui-equalizer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ca8635ed2249ea0a6d3fd83e2644f738179e742fc03721d1df91e3828f5b93"
-dependencies = [
- "ratatui-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ clap_complete = "4.6"
 unicode-width = "0.2.2"
 backtrace = "0.3.76"
 crossterm = "0.29"
-tui-equalizer = "0.2.0-alpha"
 tui-bar-graph = "0.3.3"
 colorgrad = "0.8.0"
 tokio = { version = "1.52", features = ["full"] }

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -146,7 +146,7 @@ pub struct App {
   pub last_dispatched_volume: Option<u8>,
   pub instant_since_last_current_playback_poll: Instant,
   navigation_stack: Vec<Route>,
-  pub spectrum_data: Option<SpectrumData>,
+  pub spectrum_data: Option<crate::infra::audio::SpectrumData>,
   pub audio_capture_active: bool,
   pub home_scroll: u16,
   pub user_config: UserConfig,

--- a/src/core/app/models.rs
+++ b/src/core/app/models.rs
@@ -67,7 +67,7 @@ pub struct TrackTable {
 /// Spectrum data for local audio visualization
 #[derive(Clone, Default)]
 pub struct SpectrumData {
-  pub bands: [f32; 12],
+  pub bands: Vec<f32>,
   pub peak: f32,
 }
 

--- a/src/core/app/models.rs
+++ b/src/core/app/models.rs
@@ -64,13 +64,6 @@ pub struct TrackTable {
   pub scroll_offset: std::cell::Cell<usize>,
 }
 
-/// Spectrum data for local audio visualization
-#[derive(Clone, Default)]
-pub struct SpectrumData {
-  pub bands: Vec<f32>,
-  pub peak: f32,
-}
-
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum PendingTrackSelection {
   Index(usize),

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -527,24 +527,26 @@ impl ThemePreset {
 /// Available audio visualizer styles
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub enum VisualizerStyle {
-  /// Equalizer mode: Uses tui-equalizer with half-block bars and brightness effect
+  /// Cava mode: cava's engine and mirrored stereo layout drawn in eighth blocks
   ///
-  /// Note: Older configs may contain `Classic`; it is accepted as an alias for `Equalizer`.
+  /// Note: Older configs may contain `Equalizer` (a removed style) or `Classic`
+  /// (its even older name); both are accepted as aliases so existing config
+  /// files keep loading and roll over to Cava.
   #[default]
-  #[serde(alias = "Classic")]
-  Equalizer,
+  #[serde(alias = "Classic", alias = "Equalizer")]
+  Cava,
   /// BarGraph mode: Uses tui-bar-graph with Braille patterns for high-resolution display
   BarGraph,
 }
 
 impl VisualizerStyle {
   pub fn all() -> &'static [VisualizerStyle] {
-    &[VisualizerStyle::Equalizer, VisualizerStyle::BarGraph]
+    &[VisualizerStyle::Cava, VisualizerStyle::BarGraph]
   }
 
   pub fn name(&self) -> &'static str {
     match self {
-      VisualizerStyle::Equalizer => "Equalizer",
+      VisualizerStyle::Cava => "Cava",
       VisualizerStyle::BarGraph => "Bar Graph",
     }
   }
@@ -2845,6 +2847,19 @@ pub fn color_to_string(color: Color) -> String {
 
 #[cfg(test)]
 mod tests {
+  #[test]
+  fn removed_visualizer_styles_deserialize_as_cava() {
+    use super::VisualizerStyle;
+    // Configs written before the Equalizer style was removed (or before it
+    // was renamed from Classic) must keep loading, rolling over to Cava.
+    for old_name in ["Equalizer", "Classic", "Cava"] {
+      let style: VisualizerStyle = serde_yaml::from_str(old_name).unwrap();
+      assert_eq!(style, VisualizerStyle::Cava, "{old_name}");
+    }
+    let style: VisualizerStyle = serde_yaml::from_str("BarGraph").unwrap();
+    assert_eq!(style, VisualizerStyle::BarGraph);
+  }
+
   #[test]
   fn test_parse_key() {
     use super::parse_key;

--- a/src/infra/audio/analyzer.rs
+++ b/src/infra/audio/analyzer.rs
@@ -1,10 +1,8 @@
 use std::sync::{Arc, Mutex};
 
-use super::cavacore::{treble_buffer_size, Cava, CavaBuilder, Channels, DEFAULT_NOISE_REDUCTION};
-
-/// Display bars produced before the first render tick reports the terminal
-/// width. Display bars are the mirrored stereo total (2x bars-per-channel).
-pub const DEFAULT_BANDS: usize = 12;
+use super::cavacore::{
+  max_bars_per_channel, Cava, CavaBuilder, Channels, DEFAULT_NOISE_REDUCTION, MAX_SAMPLE_RATE,
+};
 
 /// cavacore was written for 16-bit-scale samples (cava's own f32 input path
 /// multiplies by USHRT_MAX); cpal/PipeWire deliver f32 in [-1, 1], so scale up
@@ -24,8 +22,6 @@ pub struct SpectrumData {
   /// channel reversed on the left half (treble at the outer edge, bass at the
   /// center), right channel forward on the right half.
   pub bands: Vec<f32>,
-  /// Overall peak level (0.0-1.0)
-  pub peak: f32,
 }
 
 /// Audio analyzer wrapping the vendored cavacore engine: log-spaced per-bar
@@ -39,9 +35,6 @@ pub struct AudioAnalyzer {
   bars_per_channel: usize,
   /// Interleaved stereo 16-bit-scale samples awaiting the next `process()`.
   pending: Vec<f64>,
-  /// Newest samples one `execute` can consume (cavacore's sliding stereo
-  /// input window); `pending` is capped here so a stalled UI can't grow it.
-  max_pending: usize,
   /// Raw engine output: [left 0..bpc][right bpc..2bpc], each bass to treble.
   output: Box<[f64]>,
   spectrum: SpectrumData,
@@ -50,37 +43,37 @@ pub struct AudioAnalyzer {
 impl AudioAnalyzer {
   pub fn new(sample_rate: u32, display_bars: usize) -> Self {
     let sample_rate = clamp_sample_rate(sample_rate);
-    let bars_per_channel = clamp_bars_per_channel(sample_rate, display_bars / 2);
+    Self::with_plan(
+      sample_rate,
+      clamp_bars_per_channel(sample_rate, display_bars / 2),
+    )
+  }
+
+  /// Build the cavacore plan and the buffers it sizes. Both setters below go
+  /// through here, so a rebuild starts from exactly the same state a fresh
+  /// analyzer does - which is also what cava does on resize.
+  fn with_plan(sample_rate: u32, bars_per_channel: usize) -> Self {
+    let cava = build_cava(sample_rate, bars_per_channel);
+    let output = cava.make_output();
 
     Self {
-      cava: build_cava(sample_rate, bars_per_channel),
+      spectrum: SpectrumData {
+        bands: vec![0.0; output.len()],
+      },
+      pending: Vec::new(),
+      output,
+      cava,
       sample_rate,
       bars_per_channel,
-      pending: Vec::new(),
-      max_pending: treble_buffer_size(sample_rate) * 8 * 2,
-      output: vec![0.0; bars_per_channel * 2].into_boxed_slice(),
-      spectrum: SpectrumData {
-        bands: vec![0.0; bars_per_channel * 2],
-        peak: 0.0,
-      },
     }
   }
 
-  /// Rebuild the cavacore plan for a new display bar count (terminal resize or
-  /// style switch). State starts fresh, matching cava's own behavior on resize.
+  /// Rebuild for a new display bar count (terminal resize or style switch).
   pub fn set_bars(&mut self, display_bars: usize) {
     let bars_per_channel = clamp_bars_per_channel(self.sample_rate, display_bars / 2);
-    if bars_per_channel == self.bars_per_channel {
-      return;
+    if bars_per_channel != self.bars_per_channel {
+      *self = Self::with_plan(self.sample_rate, bars_per_channel);
     }
-
-    self.bars_per_channel = bars_per_channel;
-    self.cava = build_cava(self.sample_rate, bars_per_channel);
-    self.output = vec![0.0; bars_per_channel * 2].into_boxed_slice();
-    self.spectrum = SpectrumData {
-      bands: vec![0.0; bars_per_channel * 2],
-      peak: 0.0,
-    };
   }
 
   /// Adopt the rate the audio server actually negotiated. Only the PipeWire
@@ -88,32 +81,32 @@ impl AudioAnalyzer {
   #[allow(dead_code)]
   pub fn set_sample_rate(&mut self, sample_rate: u32) {
     let sample_rate = clamp_sample_rate(sample_rate);
-    if sample_rate == self.sample_rate {
-      return;
+    if sample_rate != self.sample_rate {
+      let bars_per_channel = clamp_bars_per_channel(sample_rate, self.bars_per_channel);
+      *self = Self::with_plan(sample_rate, bars_per_channel);
     }
-
-    self.sample_rate = sample_rate;
-    self.bars_per_channel = clamp_bars_per_channel(sample_rate, self.bars_per_channel);
-    self.max_pending = treble_buffer_size(sample_rate) * 8 * 2;
-    self.pending.clear();
-    self.cava = build_cava(sample_rate, self.bars_per_channel);
-    self.output = vec![0.0; self.bars_per_channel * 2].into_boxed_slice();
-    self.spectrum = SpectrumData {
-      bands: vec![0.0; self.bars_per_channel * 2],
-      peak: 0.0,
-    };
   }
 
-  /// Push interleaved stereo audio frames (left, right, left, right, ...)
-  pub fn push_samples(&mut self, samples: &[f32]) {
-    self
-      .pending
-      .extend(samples.iter().map(|&s| f64::from(s) * SAMPLE_SCALE));
+  /// Push interleaved capture frames. Owning the channel rule here keeps both
+  /// capture backends from restating it: channels 0/1 pass through to cava's
+  /// stereo pipeline, a mono device duplicates. Deinterleaving and the 16-bit
+  /// scaling happen in one pass into `pending`, so callers on the audio
+  /// thread need no temporary buffer.
+  pub fn push_frames(&mut self, data: &[f32], channels: usize) {
+    let channels = channels.max(1);
+    for frame in data.chunks_exact(channels) {
+      let left = frame[0];
+      let right = if channels > 1 { frame[1] } else { left };
+      self.pending.push(f64::from(left) * SAMPLE_SCALE);
+      self.pending.push(f64::from(right) * SAMPLE_SCALE);
+    }
 
-    // Keep only the newest samples, matching cavacore's own sliding window.
-    // Callers push whole frames, so the cap (an even number) stays aligned.
-    if self.pending.len() > self.max_pending {
-      let excess = self.pending.len() - self.max_pending;
+    // Keep only the newest samples, matching cavacore's own sliding window, so
+    // a stalled UI cannot grow the backlog. Whole frames in means the cap (an
+    // even number) stays channel-aligned.
+    let max_pending = self.cava.input_len();
+    if self.pending.len() > max_pending {
+      let excess = self.pending.len() - max_pending;
       self.pending.drain(..excess);
     }
   }
@@ -127,11 +120,6 @@ impl AudioAnalyzer {
     self.pending.clear();
 
     mirror_stereo_bands(&self.output, &mut self.spectrum.bands);
-    self.spectrum.peak = self
-      .spectrum
-      .bands
-      .iter()
-      .fold(0.0f32, |peak, &band| peak.max(band));
 
     self.spectrum.clone()
   }
@@ -153,12 +141,11 @@ fn mirror_stereo_bands(output: &[f64], bands: &mut [f32]) {
 /// so any admitted rate must keep Nyquist >= 2 or the builder's sanity check
 /// rejects the range and the expect below panics.
 fn clamp_sample_rate(sample_rate: u32) -> u32 {
-  sample_rate.clamp(4, 384_000)
+  sample_rate.clamp(4, MAX_SAMPLE_RATE)
 }
 
 fn clamp_bars_per_channel(sample_rate: u32, bars_per_channel: usize) -> usize {
-  let max_bars = treble_buffer_size(sample_rate) / 2 + 1;
-  bars_per_channel.clamp(1, max_bars)
+  bars_per_channel.clamp(1, max_bars_per_channel(sample_rate))
 }
 
 fn build_cava(sample_rate: u32, bars_per_channel: usize) -> Cava {
@@ -182,8 +169,17 @@ fn build_cava(sample_rate: u32, bars_per_channel: usize) -> Cava {
 /// Thread-safe wrapper for AudioAnalyzer
 pub type SharedAnalyzer = Arc<Mutex<AudioAnalyzer>>;
 
-pub fn create_shared_analyzer(sample_rate: u32) -> SharedAnalyzer {
-  Arc::new(Mutex::new(AudioAnalyzer::new(sample_rate, DEFAULT_BANDS)))
+pub fn create_shared_analyzer(sample_rate: u32, display_bars: usize) -> SharedAnalyzer {
+  Arc::new(Mutex::new(AudioAnalyzer::new(sample_rate, display_bars)))
+}
+
+/// Resize to `desired_bars` and read the next frame of spectrum data. Both
+/// capture backends share this so the "resize before you read" ordering is
+/// stated once.
+pub fn spectrum_for(analyzer: &SharedAnalyzer, desired_bars: usize) -> Option<SpectrumData> {
+  let mut analyzer = analyzer.lock().ok()?;
+  analyzer.set_bars(desired_bars);
+  Some(analyzer.process())
 }
 
 #[cfg(test)]
@@ -193,24 +189,43 @@ mod tests {
   #[test]
   fn push_scales_samples_to_16_bit_range() {
     let mut analyzer = AudioAnalyzer::new(48_000, 12);
-    analyzer.push_samples(&[1.0, -0.5]);
+    analyzer.push_frames(&[1.0, -0.5], 2);
     assert_eq!(analyzer.pending, vec![32_768.0, -16_384.0]);
+  }
+
+  #[test]
+  fn mono_capture_frames_are_duplicated_to_both_channels() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.push_frames(&[1.0, -0.5], 1);
+    assert_eq!(
+      analyzer.pending,
+      vec![32_768.0, 32_768.0, -16_384.0, -16_384.0]
+    );
+  }
+
+  #[test]
+  fn extra_capture_channels_are_dropped_after_the_stereo_pair() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    // One 5.1 frame: only front left/right reach the engine.
+    analyzer.push_frames(&[1.0, -1.0, 0.5, 0.25, 0.125, 0.0625], 6);
+    assert_eq!(analyzer.pending, vec![32_768.0, -32_768.0]);
   }
 
   #[test]
   fn pending_backlog_keeps_the_newest_samples() {
     let mut analyzer = AudioAnalyzer::new(48_000, 12);
-    analyzer.push_samples(&vec![0.0; analyzer.max_pending]);
-    analyzer.push_samples(&[1.0, 1.0]);
+    let max_pending = analyzer.cava.input_len();
+    analyzer.push_frames(&vec![0.0; max_pending], 2);
+    analyzer.push_frames(&[1.0, 1.0], 2);
 
-    assert_eq!(analyzer.pending.len(), analyzer.max_pending);
+    assert_eq!(analyzer.pending.len(), max_pending);
     assert_eq!(analyzer.pending.last(), Some(&32_768.0));
   }
 
   #[test]
   fn process_drains_pending_and_reports_requested_bars() {
     let mut analyzer = AudioAnalyzer::new(48_000, 12);
-    analyzer.push_samples(&[0.25; 512]);
+    analyzer.push_frames(&[0.25; 512], 2);
 
     let spectrum = analyzer.process();
 
@@ -255,7 +270,7 @@ mod tests {
   #[test]
   fn sample_rate_change_rebuilds_without_panicking() {
     let mut analyzer = AudioAnalyzer::new(48_000, 12);
-    analyzer.push_samples(&[0.5; 256]);
+    analyzer.push_frames(&[0.5; 256], 2);
     analyzer.set_sample_rate(44_100);
 
     let spectrum = analyzer.process();

--- a/src/infra/audio/analyzer.rs
+++ b/src/infra/audio/analyzer.rs
@@ -1,181 +1,264 @@
 use std::sync::{Arc, Mutex};
 
-/// Frequency bands for visualization (12 bands like chromatic scale)
-pub const NUM_BANDS: usize = 12;
+use super::cavacore::{treble_buffer_size, Cava, CavaBuilder, Channels, DEFAULT_NOISE_REDUCTION};
 
-/// Smoothing factor for spectrum display (0.0 = no smoothing, 1.0 = infinite smoothing)
-/// Higher = smoother but slower response, lower = faster but jittery
-const SMOOTHING: f32 = 0.5;
+/// Display bars produced before the first render tick reports the terminal
+/// width. Display bars are the mirrored stereo total (2x bars-per-channel).
+pub const DEFAULT_BANDS: usize = 12;
 
-/// Base gain for visualization amplitude
-const GAIN: f32 = 0.85;
+/// cavacore was written for 16-bit-scale samples (cava's own f32 input path
+/// multiplies by USHRT_MAX); cpal/PipeWire deliver f32 in [-1, 1], so scale up
+/// before the f64 cast or autosens ramps against a mis-scaled noise floor.
+const SAMPLE_SCALE: f64 = 32768.0;
 
-/// FFT window size (power of 2, ~46ms at 44.1kHz)
-const FFT_SIZE: usize = 2048;
+/// Cap on cavacore's autosens gain. Uncapped autosens (cava's behavior)
+/// normalizes ANY input level to full-scale bars given a few seconds; the cap
+/// (~+15 dB of boost) still evens out track-to-track loudness but keeps
+/// genuinely quiet audio rendering short bars instead of climbing to 100%.
+const MAX_AUTOSENS_GAIN: f64 = 6.0;
 
 /// Spectrum data for visualization
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SpectrumData {
-  /// Normalized frequency bands (0.0-1.0)
-  pub bands: [f32; NUM_BANDS],
+  /// Normalized bars (0.0-1.0) in cava's default stereo display order: left
+  /// channel reversed on the left half (treble at the outer edge, bass at the
+  /// center), right channel forward on the right half.
+  pub bands: Vec<f32>,
   /// Overall peak level (0.0-1.0)
   pub peak: f32,
 }
 
-impl Default for SpectrumData {
-  fn default() -> Self {
-    Self {
-      bands: [0.0; NUM_BANDS],
-      peak: 0.0,
-    }
-  }
-}
-
-/// Audio analyzer that performs FFT on incoming samples
+/// Audio analyzer wrapping the vendored cavacore engine: log-spaced per-bar
+/// cutoffs over bass/mid/treble FFTs, integral smoothing, gravity fall-off and
+/// autosens (one persistent gain, fast duck / slow recovery). Runs in stereo
+/// and mirrors the two channels like cava's default display.
 pub struct AudioAnalyzer {
-  fft: Arc<dyn realfft::RealToComplex<f32>>,
-  sample_buffer: Vec<f32>,
-  fft_input: Vec<f32>,
-  fft_output: Vec<realfft::num_complex::Complex<f32>>,
+  cava: Cava,
+  sample_rate: u32,
+  /// Bars per audio channel; the display shows twice this, mirrored.
+  bars_per_channel: usize,
+  /// Interleaved stereo 16-bit-scale samples awaiting the next `process()`.
+  pending: Vec<f64>,
+  /// Newest samples one `execute` can consume (cavacore's sliding stereo
+  /// input window); `pending` is capped here so a stalled UI can't grow it.
+  max_pending: usize,
+  /// Raw engine output: [left 0..bpc][right bpc..2bpc], each bass to treble.
+  output: Box<[f64]>,
   spectrum: SpectrumData,
-  write_pos: usize,
 }
 
 impl AudioAnalyzer {
-  pub fn new() -> Self {
-    let mut planner = realfft::RealFftPlanner::new();
-    let fft = planner.plan_fft_forward(FFT_SIZE);
-    let fft_output_len = FFT_SIZE / 2 + 1;
+  pub fn new(sample_rate: u32, display_bars: usize) -> Self {
+    let sample_rate = clamp_sample_rate(sample_rate);
+    let bars_per_channel = clamp_bars_per_channel(sample_rate, display_bars / 2);
 
     Self {
-      fft,
-      sample_buffer: vec![0.0; FFT_SIZE],
-      fft_input: vec![0.0; FFT_SIZE],
-      fft_output: vec![realfft::num_complex::Complex::default(); fft_output_len],
-      spectrum: SpectrumData::default(),
-      write_pos: 0,
+      cava: build_cava(sample_rate, bars_per_channel),
+      sample_rate,
+      bars_per_channel,
+      pending: Vec::new(),
+      max_pending: treble_buffer_size(sample_rate) * 8 * 2,
+      output: vec![0.0; bars_per_channel * 2].into_boxed_slice(),
+      spectrum: SpectrumData {
+        bands: vec![0.0; bars_per_channel * 2],
+        peak: 0.0,
+      },
     }
   }
 
-  /// Push audio samples into the analyzer
+  /// Rebuild the cavacore plan for a new display bar count (terminal resize or
+  /// style switch). State starts fresh, matching cava's own behavior on resize.
+  pub fn set_bars(&mut self, display_bars: usize) {
+    let bars_per_channel = clamp_bars_per_channel(self.sample_rate, display_bars / 2);
+    if bars_per_channel == self.bars_per_channel {
+      return;
+    }
+
+    self.bars_per_channel = bars_per_channel;
+    self.cava = build_cava(self.sample_rate, bars_per_channel);
+    self.output = vec![0.0; bars_per_channel * 2].into_boxed_slice();
+    self.spectrum = SpectrumData {
+      bands: vec![0.0; bars_per_channel * 2],
+      peak: 0.0,
+    };
+  }
+
+  /// Adopt the rate the audio server actually negotiated. Only the PipeWire
+  /// backend renegotiates after construction, so cpal builds never call this.
+  #[allow(dead_code)]
+  pub fn set_sample_rate(&mut self, sample_rate: u32) {
+    let sample_rate = clamp_sample_rate(sample_rate);
+    if sample_rate == self.sample_rate {
+      return;
+    }
+
+    self.sample_rate = sample_rate;
+    self.bars_per_channel = clamp_bars_per_channel(sample_rate, self.bars_per_channel);
+    self.max_pending = treble_buffer_size(sample_rate) * 8 * 2;
+    self.pending.clear();
+    self.cava = build_cava(sample_rate, self.bars_per_channel);
+    self.output = vec![0.0; self.bars_per_channel * 2].into_boxed_slice();
+    self.spectrum = SpectrumData {
+      bands: vec![0.0; self.bars_per_channel * 2],
+      peak: 0.0,
+    };
+  }
+
+  /// Push interleaved stereo audio frames (left, right, left, right, ...)
   pub fn push_samples(&mut self, samples: &[f32]) {
-    for &sample in samples {
-      self.sample_buffer[self.write_pos] = sample;
-      self.write_pos = (self.write_pos + 1) % FFT_SIZE;
+    self
+      .pending
+      .extend(samples.iter().map(|&s| f64::from(s) * SAMPLE_SCALE));
+
+    // Keep only the newest samples, matching cavacore's own sliding window.
+    // Callers push whole frames, so the cap (an even number) stays aligned.
+    if self.pending.len() > self.max_pending {
+      let excess = self.pending.len() - self.max_pending;
+      self.pending.drain(..excess);
     }
   }
 
   /// Process buffered samples and update spectrum
   pub fn process(&mut self) -> SpectrumData {
-    // Copy samples to FFT input buffer (in order from write position)
-    for i in 0..FFT_SIZE {
-      let idx = (self.write_pos + i) % FFT_SIZE;
-      // Apply Hann window
-      let window = 0.5 * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / FFT_SIZE as f32).cos());
-      self.fft_input[i] = self.sample_buffer[idx] * window;
-    }
+    // Zero new samples still executes: cavacore keeps applying gravity and the
+    // integral filter to the stale window, which is what animates bars falling
+    // after pause instead of freezing them.
+    self.cava.execute(&self.pending, &mut self.output);
+    self.pending.clear();
 
-    // Perform FFT
-    if self
-      .fft
-      .process(&mut self.fft_input, &mut self.fft_output)
-      .is_ok()
-    {
-      self.update_spectrum();
-    }
+    mirror_stereo_bands(&self.output, &mut self.spectrum.bands);
+    self.spectrum.peak = self
+      .spectrum
+      .bands
+      .iter()
+      .fold(0.0f32, |peak, &band| peak.max(band));
 
     self.spectrum.clone()
   }
+}
 
-  /// Map FFT bins to frequency bands
-  fn update_spectrum(&mut self) {
-    let bin_count = self.fft_output.len();
-
-    // Frequency band boundaries (logarithmic scale, roughly musical)
-    // Maps to approximately: C(~32Hz) to B(~16kHz) in octave bands
-    let band_edges: [usize; NUM_BANDS + 1] = [
-      1,
-      2,
-      4,
-      8,
-      16,
-      32,
-      64,
-      128,
-      256,
-      384,
-      512,
-      768,
-      bin_count - 1,
-    ];
-
-    let mut new_bands = [0.0f32; NUM_BANDS];
-    let mut max_magnitude = 0.0f32;
-
-    for band in 0..NUM_BANDS {
-      let start = band_edges[band];
-      let end = band_edges[band + 1].min(bin_count);
-
-      if start < end {
-        let mut sum = 0.0f32;
-        for i in start..end {
-          let magnitude = self.fft_output[i].norm();
-          sum += magnitude;
-          max_magnitude = max_magnitude.max(magnitude);
-        }
-        new_bands[band] = sum / (end - start) as f32;
-      }
-    }
-
-    // Per-band gain for visualization - boosted highs to compensate for low energy
-    const BAND_GAINS: [f32; NUM_BANDS] = [
-      0.7, // Sub   - reduce sub rumble
-      0.8, // Bass  - visible but not overwhelming
-      0.9, // Low   - building up
-      1.0, // LMid  - full
-      1.0, // Mid   - peak visibility (voice frequencies)
-      1.0, // UMid  - peak visibility
-      1.1, // High  - boost slightly
-      1.2, // HiMd  - boost more
-      1.3, // Pres  - boost more
-      1.4, // Bril  - boost more
-      1.6, // Air   - significant boost
-      2.0, // Ultra - major boost (very little energy here)
-    ];
-
-    // Normalize and apply pleasing visual curve
-    if max_magnitude > 0.0 {
-      for (i, band) in new_bands.iter_mut().enumerate() {
-        // Normalize, apply per-band curve, then global gain
-        let normalized = (*band / max_magnitude) * BAND_GAINS[i] * GAIN;
-        // Square root gives more pleasing response (dB-like scaling)
-        let scaled = normalized.sqrt();
-        // Gentle limiting - cap at 85% so bars never hit the top
-        *band = scaled.min(0.85);
-      }
-    }
-
-    // Apply smoothing for butter-smooth animation
-    for (i, new_band) in new_bands.iter().enumerate() {
-      self.spectrum.bands[i] = self.spectrum.bands[i] * SMOOTHING + *new_band * (1.0 - SMOOTHING);
-      // Noise gate: treat very low values as zero
-      if self.spectrum.bands[i] < 0.005 {
-        self.spectrum.bands[i] = 0.0;
-      }
-    }
-
-    // Update peak with smoothing and noise gate
-    let current_peak = new_bands.iter().cloned().fold(0.0f32, f32::max);
-    self.spectrum.peak = self.spectrum.peak * SMOOTHING + current_peak * (1.0 - SMOOTHING);
-    if self.spectrum.peak < 0.005 {
-      self.spectrum.peak = 0.0;
-    }
+/// cava.c's default stereo display order (its `p.stereo` mirroring loop with
+/// `reverse = 0`): display position n < bars/2 shows the left channel at index
+/// bars/2 - n - 1 (reversed), position n >= bars/2 shows the right channel at
+/// index n - bars/2 (forward). Bass meets in the middle.
+fn mirror_stereo_bands(output: &[f64], bands: &mut [f32]) {
+  let bars_per_channel = output.len() / 2;
+  for n in 0..bars_per_channel {
+    bands[n] = output[bars_per_channel - n - 1].clamp(0.0, 1.0) as f32;
+    bands[bars_per_channel + n] = output[bars_per_channel + n].clamp(0.0, 1.0) as f32;
   }
+}
+
+/// Floor 4 (not 1): build_cava caps `freq_end` at Nyquist but never below 2,
+/// so any admitted rate must keep Nyquist >= 2 or the builder's sanity check
+/// rejects the range and the expect below panics.
+fn clamp_sample_rate(sample_rate: u32) -> u32 {
+  sample_rate.clamp(4, 384_000)
+}
+
+fn clamp_bars_per_channel(sample_rate: u32, bars_per_channel: usize) -> usize {
+  let max_bars = treble_buffer_size(sample_rate) / 2 + 1;
+  bars_per_channel.clamp(1, max_bars)
+}
+
+fn build_cava(sample_rate: u32, bars_per_channel: usize) -> Cava {
+  // cava's default range, with the top capped at Nyquist for low-rate devices
+  // (and the start kept under the top for absurdly low ones).
+  let freq_end = 10_000.min(sample_rate / 2);
+  let freq_start = 50.min(freq_end - 1).max(1);
+
+  CavaBuilder::default()
+    .bars_per_channel(bars_per_channel)
+    .sample_rate(sample_rate)
+    .audio_channels(Channels::Stereo)
+    .enable_autosens(true)
+    .max_sens(MAX_AUTOSENS_GAIN)
+    .noise_reduction(DEFAULT_NOISE_REDUCTION)
+    .frequency_range(freq_start..freq_end)
+    .build()
+    .expect("cavacore build with pre-clamped parameters")
 }
 
 /// Thread-safe wrapper for AudioAnalyzer
 pub type SharedAnalyzer = Arc<Mutex<AudioAnalyzer>>;
 
-pub fn create_shared_analyzer() -> SharedAnalyzer {
-  Arc::new(Mutex::new(AudioAnalyzer::new()))
+pub fn create_shared_analyzer(sample_rate: u32) -> SharedAnalyzer {
+  Arc::new(Mutex::new(AudioAnalyzer::new(sample_rate, DEFAULT_BANDS)))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn push_scales_samples_to_16_bit_range() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.push_samples(&[1.0, -0.5]);
+    assert_eq!(analyzer.pending, vec![32_768.0, -16_384.0]);
+  }
+
+  #[test]
+  fn pending_backlog_keeps_the_newest_samples() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.push_samples(&vec![0.0; analyzer.max_pending]);
+    analyzer.push_samples(&[1.0, 1.0]);
+
+    assert_eq!(analyzer.pending.len(), analyzer.max_pending);
+    assert_eq!(analyzer.pending.last(), Some(&32_768.0));
+  }
+
+  #[test]
+  fn process_drains_pending_and_reports_requested_bars() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.push_samples(&[0.25; 512]);
+
+    let spectrum = analyzer.process();
+
+    assert!(analyzer.pending.is_empty());
+    assert_eq!(spectrum.bands.len(), 12);
+  }
+
+  #[test]
+  fn set_bars_rebuilds_the_plan_for_the_new_count() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.set_bars(40);
+    assert_eq!(analyzer.process().bands.len(), 40);
+  }
+
+  #[test]
+  fn bands_are_mirrored_like_cavas_stereo_display() {
+    // Engine output: [left: 0.1, 0.2, 0.3][right: 0.4, 0.5, 0.6].
+    let mut bands = vec![0.0f32; 6];
+    mirror_stereo_bands(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6], &mut bands);
+
+    // Left half reversed (treble at the outer edge), right half forward.
+    assert_eq!(bands, vec![0.3, 0.2, 0.1, 0.4, 0.5, 0.6]);
+  }
+
+  #[test]
+  fn bars_are_clamped_to_what_the_sample_rate_supports() {
+    // 8 kHz -> treble buffer 128 -> at most 65 bars per channel.
+    let analyzer = AudioAnalyzer::new(8_000, 512);
+    assert_eq!(analyzer.bars_per_channel, 65);
+    assert_eq!(analyzer.spectrum.bands.len(), 130);
+  }
+
+  #[test]
+  fn degenerate_sample_rates_never_panic_the_builder() {
+    for rate in [0, 1, 2, 3, 4, 7_999] {
+      let mut analyzer = AudioAnalyzer::new(rate, 12);
+      analyzer.set_sample_rate(5);
+      let _ = analyzer.process();
+    }
+  }
+
+  #[test]
+  fn sample_rate_change_rebuilds_without_panicking() {
+    let mut analyzer = AudioAnalyzer::new(48_000, 12);
+    analyzer.push_samples(&[0.5; 256]);
+    analyzer.set_sample_rate(44_100);
+
+    let spectrum = analyzer.process();
+    assert_eq!(spectrum.bands.len(), 12);
+  }
 }

--- a/src/infra/audio/capture.rs
+++ b/src/infra/audio/capture.rs
@@ -31,7 +31,7 @@ impl AudioCaptureManager {
     // Get a compatible config that won't interfere with playback
     let config = Self::get_compatible_config(&device)?;
 
-    let analyzer = create_shared_analyzer();
+    let analyzer = create_shared_analyzer(config.sample_rate);
     let active = Arc::new(AtomicBool::new(true));
 
     let stream = Self::build_stream(&device, &config, analyzer.clone(), active.clone())?;
@@ -48,13 +48,15 @@ impl AudioCaptureManager {
     })
   }
 
-  /// Get the current spectrum data
-  pub fn get_spectrum(&self) -> Option<SpectrumData> {
+  /// Get the current spectrum data, sized to `desired_bars` (the analyzer
+  /// rebuilds its plan when the count changes, and clamps unsupportable counts)
+  pub fn get_spectrum(&self, desired_bars: usize) -> Option<SpectrumData> {
     if !self.active.load(Ordering::Relaxed) {
       return None;
     }
 
     if let Ok(mut analyzer) = self.analyzer.lock() {
+      analyzer.set_bars(desired_bars);
       Some(analyzer.process())
     } else {
       None
@@ -184,14 +186,19 @@ impl AudioCaptureManager {
     let active_clone = active.clone();
 
     let data_callback = move |data: &[f32], _: &cpal::InputCallbackInfo| {
-      // Convert to mono by averaging channels
-      let mono_samples: Vec<f32> = data
+      // Interleaved stereo frames for the analyzer, matching cava's default
+      // stereo pipeline: channels 0/1 pass through, a mono device duplicates.
+      let stereo_samples: Vec<f32> = data
         .chunks(channels)
-        .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+        .flat_map(|frame| {
+          let left = frame.first().copied().unwrap_or(0.0);
+          let right = frame.get(1).copied().unwrap_or(left);
+          [left, right]
+        })
         .collect();
 
       if let Ok(mut analyzer) = analyzer.lock() {
-        analyzer.push_samples(&mono_samples);
+        analyzer.push_samples(&stereo_samples);
       }
     };
 

--- a/src/infra/audio/capture.rs
+++ b/src/infra/audio/capture.rs
@@ -1,4 +1,4 @@
-use super::analyzer::{create_shared_analyzer, SharedAnalyzer, SpectrumData};
+use super::analyzer::{create_shared_analyzer, spectrum_for, SharedAnalyzer, SpectrumData};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 #[cfg(not(target_os = "windows"))]
 use cpal::BufferSize;
@@ -14,9 +14,9 @@ pub struct AudioCaptureManager {
 }
 
 impl AudioCaptureManager {
-  /// Create a new audio capture manager
+  /// Create a new audio capture manager sized for `display_bars`
   /// Returns None if no suitable audio device is found
-  pub fn new() -> Option<Self> {
+  pub fn new(display_bars: usize) -> Option<Self> {
     let host = cpal::default_host();
 
     // Try to find a loopback/monitor device
@@ -31,7 +31,7 @@ impl AudioCaptureManager {
     // Get a compatible config that won't interfere with playback
     let config = Self::get_compatible_config(&device)?;
 
-    let analyzer = create_shared_analyzer(config.sample_rate);
+    let analyzer = create_shared_analyzer(config.sample_rate, display_bars);
     let active = Arc::new(AtomicBool::new(true));
 
     let stream = Self::build_stream(&device, &config, analyzer.clone(), active.clone())?;
@@ -55,12 +55,7 @@ impl AudioCaptureManager {
       return None;
     }
 
-    if let Ok(mut analyzer) = self.analyzer.lock() {
-      analyzer.set_bars(desired_bars);
-      Some(analyzer.process())
-    } else {
-      None
-    }
+    spectrum_for(&self.analyzer, desired_bars)
   }
 
   /// Check if audio capture is currently active
@@ -186,19 +181,8 @@ impl AudioCaptureManager {
     let active_clone = active.clone();
 
     let data_callback = move |data: &[f32], _: &cpal::InputCallbackInfo| {
-      // Interleaved stereo frames for the analyzer, matching cava's default
-      // stereo pipeline: channels 0/1 pass through, a mono device duplicates.
-      let stereo_samples: Vec<f32> = data
-        .chunks(channels)
-        .flat_map(|frame| {
-          let left = frame.first().copied().unwrap_or(0.0);
-          let right = frame.get(1).copied().unwrap_or(left);
-          [left, right]
-        })
-        .collect();
-
       if let Ok(mut analyzer) = analyzer.lock() {
-        analyzer.push_samples(&stereo_samples);
+        analyzer.push_frames(data, channels);
       }
     };
 

--- a/src/infra/audio/cavacore/builder.rs
+++ b/src/infra/audio/cavacore/builder.rs
@@ -1,0 +1,197 @@
+use std::ops::Range;
+
+use crate::infra::audio::cavacore::{Channels, Error};
+
+/// The recommended default noise reduction value.
+/// Is automatically set if a new [`CavaBuilder`] is created.
+pub const DEFAULT_NOISE_REDUCTION: f64 = 0.77;
+
+/// The sample rate cap upstream encoded in its `SampleRate` bounded type;
+/// enforced by `sanity_check` instead (see the module-level divergence notes).
+const MAX_SAMPLE_RATE: u32 = 384_000;
+
+#[derive(Debug, Clone)]
+pub struct CavaBuilder {
+  pub(crate) bars_per_channel: usize,
+  pub(crate) sample_rate: u32,
+  pub(crate) audio_channels: Channels,
+  pub(crate) enable_autosens: bool,
+  pub(crate) noise_reduction: f64,
+  pub(crate) freq_range: Range<u32>,
+  pub(crate) max_sens: f64,
+}
+
+impl CavaBuilder {
+  pub fn bars_per_channel(mut self, bars_per_channel: usize) -> Self {
+    self.bars_per_channel = bars_per_channel;
+    self
+  }
+
+  pub fn sample_rate(mut self, sample_rate: u32) -> Self {
+    self.sample_rate = sample_rate;
+    self
+  }
+
+  pub fn audio_channels(mut self, audio_channels: Channels) -> Self {
+    self.audio_channels = audio_channels;
+    self
+  }
+
+  pub fn enable_autosens(mut self, enable_autosens: bool) -> Self {
+    self.enable_autosens = enable_autosens;
+    self
+  }
+
+  /// Adjust noise reduciton filters. Has to be within the range `0..=1`.
+  ///
+  /// The raw visualization is very noisy, this factor adjusts the integral
+  /// and gravity filters inside cavacore to keep the signal smooth:
+  /// `1` will be very slow and smooth, `0` will be fast but noisy.
+  pub fn noise_reduction(mut self, noise_reduction: f64) -> Self {
+    self.noise_reduction = noise_reduction;
+    self
+  }
+
+  pub fn frequency_range(mut self, freq_range: Range<u32>) -> Self {
+    self.freq_range = freq_range;
+    self
+  }
+
+  /// EXTENSION(spotatui): cap the autosens gain so near-silent input cannot be
+  /// amplified all the way to full-scale bars. Upstream and C cava have no
+  /// such cap (the default, infinity, keeps their behavior).
+  pub fn max_sens(mut self, max_sens: f64) -> Self {
+    self.max_sens = max_sens;
+    self
+  }
+
+  pub fn sanity_check(&self) -> Result<(), Vec<Error>> {
+    let mut errors = Vec::new();
+    let treble_buffer_size = self.compute_treble_buffer_size();
+
+    // These three checks replace upstream's NonZeroUsize / SampleRate /
+    // NonZeroU32 parameter types.
+    if self.bars_per_channel == 0 {
+      errors.push(Error::ZeroBars);
+    }
+
+    if self.sample_rate == 0 || self.sample_rate > MAX_SAMPLE_RATE {
+      errors.push(Error::InvalidSampleRate(self.sample_rate));
+    }
+
+    if self.freq_range.start == 0 {
+      errors.push(Error::ZeroFreqStart);
+    }
+
+    if self.bars_per_channel > treble_buffer_size / 2 + 1 {
+      errors.push(Error::TooHighAmountBars {
+        amount_bars: self.bars_per_channel,
+        sample_rate: self.sample_rate,
+        max_amount_bars: treble_buffer_size / 2 + 1,
+      });
+    }
+
+    if self.freq_range.is_empty() {
+      errors.push(Error::EmptyFreqRange {
+        start: self.freq_range.start,
+        end: self.freq_range.end,
+      });
+    }
+
+    if self.freq_range.end > self.sample_rate / 2 {
+      errors.push(Error::NyquistIssue {
+        freq: self.freq_range.end,
+        max_freq: self.sample_rate / 2,
+      });
+    }
+
+    if !errors.is_empty() {
+      return Err(errors);
+    }
+
+    Ok(())
+  }
+
+  pub(crate) fn compute_treble_buffer_size(&self) -> usize {
+    treble_buffer_size(self.sample_rate)
+  }
+}
+
+/// The treble FFT window cavacore picks for a sample rate. The bass window (and
+/// so the whole sliding input buffer for mono audio) is 8x this.
+pub fn treble_buffer_size(sample_rate: u32) -> usize {
+  let factor = if sample_rate <= 8_125 {
+    1
+  } else if sample_rate <= 16_250 {
+    2
+  } else if sample_rate <= 32_500 {
+    4
+  } else if sample_rate <= 75_000 {
+    8
+  } else if sample_rate <= 150_000 {
+    16
+  } else if sample_rate <= 300_000 {
+    32
+  } else {
+    64
+  };
+
+  factor * 128
+}
+
+impl Default for CavaBuilder {
+  fn default() -> Self {
+    Self {
+      bars_per_channel: 32,
+      sample_rate: 44_100,
+      audio_channels: Channels::Stereo,
+      enable_autosens: true,
+      noise_reduction: DEFAULT_NOISE_REDUCTION,
+      freq_range: 50..10_000,
+      max_sens: f64::INFINITY,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::CavaBuilder;
+
+  #[test]
+  fn sample_rate() {
+    assert!(CavaBuilder::default()
+      .sample_rate(0)
+      .sanity_check()
+      .is_err());
+    assert!(CavaBuilder::default()
+      .sample_rate(384_001)
+      .sanity_check()
+      .is_err());
+  }
+
+  #[test]
+  fn treble_buffer_size() {
+    let mut builder = CavaBuilder::default();
+    builder = builder.sample_rate(8_125);
+
+    assert_eq!(128, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(16_250);
+    assert_eq!(128 * 2, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(32_500);
+    assert_eq!(128 * 4, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(75_000);
+    assert_eq!(128 * 8, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(150_000);
+    assert_eq!(128 * 16, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(300_000);
+    assert_eq!(128 * 32, builder.compute_treble_buffer_size());
+
+    builder = builder.sample_rate(300_001);
+    assert_eq!(128 * 64, builder.compute_treble_buffer_size());
+  }
+}

--- a/src/infra/audio/cavacore/builder.rs
+++ b/src/infra/audio/cavacore/builder.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_NOISE_REDUCTION: f64 = 0.77;
 
 /// The sample rate cap upstream encoded in its `SampleRate` bounded type;
 /// enforced by `sanity_check` instead (see the module-level divergence notes).
-const MAX_SAMPLE_RATE: u32 = 384_000;
+pub const MAX_SAMPLE_RATE: u32 = 384_000;
 
 #[derive(Debug, Clone)]
 pub struct CavaBuilder {
@@ -83,11 +83,12 @@ impl CavaBuilder {
       errors.push(Error::ZeroFreqStart);
     }
 
-    if self.bars_per_channel > treble_buffer_size / 2 + 1 {
+    let max_amount_bars = max_bars_from_treble_buffer(treble_buffer_size);
+    if self.bars_per_channel > max_amount_bars {
       errors.push(Error::TooHighAmountBars {
         amount_bars: self.bars_per_channel,
         sample_rate: self.sample_rate,
-        max_amount_bars: treble_buffer_size / 2 + 1,
+        max_amount_bars,
       });
     }
 
@@ -137,6 +138,17 @@ pub fn treble_buffer_size(sample_rate: u32) -> usize {
   };
 
   factor * 128
+}
+
+/// The most bars per channel the treble window can resolve at `sample_rate`.
+/// `sanity_check` rejects anything above this, so callers that must not see a
+/// build error clamp to it first.
+pub fn max_bars_per_channel(sample_rate: u32) -> usize {
+  max_bars_from_treble_buffer(treble_buffer_size(sample_rate))
+}
+
+fn max_bars_from_treble_buffer(treble_buffer_size: usize) -> usize {
+  treble_buffer_size / 2 + 1
 }
 
 impl Default for CavaBuilder {

--- a/src/infra/audio/cavacore/error.rs
+++ b/src/infra/audio/cavacore/error.rs
@@ -1,0 +1,65 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub enum Error {
+  TooHighAmountBars {
+    amount_bars: usize,
+    sample_rate: u32,
+    max_amount_bars: usize,
+  },
+
+  InvalidNoiseReduction(f64),
+
+  EmptyFreqRange {
+    start: u32,
+    end: u32,
+  },
+
+  NyquistIssue {
+    freq: u32,
+    max_freq: u32,
+  },
+
+  // The three variants below replace upstream's bounded/non-zero parameter
+  // types (see the module-level divergence notes).
+  InvalidSampleRate(u32),
+
+  ZeroBars,
+
+  ZeroFreqStart,
+}
+
+impl fmt::Display for Error {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Error::TooHighAmountBars {
+        amount_bars,
+        sample_rate,
+        max_amount_bars,
+      } => write!(
+        f,
+        "{amount_bars} bars for a sample rate of {sample_rate} can't be more than {max_amount_bars} bars"
+      ),
+      Error::InvalidNoiseReduction(value) => write!(
+        f,
+        "Noise reduction has to be within the range [0..1]. Your value: {value}."
+      ),
+      Error::EmptyFreqRange { start, end } => write!(
+        f,
+        "Frequency start and end frequency musn't be equal but given frequency range: {start}..{end} (Hz)"
+      ),
+      Error::NyquistIssue { freq, max_freq } => write!(
+        f,
+        "Due to the Nyquist sampling theorem the highesest frequency cutoff does not exceed 'sample rate' / 2 (= {max_freq}) but you set it to {freq}"
+      ),
+      Error::InvalidSampleRate(rate) => write!(
+        f,
+        "Sample rate has to be within the range 1..=384000. Your value: {rate}."
+      ),
+      Error::ZeroBars => write!(f, "The amount of bars per channel mustn't be zero"),
+      Error::ZeroFreqStart => write!(f, "The frequency range mustn't start at 0 Hz"),
+    }
+  }
+}
+
+impl std::error::Error for Error {}

--- a/src/infra/audio/cavacore/mod.rs
+++ b/src/infra/audio/cavacore/mod.rs
@@ -18,8 +18,10 @@
 //! - Dropped the `bounded-integer` and `thiserror` deps: `SampleRate` /
 //!   `NonZero*` parameter types became plain integers validated in
 //!   `sanity_check`, and `Error` implements `Display` by hand.
-//! - `treble_buffer_size(rate)` is exposed standalone so the analyzer can cap
-//!   its sample backlog to cavacore's sliding input window.
+//! - Engine bounds the integration must respect are exposed rather than
+//!   restated app-side: `MAX_SAMPLE_RATE` and `max_bars_per_channel(rate)` are
+//!   the values `sanity_check` enforces, and `Cava::input_len()` is the
+//!   sliding input window a caller caps its sample backlog to.
 //! - EXTENSION (not in C cava): `CavaBuilder::max_sens` caps the autosens gain
 //!   so near-silent input cannot be normalized up to full-scale bars; the
 //!   default (infinity) preserves upstream behavior.
@@ -56,7 +58,7 @@ use realfft::{num_complex::Complex, FftNum, RealFftPlanner, RealToComplex};
 mod builder;
 mod error;
 
-pub use builder::{treble_buffer_size, CavaBuilder, DEFAULT_NOISE_REDUCTION};
+pub use builder::{max_bars_per_channel, CavaBuilder, DEFAULT_NOISE_REDUCTION, MAX_SAMPLE_RATE};
 pub use error::Error;
 
 #[repr(u8)]
@@ -99,6 +101,13 @@ pub struct Cava {
 }
 
 impl Cava {
+  /// Length of the sliding input window one `execute` can consume, in
+  /// interleaved samples. Callers that buffer between calls cap their backlog
+  /// here instead of re-deriving it from the sample rate and channel count.
+  pub fn input_len(&self) -> usize {
+    self.input_buffer.len()
+  }
+
   pub fn make_output(&self) -> Box<[f64]> {
     let amount_channels = if self.right.is_some() { 2 } else { 1 };
     let total_amount_bars = self.bars_per_channel * amount_channels;

--- a/src/infra/audio/cavacore/mod.rs
+++ b/src/infra/audio/cavacore/mod.rs
@@ -1,0 +1,717 @@
+//! Vendored from the `cavacore` crate v2.0.2 — a Rust port of cava's core
+//! processing engine (<https://github.com/karlstav/cava/blob/master/CAVACORE.md>).
+//! Upstream: <https://github.com/TornaxO7/cavacore-rs> (archived).
+//!
+//! Vendored instead of depended on because upstream is archived and ships
+//! correctness bugs we need fixed. Local changes, kept minimal on purpose
+//! (each patch site is marked `PATCH(spotatui)`):
+//! - Autosens fix: upstream only *raised* `sens` during digital silence; the C
+//!   original raises it while signal is present (`if (!silence)`). Without the
+//!   fix, opening the visualizer mid-song leaves bars at ~2% height forever.
+//! - Cutoff fix: upstream cast the fractional `relative_cut_off` to u32 before
+//!   multiplying by the FFT size at all five cutoff sites, truncating every
+//!   cutoff to 0 and collapsing the log-spaced bar mapping into consecutive
+//!   near-DC bins. C multiplies in float first.
+//! - Input-order fix: upstream copied each new chunk into the sliding buffer
+//!   in forward order; C writes it time-reversed (newest sample at index 0),
+//!   which keeps the buffer free of chunk-boundary discontinuities.
+//! - Dropped the `bounded-integer` and `thiserror` deps: `SampleRate` /
+//!   `NonZero*` parameter types became plain integers validated in
+//!   `sanity_check`, and `Error` implements `Display` by hand.
+//! - `treble_buffer_size(rate)` is exposed standalone so the analyzer can cap
+//!   its sample backlog to cavacore's sliding input window.
+//! - EXTENSION (not in C cava): `CavaBuilder::max_sens` caps the autosens gain
+//!   so near-silent input cannot be normalized up to full-scale bars; the
+//!   default (infinity) preserves upstream behavior.
+//!
+//! Upstream license (MIT):
+//!
+//! ```text
+//! MIT License
+//!
+//! Copyright (c) 2025 TornaxO7
+//!
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//!
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//!
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+//! ```
+use std::sync::Arc;
+
+use realfft::{num_complex::Complex, FftNum, RealFftPlanner, RealToComplex};
+
+mod builder;
+mod error;
+
+pub use builder::{treble_buffer_size, CavaBuilder, DEFAULT_NOISE_REDUCTION};
+pub use error::Error;
+
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Channels {
+  Mono = 1,
+  Stereo,
+}
+
+pub struct Cava {
+  bars_per_channel: usize,
+  sample_rate: u32,
+  enable_autosens: bool,
+  init_sens: bool,
+  sens: f64,
+  max_sens: f64,
+  framerate: f64,
+  frame_skip: f64,
+  noise_reduction: f64,
+
+  left: AudioData<f64>,
+  right: Option<AudioData<f64>>,
+
+  bass_hann_window: Box<[f64]>,
+  mid_hann_window: Box<[f64]>,
+  treble_hann_window: Box<[f64]>,
+
+  input_buffer: Box<[f64]>,
+  buffer_lower_cut_off: Box<[u32]>,
+  buffer_upper_cut_off: Box<[u32]>,
+  eq: Box<[f64]>,
+
+  bass_cut_off_bar: i32,
+  treble_cut_off_bar: i32,
+
+  cava_fall: Box<[f64]>,
+  cava_mem: Box<[f64]>,
+  cava_peak: Box<[f64]>,
+  prev_cava_out: Box<[f64]>,
+}
+
+impl Cava {
+  pub fn make_output(&self) -> Box<[f64]> {
+    let amount_channels = if self.right.is_some() { 2 } else { 1 };
+    let total_amount_bars = self.bars_per_channel * amount_channels;
+
+    vec![0.; total_amount_bars].into_boxed_slice()
+  }
+
+  pub fn execute(&mut self, input: &[f64], output: &mut [f64]) {
+    if input.is_empty() {
+      self.frame_skip += 1.;
+    } else {
+      self.framerate -= self.framerate / 64.;
+
+      let amount_audio_channels = if self.right.is_some() { 2. } else { 1. };
+
+      self.framerate += (self.sample_rate as f64 * amount_audio_channels * self.frame_skip)
+        / input.len() as f64
+        / 64.;
+
+      self.frame_skip = 1.;
+
+      let input_buffer_len = self.input_buffer.len();
+      self
+        .input_buffer
+        .copy_within(..input_buffer_len - input.len(), input.len());
+      // PATCH(spotatui): C writes the new chunk time-reversed (newest sample
+      // at index 0), keeping the whole buffer one continuous time-reversed
+      // stream; upstream copied it forward, splicing a discontinuity into the
+      // FFT windows at every chunk boundary.
+      for (n, &sample) in input.iter().enumerate() {
+        self.input_buffer[input.len() - n - 1] = sample;
+      }
+    }
+
+    // fill the bass, mid and treble buffers
+    if let Some(right) = self.right.as_mut() {
+      // bass
+      for i in 0..self.left.in_bass.len() {
+        right.in_bass[i] = self.input_buffer[i * 2] * self.bass_hann_window[i];
+        self.left.in_bass[i] = self.input_buffer[i * 2 + 1] * self.bass_hann_window[i];
+      }
+
+      // mid
+      for i in 0..self.left.in_mid.len() {
+        right.in_mid[i] = self.input_buffer[i * 2] * self.mid_hann_window[i];
+        self.left.in_mid[i] = self.input_buffer[i * 2 + 1] * self.mid_hann_window[i];
+      }
+
+      // treble
+      for i in 0..self.left.in_treble.len() {
+        right.in_treble[i] = self.input_buffer[i * 2] * self.treble_hann_window[i];
+        self.left.in_treble[i] = self.input_buffer[i * 2 + 1] * self.treble_hann_window[i];
+      }
+
+      right
+        .p_bass
+        .process(&mut right.in_bass, &mut right.out_bass)
+        .unwrap();
+      right
+        .p_mid
+        .process(&mut right.in_mid, &mut right.out_mid)
+        .unwrap();
+      right
+        .p_treble
+        .process(&mut right.in_treble, &mut right.out_treble)
+        .unwrap();
+    } else {
+      // bass
+      for i in 0..self.left.in_bass.len() {
+        self.left.in_bass[i] = self.input_buffer[i] * self.bass_hann_window[i];
+      }
+
+      // mid
+      for i in 0..self.left.in_mid.len() {
+        self.left.in_mid[i] = self.input_buffer[i] * self.mid_hann_window[i];
+      }
+
+      // treble
+      for i in 0..self.left.in_treble.len() {
+        self.left.in_treble[i] = self.input_buffer[i] * self.treble_hann_window[i];
+      }
+    }
+
+    // fft goes brrrrrrr
+    self
+      .left
+      .p_bass
+      .process(&mut self.left.in_bass, &mut self.left.out_bass)
+      .unwrap();
+    self
+      .left
+      .p_mid
+      .process(&mut self.left.in_mid, &mut self.left.out_mid)
+      .unwrap();
+    self
+      .left
+      .p_treble
+      .process(&mut self.left.in_treble, &mut self.left.out_treble)
+      .unwrap();
+
+    // separate frequency bands
+    for n in 0..self.bars_per_channel {
+      let mut tmp_l = 0.;
+      let mut tmp_r = 0.;
+
+      // add upp FFT values within bands
+      for i in self.buffer_lower_cut_off[n] as usize..=self.buffer_upper_cut_off[n] as usize {
+        if n <= self.bass_cut_off_bar as usize {
+          tmp_l += self.left.out_bass[i].norm();
+          if let Some(right) = &self.right {
+            tmp_r += right.out_bass[i].norm();
+          }
+        } else if (self.bass_cut_off_bar as usize..=self.treble_cut_off_bar as usize).contains(&n) {
+          tmp_l += self.left.out_mid[i].norm();
+          if let Some(right) = &self.right {
+            tmp_r += right.out_mid[i].norm();
+          }
+        } else if (self.treble_cut_off_bar as usize) < n {
+          tmp_l += self.left.out_treble[i].norm();
+          if let Some(right) = &self.right {
+            tmp_r += right.out_treble[i].norm();
+          }
+        }
+      }
+
+      // getting average multiply with eq
+      tmp_l /= self.buffer_upper_cut_off[n] as f64 - self.buffer_lower_cut_off[n] as f64 + 1.;
+      tmp_l *= self.eq[n];
+      output[n] = tmp_l;
+
+      if self.right.is_some() {
+        tmp_r /= self.buffer_upper_cut_off[n] as f64 - self.buffer_lower_cut_off[n] as f64 + 1.;
+        tmp_r *= self.eq[n];
+        output[n + self.bars_per_channel] = tmp_r;
+      }
+    }
+
+    // applying sens or getting max value
+    if self.enable_autosens {
+      for val in output.iter_mut() {
+        *val *= self.sens;
+      }
+    }
+
+    // process [smoothing]
+    let mut is_overshooting = false;
+    let gravity_mod = {
+      let gravity_mod = (60. / self.framerate).powf(2.5) * 1.54 / self.noise_reduction;
+
+      gravity_mod.max(1.)
+    };
+
+    let amount_channels = if self.right.is_some() { 2 } else { 1 };
+    for (n, out) in output
+      .iter_mut()
+      .enumerate()
+      .take(self.bars_per_channel * amount_channels)
+    {
+      // [smoothing]: falloff
+      if *out < self.prev_cava_out[n] && self.noise_reduction > 0.1 {
+        *out = self.cava_peak[n] * (1. - (self.cava_fall[n].powf(2.) * gravity_mod));
+
+        if *out < 0.0 {
+          *out = 0.0;
+        }
+        self.cava_fall[n] += 0.028;
+      } else {
+        self.cava_peak[n] = *out;
+        self.cava_fall[n] = 0.;
+      }
+      self.prev_cava_out[n] = *out;
+
+      // [smoothing]: integral
+      *out += self.cava_mem[n] * self.noise_reduction;
+      self.cava_mem[n] = *out;
+      if self.enable_autosens {
+        // check if we overshoot target height
+        if *out > 1. {
+          is_overshooting = true;
+        }
+      }
+    }
+
+    // calculating automatic sense adjustment
+    if self.enable_autosens {
+      if is_overshooting {
+        self.sens *= 0.98;
+        self.init_sens = false;
+      } else {
+        // PATCH(spotatui): upstream had `if is_silent`, inverted against the C
+        // original's `if (!silence)` — sens must rise while signal plays (slow
+        // recovery) and duck on overshoot, not rise only during silence.
+        let is_silent = input.iter().all(|&v| v == 0.);
+        if !is_silent {
+          self.sens *= 1.002;
+          if self.init_sens {
+            self.sens *= 1.1;
+          }
+        }
+      }
+
+      // EXTENSION(spotatui): optional autosens gain cap (upstream has none) so
+      // near-silent input stops short of full-scale bars.
+      if self.sens > self.max_sens {
+        self.sens = self.max_sens;
+      }
+    }
+  }
+}
+
+impl CavaBuilder {
+  pub fn build(&self) -> Result<Cava, Vec<Error>> {
+    self.sanity_check()?;
+
+    let bars_per_channel = self.bars_per_channel;
+    let sample_rate = self.sample_rate;
+    let enable_autosens = self.enable_autosens;
+    let init_sens = true;
+    let sens = 1.;
+    let max_sens = self.max_sens;
+    let framerate = 75.;
+    let frame_skip = 1.;
+    let noise_reduction = self.noise_reduction;
+
+    let treble_buffer_size = self.compute_treble_buffer_size();
+    let (left, right): (AudioData<f64>, Option<AudioData<f64>>) = {
+      let left = AudioData::new(treble_buffer_size);
+      let right = match self.audio_channels {
+        Channels::Mono => None,
+        Channels::Stereo => Some(AudioData::new(treble_buffer_size)),
+      };
+      (left, right)
+    };
+
+    let bass_hann_window = compute_hann_window(left.in_bass.len());
+    let mid_hann_window = compute_hann_window(left.in_mid.len());
+    let treble_hann_window = compute_hann_window(left.in_treble.len());
+
+    let input_buffer =
+      vec![0.0; left.in_bass.len() * self.audio_channels as usize].into_boxed_slice();
+
+    let mut buffer_lower_cut_off = vec![0; bars_per_channel + 1].into_boxed_slice();
+    let mut buffer_upper_cut_off = vec![0; bars_per_channel + 1].into_boxed_slice();
+    let mut eq = vec![0.; bars_per_channel + 1].into_boxed_slice();
+    let mut cut_off_frequency = vec![0f64; bars_per_channel + 1].into_boxed_slice();
+
+    let total_amount_bars = bars_per_channel * self.audio_channels as usize;
+    let cava_fall = vec![0.0; total_amount_bars].into_boxed_slice();
+    let cava_mem = vec![0.0; total_amount_bars].into_boxed_slice();
+    let cava_peak = vec![0.0; total_amount_bars].into_boxed_slice();
+    let prev_cava_out = vec![0.0; total_amount_bars].into_boxed_slice();
+
+    // process: calculate cutoff frequencies and eq
+    let bass_cut_off = 100.;
+    let treble_cut_off = 500.;
+
+    // calculate frequency constant (used to distribute bars across the frequency band)
+    let frequency_constant = (self.freq_range.start as f64 / self.freq_range.end as f64).log10()
+      / (1. / (self.bars_per_channel as f64 + 1.) - 1.);
+
+    let mut relative_cut_off = vec![0.; self.bars_per_channel + 1].into_boxed_slice();
+    let mut bass_cut_off_bar = -1;
+    let mut treble_cut_off_bar = -1;
+    let mut first_bar = true;
+    let mut first_treble_bar = 0;
+    let mut bar_buffer = vec![0; self.bars_per_channel + 1];
+
+    for n in 0..bars_per_channel + 1 {
+      let mut bar_distribution_coefficient = -frequency_constant;
+      bar_distribution_coefficient +=
+        (n as f64 + 1.) / (bars_per_channel as f64 + 1.) * frequency_constant;
+
+      cut_off_frequency[n] = self.freq_range.end as f64 * 10f64.powf(bar_distribution_coefficient);
+
+      if n > 0 {
+        // what?
+        let condition = cut_off_frequency[n - 1] >= cut_off_frequency[n]
+          && cut_off_frequency[n - 1] > bass_cut_off;
+
+        if condition {
+          cut_off_frequency[n] =
+            cut_off_frequency[n - 1] + (cut_off_frequency[n - 1] - cut_off_frequency[n - 2]);
+        }
+      }
+
+      relative_cut_off[n] = cut_off_frequency[n] / (self.sample_rate as f64 / 2.);
+
+      // some random magic?
+      eq[n] = cut_off_frequency[n].powf(1.);
+      eq[n] /= 2f64.powf(29.);
+      eq[n] /= (left.in_bass.len() as f64).log2();
+
+      // PATCH(spotatui): upstream cast relative_cut_off (a 0..1 fraction) to
+      // u32 BEFORE the multiply at all five cutoff sites below, truncating
+      // every cutoff to bin 0 and collapsing cava's log-spaced bar mapping
+      // into consecutive near-DC bins. C multiplies in float and truncates on
+      // the int assignment: `relative_cut_off[n] * (bufferSize / 2)`.
+      if cut_off_frequency[n] < bass_cut_off {
+        // BASS
+        bar_buffer[n] = 1;
+        buffer_lower_cut_off[n] = (relative_cut_off[n] * (left.in_bass.len() as f64 / 2.)) as u32;
+        bass_cut_off_bar += 1;
+        treble_cut_off_bar += 1;
+        if bass_cut_off_bar > 0 {
+          first_bar = false;
+        }
+
+        if buffer_lower_cut_off[n] > left.in_bass.len() as u32 / 2 {
+          buffer_lower_cut_off[n] = left.in_bass.len() as u32 / 2;
+        }
+      } else if cut_off_frequency[n] > bass_cut_off && cut_off_frequency[n] < treble_cut_off {
+        // MID
+        bar_buffer[n] = 2;
+        buffer_lower_cut_off[n] = (relative_cut_off[n] * (left.in_mid.len() as f64 / 2.)) as u32;
+        treble_cut_off_bar += 1;
+
+        if (treble_cut_off_bar - bass_cut_off_bar) == 1 {
+          first_bar = true;
+          if n > 0 {
+            buffer_upper_cut_off[n - 1] =
+              (relative_cut_off[n] * (left.in_bass.len() as f64 / 2.)) as u32;
+          }
+        } else {
+          first_bar = false;
+        }
+
+        if buffer_lower_cut_off[n] > left.in_mid.len() as u32 / 2 {
+          buffer_lower_cut_off[n] = left.in_mid.len() as u32 / 2;
+        }
+      } else {
+        // TREBLE
+        bar_buffer[n] = 3;
+        buffer_lower_cut_off[n] = (relative_cut_off[n] * (left.in_treble.len() as f64 / 2.)) as u32;
+        first_treble_bar += 1;
+        if first_treble_bar == 1 {
+          first_bar = true;
+          if n > 0 {
+            buffer_upper_cut_off[n - 1] =
+              (relative_cut_off[n] * (left.in_mid.len() as f64 / 2.)) as u32;
+          }
+        } else {
+          first_bar = false;
+        }
+
+        if buffer_lower_cut_off[n] > left.in_treble.len() as u32 / 2 {
+          buffer_lower_cut_off[n] = left.in_treble.len() as u32 / 2;
+        }
+      }
+
+      if n > 0 {
+        if !first_bar {
+          buffer_upper_cut_off[n - 1] = buffer_lower_cut_off[n].saturating_sub(1);
+
+          if buffer_lower_cut_off[n] <= buffer_lower_cut_off[n - 1] {
+            let mut room_for_more = false;
+
+            if bar_buffer[n] == 1 {
+              if buffer_lower_cut_off[n - 1] + 1 < left.in_bass.len() as u32 / 2 + 1 {
+                room_for_more = true;
+              }
+            } else if bar_buffer[n] == 2 {
+              if buffer_lower_cut_off[n - 1] + 1 < left.in_mid.len() as u32 / 2 + 1 {
+                room_for_more = true;
+              }
+            } else if bar_buffer[n] == 3
+              && buffer_lower_cut_off[n - 1] + 1 < left.in_treble.len() as u32 / 2 + 1
+            {
+              room_for_more = true;
+            }
+
+            if room_for_more {
+              // push the spectrum up
+              buffer_lower_cut_off[n] = buffer_lower_cut_off[n - 1] + 1;
+              buffer_upper_cut_off[n - 1] = buffer_lower_cut_off[n] - 1;
+
+              // calculate new cut off frequency
+              if bar_buffer[n] == 1 {
+                relative_cut_off[n] =
+                  buffer_lower_cut_off[n] as f64 / (left.in_bass.len() as f64 / 2.);
+              } else if bar_buffer[n] == 2 {
+                relative_cut_off[n] =
+                  buffer_lower_cut_off[n] as f64 / (left.in_mid.len() as f64 / 2.);
+              } else if bar_buffer[n] == 3 {
+                relative_cut_off[n] =
+                  buffer_lower_cut_off[n] as f64 / (left.in_treble.len() as f64 / 2.);
+              }
+
+              cut_off_frequency[n] = relative_cut_off[n] * (self.sample_rate as f64 / 2.);
+            }
+          }
+        } else if buffer_upper_cut_off[n - 1] <= buffer_lower_cut_off[n - 1] {
+          buffer_upper_cut_off[n - 1] = buffer_lower_cut_off[n - 1] + 1;
+        }
+      }
+    }
+
+    Ok(Cava {
+      bars_per_channel,
+      sample_rate,
+      enable_autosens,
+      init_sens,
+      sens,
+      max_sens,
+      framerate,
+      frame_skip,
+      noise_reduction,
+      left,
+      right,
+      bass_hann_window,
+      mid_hann_window,
+      treble_hann_window,
+      input_buffer,
+      buffer_lower_cut_off,
+      buffer_upper_cut_off,
+      eq,
+      bass_cut_off_bar,
+      treble_cut_off_bar,
+      cava_fall,
+      cava_mem,
+      cava_peak,
+      prev_cava_out,
+    })
+  }
+}
+
+struct AudioData<F: FftNum> {
+  p_bass: Arc<dyn RealToComplex<F>>,
+  p_mid: Arc<dyn RealToComplex<F>>,
+  p_treble: Arc<dyn RealToComplex<F>>,
+
+  out_bass: Vec<Complex<F>>,
+  out_mid: Vec<Complex<F>>,
+  out_treble: Vec<Complex<F>>,
+
+  in_bass: Vec<F>,
+  in_mid: Vec<F>,
+  in_treble: Vec<F>,
+}
+
+impl<F: FftNum> AudioData<F> {
+  pub fn new(treble_buffer_size: usize) -> Self {
+    let mut planner = RealFftPlanner::new();
+
+    let bass = planner.plan_fft_forward(treble_buffer_size * 8);
+    let mid = planner.plan_fft_forward(treble_buffer_size * 4);
+    let treble = planner.plan_fft_forward(treble_buffer_size);
+
+    let out_bass = bass.make_output_vec();
+    let out_mid = mid.make_output_vec();
+    let out_treble = treble.make_output_vec();
+
+    let in_bass = bass.make_input_vec();
+    let in_mid = mid.make_input_vec();
+    let in_treble = treble.make_input_vec();
+
+    Self {
+      p_bass: bass,
+      p_mid: mid,
+      p_treble: treble,
+
+      out_bass,
+      out_mid,
+      out_treble,
+
+      in_bass,
+      in_mid,
+      in_treble,
+    }
+  }
+}
+
+fn compute_hann_window(buffer_size: usize) -> Box<[f64]> {
+  let mut hann_window = Vec::with_capacity(buffer_size);
+
+  for i in 0..buffer_size {
+    let multiplier =
+      0.5 * (1. - (2. * std::f64::consts::PI * i as f64 / (buffer_size as f64 - 1.)).cos());
+    hann_window.push(multiplier);
+  }
+
+  hann_window.into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+  mod audio_data {
+    use crate::infra::audio::cavacore::AudioData;
+
+    #[test]
+    fn buffer_size() {
+      let treble_buffer_size = 128 * 4;
+
+      let audio_data: AudioData<f32> = AudioData::new(treble_buffer_size);
+
+      assert_eq!(audio_data.in_bass.len(), treble_buffer_size * 8);
+      assert_eq!(audio_data.in_mid.len(), treble_buffer_size * 4);
+      assert_eq!(audio_data.in_treble.len(), treble_buffer_size);
+    }
+  }
+
+  // Pins the vendored autosens patch: sens must ramp while signal is present
+  // and hold during digital silence, matching the C original. Upstream 2.0.2
+  // had the condition inverted, which left bars near zero when the visualizer
+  // opened mid-song (ducking-only sens can never recover from a loud passage).
+  mod autosens_patch {
+    use crate::infra::audio::cavacore::{Cava, CavaBuilder, Channels};
+
+    fn cava() -> Cava {
+      CavaBuilder::default()
+        .bars_per_channel(10)
+        .sample_rate(44_100)
+        .audio_channels(Channels::Mono)
+        .build()
+        .unwrap()
+    }
+
+    #[test]
+    fn sens_ramps_while_signal_is_present() {
+      let mut cava = cava();
+      let mut output = cava.make_output();
+      // Non-zero but far too quiet to overshoot: the ramp branch must run.
+      let quiet_signal = vec![1.0; 512];
+
+      let before = cava.sens;
+      for _ in 0..10 {
+        cava.execute(&quiet_signal, &mut output);
+      }
+
+      assert!(
+        cava.sens > before,
+        "sens must rise while signal plays: {} -> {}",
+        before,
+        cava.sens
+      );
+    }
+
+    #[test]
+    fn sens_stops_ramping_at_the_max_sens_cap() {
+      let mut cava = CavaBuilder::default()
+        .bars_per_channel(10)
+        .sample_rate(44_100)
+        .audio_channels(Channels::Mono)
+        .max_sens(2.0)
+        .build()
+        .unwrap();
+      let mut output = cava.make_output();
+      // Non-zero but far too quiet to overshoot: uncapped, the init ramp
+      // (x1.1 per frame) would push sens far past 2.0 within 100 frames.
+      let quiet_signal = vec![1.0; 512];
+
+      for _ in 0..100 {
+        cava.execute(&quiet_signal, &mut output);
+      }
+
+      assert!(cava.sens <= 2.0, "sens exceeded the cap: {}", cava.sens);
+    }
+
+    #[test]
+    fn sens_holds_during_silence() {
+      let mut cava = cava();
+      let mut output = cava.make_output();
+      let silence = vec![0.0; 512];
+
+      let before = cava.sens;
+      for _ in 0..10 {
+        cava.execute(&silence, &mut output);
+      }
+
+      assert_eq!(
+        cava.sens, before,
+        "sens must not ramp during digital silence"
+      );
+    }
+  }
+
+  // Pins the other two vendored patches (cutoff truncation, input chunk order).
+  mod port_patches {
+    use crate::infra::audio::cavacore::{Cava, CavaBuilder, Channels};
+
+    fn cava() -> Cava {
+      CavaBuilder::default()
+        .bars_per_channel(10)
+        .sample_rate(44_100)
+        .audio_channels(Channels::Mono)
+        .build()
+        .unwrap()
+    }
+
+    // Upstream's cast-before-multiply truncated every cutoff to 0 and
+    // degenerated the mapping into consecutive bins 0,1,2,... With float math
+    // (matching C), the top bar of a 10-bar 44.1kHz plan reads treble bin
+    // ~136 (~5.9 kHz), nowhere near bin 9.
+    #[test]
+    fn cutoffs_are_log_spaced_not_consecutive() {
+      let cava = cava();
+      assert!(
+        cava.buffer_lower_cut_off[9] > 100,
+        "top bar reads bin {} - cutoffs degenerated to consecutive bins",
+        cava.buffer_lower_cut_off[9]
+      );
+      // Bar 0 starts at 50 Hz: 50/22050 * 4096 = bin 9 of the bass FFT.
+      assert_eq!(cava.buffer_lower_cut_off[0], 9);
+    }
+
+    // The sliding buffer must stay one continuous time-reversed stream
+    // (newest sample at index 0) across execute calls, as in C.
+    #[test]
+    fn input_buffer_is_a_continuous_time_reversed_stream() {
+      let mut cava = cava();
+      let mut output = cava.make_output();
+      cava.execute(&[1., 2., 3.], &mut output);
+      cava.execute(&[4., 5., 6.], &mut output);
+      assert_eq!(cava.input_buffer[..6], [6., 5., 4., 3., 2., 1.]);
+    }
+  }
+}

--- a/src/infra/audio/cavacore/mod.rs
+++ b/src/infra/audio/cavacore/mod.rs
@@ -15,6 +15,12 @@
 //! - Input-order fix: upstream copied each new chunk into the sliding buffer
 //!   in forward order; C writes it time-reversed (newest sample at index 0),
 //!   which keeps the buffer free of chunk-boundary discontinuities.
+//! - Signed-comparison fix: the band-selection loop compared bar indices
+//!   against the cutoff bars `as usize`; the cutoffs are -1 sentinels when a
+//!   range has no bar, wrapping to usize::MAX. C compares signed ints.
+//! - Cutoff-adjustment guard: the non-monotonic-cutoff fixup reads index
+//!   n - 2 under an `n > 0` guard; at n == 1 that is an out-of-bounds read in
+//!   C and a panic here, so the guard is `n > 1` (a deliberate divergence).
 //! - Dropped the `bounded-integer` and `thiserror` deps: `SampleRate` /
 //!   `NonZero*` parameter types became plain integers validated in
 //!   `sanity_check`, and `Error` implements `Display` by hand.
@@ -214,18 +220,23 @@ impl Cava {
       let mut tmp_r = 0.;
 
       // add upp FFT values within bands
+      // PATCH(spotatui): compare in signed space like C. The cutoff bars are
+      // -1 sentinels when a range has no bar; upstream compared `n` against
+      // them `as usize`, so -1 wrapped to usize::MAX and every bar summed the
+      // bass FFT whenever no bass bar existed.
+      let bar = n as i32;
       for i in self.buffer_lower_cut_off[n] as usize..=self.buffer_upper_cut_off[n] as usize {
-        if n <= self.bass_cut_off_bar as usize {
+        if bar <= self.bass_cut_off_bar {
           tmp_l += self.left.out_bass[i].norm();
           if let Some(right) = &self.right {
             tmp_r += right.out_bass[i].norm();
           }
-        } else if (self.bass_cut_off_bar as usize..=self.treble_cut_off_bar as usize).contains(&n) {
+        } else if bar <= self.treble_cut_off_bar {
           tmp_l += self.left.out_mid[i].norm();
           if let Some(right) = &self.right {
             tmp_r += right.out_mid[i].norm();
           }
-        } else if (self.treble_cut_off_bar as usize) < n {
+        } else {
           tmp_l += self.left.out_treble[i].norm();
           if let Some(right) = &self.right {
             tmp_r += right.out_treble[i].norm();
@@ -382,7 +393,11 @@ impl CavaBuilder {
 
       cut_off_frequency[n] = self.freq_range.end as f64 * 10f64.powf(bar_distribution_coefficient);
 
-      if n > 0 {
+      // PATCH(spotatui): n > 1, not n > 0. The adjustment reads index n - 2,
+      // which at n == 1 is an out-of-bounds read in C and a usize-underflow
+      // panic here. Only reachable when bar 0 lands above the 100 Hz bass
+      // cutoff, which needs a freq range starting higher than the analyzer's.
+      if n > 1 {
         // what?
         let condition = cut_off_frequency[n - 1] >= cut_off_frequency[n]
           && cut_off_frequency[n - 1] > bass_cut_off;

--- a/src/infra/audio/mod.rs
+++ b/src/infra/audio/mod.rs
@@ -16,6 +16,13 @@ pub use player::LocalPlayer;
 #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
 mod analyzer;
 
+// Vendored cava DSP engine (see cavacore/mod.rs for provenance and the local
+// patches). Lint allowances instead of cleanups keep it diffable against
+// upstream: it carries items our integration never constructs.
+#[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+#[allow(dead_code, clippy::all)]
+mod cavacore;
+
 // Platform-specific capture backends
 #[cfg(all(feature = "audio-viz", target_os = "linux"))]
 mod pipewire_capture;
@@ -49,7 +56,7 @@ pub use analyzer::SpectrumData;
 #[derive(Clone, Default)]
 #[allow(dead_code)]
 pub struct SpectrumData {
-  pub bands: [f32; 12],
+  pub bands: Vec<f32>,
   pub peak: f32,
 }
 
@@ -70,7 +77,7 @@ impl AudioCaptureManager {
     None
   }
 
-  pub fn get_spectrum(&self) -> Option<SpectrumData> {
+  pub fn get_spectrum(&self, _desired_bars: usize) -> Option<SpectrumData> {
     None
   }
 

--- a/src/infra/audio/mod.rs
+++ b/src/infra/audio/mod.rs
@@ -57,7 +57,6 @@ pub use analyzer::SpectrumData;
 #[allow(dead_code)]
 pub struct SpectrumData {
   pub bands: Vec<f32>,
-  pub peak: f32,
 }
 
 #[cfg(not(any(
@@ -73,7 +72,7 @@ pub struct AudioCaptureManager;
 )))]
 #[allow(dead_code)]
 impl AudioCaptureManager {
-  pub fn new() -> Option<Self> {
+  pub fn new(_display_bars: usize) -> Option<Self> {
     None
   }
 

--- a/src/infra/audio/pipewire_capture.rs
+++ b/src/infra/audio/pipewire_capture.rs
@@ -21,7 +21,9 @@ impl PipeWireCapture {
   /// Create a new PipeWire audio capture manager
   /// Returns None if PipeWire initialization fails
   pub fn new() -> Option<Self> {
-    let analyzer = create_shared_analyzer();
+    // Built at the rate we request below; the param_changed callback swaps in
+    // the rate PipeWire actually negotiates.
+    let analyzer = create_shared_analyzer(48000);
     let active = Arc::new(AtomicBool::new(true));
 
     let analyzer_clone = analyzer.clone();
@@ -48,13 +50,15 @@ impl PipeWireCapture {
     }
   }
 
-  /// Get the current spectrum data
-  pub fn get_spectrum(&self) -> Option<SpectrumData> {
+  /// Get the current spectrum data, sized to `desired_bars` (the analyzer
+  /// rebuilds its plan when the count changes, and clamps unsupportable counts)
+  pub fn get_spectrum(&self, desired_bars: usize) -> Option<SpectrumData> {
     if !self.active.load(Ordering::Relaxed) {
       return None;
     }
 
     if let Ok(mut analyzer) = self.analyzer.lock() {
+      analyzer.set_bars(desired_bars);
       Some(analyzer.process())
     } else {
       None
@@ -102,21 +106,29 @@ fn run_pipewire_capture(
 
   let active_clone = active.clone();
   let analyzer_clone = analyzer.clone();
+  let param_analyzer = analyzer.clone();
 
   // Set up stream listener
   let _listener = stream
     .add_local_listener_with_user_data(StreamData::default())
-    .param_changed(|_, user_data, id, param| {
+    .param_changed(move |_, user_data, id, param| {
       let Some(param) = param else { return };
       if id != pw::spa::param::ParamType::Format.as_raw() {
         return;
       }
 
-      // Parse the format to get channel count
+      // Parse the format to get channel count and negotiated sample rate
       if let Ok(mut format) = user_data.format.lock() {
         if format.parse(param).is_ok() {
           let channels = format.channels();
           user_data.channels.store(channels, Ordering::Relaxed);
+
+          let rate = format.rate();
+          if rate > 0 {
+            if let Ok(mut analyzer) = param_analyzer.lock() {
+              analyzer.set_sample_rate(rate);
+            }
+          }
         }
       }
     })
@@ -149,23 +161,29 @@ fn run_pipewire_capture(
         // Only process the valid portion of the buffer
         let valid_bytes = &samples_bytes[..n_bytes.min(samples_bytes.len())];
 
-        // Convert bytes to f32 samples and mix to mono
-        let mono_samples: Vec<f32> = valid_bytes
-          .chunks_exact(mem::size_of::<f32>())
-          .enumerate()
-          .filter_map(|(i, chunk)| {
-            // Simple mono mixdown - take one sample per frame
-            if i % n_channels == 0 {
-              Some(f32::from_le_bytes(chunk.try_into().unwrap_or([0; 4])))
-            } else {
-              None
-            }
+        // Interleaved stereo frames for the analyzer, matching cava's default
+        // stereo pipeline (and the cpal backend): channels 0/1 pass through,
+        // a mono stream duplicates.
+        let sample_size = mem::size_of::<f32>();
+        let stereo_samples: Vec<f32> = valid_bytes
+          .chunks_exact(sample_size * n_channels)
+          .flat_map(|frame| {
+            let sample = |channel: usize| {
+              frame
+                .get(channel * sample_size..(channel + 1) * sample_size)
+                .and_then(|bytes| bytes.try_into().ok())
+                .map(f32::from_le_bytes)
+                .unwrap_or(0.0)
+            };
+            let left = sample(0);
+            let right = if n_channels > 1 { sample(1) } else { left };
+            [left, right]
           })
           .collect();
 
-        if !mono_samples.is_empty() {
+        if !stereo_samples.is_empty() {
           if let Ok(mut analyzer) = analyzer_clone.lock() {
-            analyzer.push_samples(&mono_samples);
+            analyzer.push_samples(&stereo_samples);
           }
         }
       }

--- a/src/infra/audio/pipewire_capture.rs
+++ b/src/infra/audio/pipewire_capture.rs
@@ -1,7 +1,7 @@
 // PipeWire-native audio capture for Linux
 // This provides direct access to PipeWire's audio graph for monitor capture
 
-use super::analyzer::{create_shared_analyzer, SharedAnalyzer, SpectrumData};
+use super::analyzer::{create_shared_analyzer, spectrum_for, SharedAnalyzer, SpectrumData};
 use pipewire as pw;
 use pw::spa::param::audio::AudioInfoRaw;
 use pw::spa::pod::Pod;
@@ -18,12 +18,12 @@ pub struct PipeWireCapture {
 }
 
 impl PipeWireCapture {
-  /// Create a new PipeWire audio capture manager
+  /// Create a new PipeWire audio capture manager sized for `display_bars`
   /// Returns None if PipeWire initialization fails
-  pub fn new() -> Option<Self> {
+  pub fn new(display_bars: usize) -> Option<Self> {
     // Built at the rate we request below; the param_changed callback swaps in
     // the rate PipeWire actually negotiates.
-    let analyzer = create_shared_analyzer(48000);
+    let analyzer = create_shared_analyzer(48000, display_bars);
     let active = Arc::new(AtomicBool::new(true));
 
     let analyzer_clone = analyzer.clone();
@@ -57,12 +57,7 @@ impl PipeWireCapture {
       return None;
     }
 
-    if let Ok(mut analyzer) = self.analyzer.lock() {
-      analyzer.set_bars(desired_bars);
-      Some(analyzer.process())
-    } else {
-      None
-    }
+    spectrum_for(&self.analyzer, desired_bars)
   }
 
   /// Check if audio capture is currently active
@@ -161,29 +156,16 @@ fn run_pipewire_capture(
         // Only process the valid portion of the buffer
         let valid_bytes = &samples_bytes[..n_bytes.min(samples_bytes.len())];
 
-        // Interleaved stereo frames for the analyzer, matching cava's default
-        // stereo pipeline (and the cpal backend): channels 0/1 pass through,
-        // a mono stream duplicates.
-        let sample_size = mem::size_of::<f32>();
-        let stereo_samples: Vec<f32> = valid_bytes
-          .chunks_exact(sample_size * n_channels)
-          .flat_map(|frame| {
-            let sample = |channel: usize| {
-              frame
-                .get(channel * sample_size..(channel + 1) * sample_size)
-                .and_then(|bytes| bytes.try_into().ok())
-                .map(f32::from_le_bytes)
-                .unwrap_or(0.0)
-            };
-            let left = sample(0);
-            let right = if n_channels > 1 { sample(1) } else { left };
-            [left, right]
-          })
+        // Decode the interleaved f32 stream; the analyzer owns the channel
+        // rule (0/1 through, mono duplicated) so it is stated in one place.
+        let samples: Vec<f32> = valid_bytes
+          .chunks_exact(mem::size_of::<f32>())
+          .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap_or([0; 4])))
           .collect();
 
-        if !stereo_samples.is_empty() {
+        if !samples.is_empty() {
           if let Ok(mut analyzer) = analyzer_clone.lock() {
-            analyzer.push_samples(&stereo_samples);
+            analyzer.push_frames(&samples, n_channels);
           }
         }
       }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -382,6 +382,29 @@ fn dispatch_key(key: Key, app: &mut App) -> bool {
   false
 }
 
+/// Bars the analyzer should produce for the visualizer block's inner width.
+/// Each style has its own geometry; the analyzer clamps counts its sample rate
+/// cannot support, and renderers draw from `bands.len()`, so a stale count
+/// during a resize race only mis-sizes one frame.
+/// The only production caller is behind the audio-viz feature gates; slim
+/// builds still compile (and test) the function itself.
+#[allow(dead_code)]
+fn visualizer_bar_count(
+  style: crate::core::user_config::VisualizerStyle,
+  inner_width: u16,
+) -> usize {
+  use crate::core::user_config::VisualizerStyle;
+  match style {
+    // Braille has 2x horizontal resolution: one real bar per half-cell.
+    VisualizerStyle::BarGraph => (inner_width as usize * 2).max(2),
+    // Capped at ~40 bars (the classic cava look at a normal font); the
+    // renderer widens bars to fill the terminal, so dense fonts get chunky
+    // columns instead of one pencil bar per 3 columns. Below ~120 columns
+    // this degrades to exactly cava's auto rule (bar width 2, spacing 1).
+    VisualizerStyle::Cava => ((inner_width as usize + 1) / 3).clamp(2, 40),
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -396,6 +419,30 @@ mod tests {
       crate::core::user_config::UserConfig::new(),
       Some(SystemTime::now()),
     )
+  }
+
+  #[test]
+  fn visualizer_bar_count_follows_each_styles_geometry() {
+    use crate::core::user_config::VisualizerStyle;
+
+    // BarGraph gets two Braille bars per cell.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 100), 200);
+
+    // Cava: one bar per 3 columns (bar width 2 + spacing 1).
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 80), 27);
+  }
+
+  #[test]
+  fn visualizer_bar_count_clamps_degenerate_widths() {
+    use crate::core::user_config::VisualizerStyle;
+
+    // Zero-width terminals still request a drawable minimum.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 0), 2);
+    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 0), 2);
+
+    // The ~40-bar cap holds on wide terminals and dense fonts.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 4000), 40);
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 216), 40);
   }
 
   #[test]
@@ -1393,13 +1440,21 @@ pub async fn start_ui(
             }
 
             if let Some(ref capture) = audio_capture {
-              if let Some(spectrum) = capture.get_spectrum() {
+              // Visualizer block inner width: the frame minus the main layout
+              // margin on both sides and the block's two border columns.
+              let margin = crate::core::layout::main_layout_margin(&app);
+              let inner_width = app.size.width.saturating_sub(margin * 2 + 2);
+              let desired_bars =
+                visualizer_bar_count(app.user_config.behavior.visualizer_style, inner_width);
+              if let Some(spectrum) = capture.get_spectrum(desired_bars) {
                 app.spectrum_data = Some(app::SpectrumData {
                   bands: spectrum.bands,
                   peak: spectrum.peak,
                 });
-                app.audio_capture_active = capture.is_active();
               }
+              // Kept outside the spectrum arm: a dead stream must drop the
+              // "Capturing audio" status instead of freezing it on.
+              app.audio_capture_active = capture.is_active();
             }
           } else if audio_capture.is_some() {
             audio_capture = None;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -382,29 +382,6 @@ fn dispatch_key(key: Key, app: &mut App) -> bool {
   false
 }
 
-/// Bars the analyzer should produce for the visualizer block's inner width.
-/// Each style has its own geometry; the analyzer clamps counts its sample rate
-/// cannot support, and renderers draw from `bands.len()`, so a stale count
-/// during a resize race only mis-sizes one frame.
-/// The only production caller is behind the audio-viz feature gates; slim
-/// builds still compile (and test) the function itself.
-#[allow(dead_code)]
-fn visualizer_bar_count(
-  style: crate::core::user_config::VisualizerStyle,
-  inner_width: u16,
-) -> usize {
-  use crate::core::user_config::VisualizerStyle;
-  match style {
-    // Braille has 2x horizontal resolution: one real bar per half-cell.
-    VisualizerStyle::BarGraph => (inner_width as usize * 2).max(2),
-    // Capped at ~40 bars (the classic cava look at a normal font); the
-    // renderer widens bars to fill the terminal, so dense fonts get chunky
-    // columns instead of one pencil bar per 3 columns. Below ~120 columns
-    // this degrades to exactly cava's auto rule (bar width 2, spacing 1).
-    VisualizerStyle::Cava => ((inner_width as usize + 1) / 3).clamp(2, 40),
-  }
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -419,30 +396,6 @@ mod tests {
       crate::core::user_config::UserConfig::new(),
       Some(SystemTime::now()),
     )
-  }
-
-  #[test]
-  fn visualizer_bar_count_follows_each_styles_geometry() {
-    use crate::core::user_config::VisualizerStyle;
-
-    // BarGraph gets two Braille bars per cell.
-    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 100), 200);
-
-    // Cava: one bar per 3 columns (bar width 2 + spacing 1).
-    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 80), 27);
-  }
-
-  #[test]
-  fn visualizer_bar_count_clamps_degenerate_widths() {
-    use crate::core::user_config::VisualizerStyle;
-
-    // Zero-width terminals still request a drawable minimum.
-    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 0), 2);
-    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 0), 2);
-
-    // The ~40-bar cap holds on wide terminals and dense fonts.
-    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 4000), 40);
-    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 216), 40);
   }
 
   #[test]
@@ -1434,23 +1387,21 @@ pub async fn start_ui(
           let in_analysis_view = app.get_current_route().active_block == ActiveBlock::Analysis;
 
           if in_analysis_view {
+            let desired_bars = ui::audio_analysis::visualizer_bar_count(
+              app.user_config.behavior.visualizer_style,
+              ui::audio_analysis::visualizer_inner_width(&app),
+            );
+
             if audio_capture.is_none() {
-              audio_capture = audio::AudioCaptureManager::new();
+              // Built at the count we are about to ask for, so the first frame
+              // does not immediately throw the fresh cavacore plan away.
+              audio_capture = audio::AudioCaptureManager::new(desired_bars);
               app.audio_capture_active = audio_capture.is_some();
             }
 
             if let Some(ref capture) = audio_capture {
-              // Visualizer block inner width: the frame minus the main layout
-              // margin on both sides and the block's two border columns.
-              let margin = crate::core::layout::main_layout_margin(&app);
-              let inner_width = app.size.width.saturating_sub(margin * 2 + 2);
-              let desired_bars =
-                visualizer_bar_count(app.user_config.behavior.visualizer_style, inner_width);
               if let Some(spectrum) = capture.get_spectrum(desired_bars) {
-                app.spectrum_data = Some(app::SpectrumData {
-                  bands: spectrum.bands,
-                  peak: spectrum.peak,
-                });
+                app.spectrum_data = Some(spectrum);
               }
               // Kept outside the spectrum arm: a dead stream must drop the
               // "Capturing audio" status instead of freezing it on.

--- a/src/tui/ui/audio_analysis.rs
+++ b/src/tui/ui/audio_analysis.rs
@@ -4,6 +4,7 @@ use crate::core::user_config::{normalize_tick_rate_milliseconds, VisualizerStyle
 use ratatui::{
   layout::{Constraint, Layout, Rect},
   style::{Color, Style},
+  symbols::bar,
   text::{Line, Span},
   widgets::{Block, Borders, Paragraph},
   Frame,
@@ -11,12 +12,35 @@ use ratatui::{
 
 use tui_bar_graph::{BarGraph, BarStyle, ColorMode};
 
+/// The analysis screen's two rows: the info strip and the visualizer block.
+fn analysis_areas(root: Rect, margin: u16) -> [Rect; 2] {
+  root.layout(&Layout::vertical([Constraint::Length(3), Constraint::Min(10)]).margin(margin))
+}
+
+/// The visualizer's surrounding block, borders only. `draw` styles and titles
+/// it; `visualizer_inner_width` needs it only to measure the border inset.
+fn visualizer_block<'a>() -> Block<'a> {
+  Block::default().borders(Borders::ALL)
+}
+
+/// Inner width of the visualizer block at the current terminal size. The
+/// runner picks the analyzer's bar count before a frame exists, so it derives
+/// the rect from `app.size` through here rather than re-deriving the margin
+/// and border inset itself.
+///
+/// This and `visualizer_bar_count` are only called behind the audio-viz
+/// feature gates; slim builds still compile (and test) them.
+#[allow(dead_code)]
+pub fn visualizer_inner_width(app: &App) -> u16 {
+  let root = Rect::new(0, 0, app.size.width, app.size.height);
+  let [_, visualizer_area] = analysis_areas(root, main_layout_margin(app));
+  visualizer_block().inner(visualizer_area).width
+}
+
 pub fn draw(f: &mut Frame<'_>, app: &App) {
   let margin = main_layout_margin(app);
 
-  let [info_area, visualizer_area] = f
-    .area()
-    .layout(&Layout::vertical([Constraint::Length(3), Constraint::Min(10)]).margin(margin));
+  let [info_area, visualizer_area] = analysis_areas(f.area(), margin);
 
   let white = Style::default().fg(app.user_config.theme.text);
   let gray = Style::default().fg(app.user_config.theme.inactive);
@@ -34,8 +58,7 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
 
   let bar_chart_title = &format!("Spectrum | {} FPS | Press q to exit", 1000 / tick_rate);
 
-  let bar_chart_block = Block::default()
-    .borders(Borders::ALL)
+  let bar_chart_block = visualizer_block()
     .style(white)
     .title(Span::styled(bar_chart_title, gray))
     .border_style(gray);
@@ -50,7 +73,8 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
       "[||] Paused"
     };
 
-    let peak_text = format!("Peak: {:.0}%", spectrum.peak * 100.0);
+    let peak = spectrum.bands.iter().copied().fold(0.0f32, f32::max);
+    let peak_text = format!("Peak: {:.0}%", peak * 100.0);
     let style_hint = "Press 'V' to cycle visualizer style";
 
     let texts = vec![Line::from(vec![
@@ -71,22 +95,17 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
 
     // Calculate inner area for visualizer (within the block borders)
     let inner_area = bar_chart_block.inner(visualizer_area);
+    f.render_widget(bar_chart_block, visualizer_area);
 
     // Render the appropriate visualizer based on user setting
     match visualizer_style {
-      VisualizerStyle::BarGraph => {
-        f.render_widget(bar_chart_block, visualizer_area);
-        render_bar_graph(f, &spectrum.bands, inner_area);
-      }
-      VisualizerStyle::Cava => {
-        f.render_widget(bar_chart_block, visualizer_area);
-        render_cava(
-          f,
-          &spectrum.bands,
-          inner_area,
-          app.user_config.theme.analysis_bar,
-        );
-      }
+      VisualizerStyle::BarGraph => render_bar_graph(f, &spectrum.bands, inner_area),
+      VisualizerStyle::Cava => render_cava(
+        f,
+        &spectrum.bands,
+        inner_area,
+        app.user_config.theme.analysis_bar,
+      ),
     }
   } else {
     // No audio capture available
@@ -125,18 +144,8 @@ fn render_bar_graph(f: &mut Frame<'_>, bands: &[f32], area: Rect) {
     return;
   }
 
-  // Bands normally arrive sized for Braille resolution (2 per cell, computed
-  // by the runner), each a real analyzer bar. When they don't match - the
-  // analyzer caps bar counts at what the sample rate supports (513 at
-  // 44.1/48 kHz, i.e. terminals wider than ~257 columns), or a style switch /
-  // resize lags one frame - stretch them across the full width instead of
-  // leaving the right side blank (the widget draws left-aligned).
   let target_width = (area.width as usize) * 2;
-  let data: Vec<f64> = if bands.len() == target_width {
-    bands.iter().map(|&v| f64::from(v)).collect()
-  } else {
-    interpolate_bands(bands, target_width)
-  };
+  let data = interpolate_bands(bands, target_width);
 
   let bar_graph = BarGraph::new(data)
     .with_gradient(colorgrad::preset::turbo())
@@ -147,8 +156,13 @@ fn render_bar_graph(f: &mut Frame<'_>, bands: &[f32], area: Rect) {
   f.render_widget(bar_graph, area);
 }
 
-/// Linearly interpolate band values onto `target_width` points (only used when
-/// the analyzer could not supply one real bar per Braille half-column).
+/// Linearly interpolate band values onto `target_width` points. Bands normally
+/// already arrive at Braille resolution (2 per cell, requested by the runner),
+/// in which case this is an exact copy. They fall short when the analyzer caps
+/// the count at what the sample rate supports (513 at 44.1/48 kHz, i.e.
+/// terminals wider than ~257 columns) or when a style switch or resize lags a
+/// frame; stretching keeps the right side from going blank, since the widget
+/// draws left-aligned.
 fn interpolate_bands(bands: &[f32], target_width: usize) -> Vec<f64> {
   if bands.is_empty() {
     return vec![0.0; target_width];
@@ -177,8 +191,19 @@ fn interpolate_bands(bands: &[f32], target_width: usize) -> Vec<f64> {
   result
 }
 
-/// Bar glyphs from empty to full block, indexed by filled eighths (0-8).
-const EIGHTH_GLYPHS: [char; 9] = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+/// Bar glyphs from empty to full block, indexed by filled eighths (0-8):
+/// ratatui's own nine-level bar set, with a blank for the empty cell.
+const EIGHTH_GLYPHS: [&str; 9] = [
+  bar::NINE_LEVELS.empty,
+  bar::NINE_LEVELS.one_eighth,
+  bar::NINE_LEVELS.one_quarter,
+  bar::NINE_LEVELS.three_eighths,
+  bar::NINE_LEVELS.half,
+  bar::NINE_LEVELS.five_eighths,
+  bar::NINE_LEVELS.three_quarters,
+  bar::NINE_LEVELS.seven_eighths,
+  bar::NINE_LEVELS.full,
+];
 
 /// Total filled eighths for a bar value in a column `rows` cells tall, with
 /// cava's idle floor of one eighth (the signature resting line). u32 math:
@@ -194,20 +219,47 @@ fn cell_eighths(total_eighths: u32, row: u16) -> u32 {
   total_eighths.saturating_sub(u32::from(row) * 8).min(8)
 }
 
-/// Bar width and spacing for the cava style. The bar count is capped (~40),
-/// so bars widen with the terminal to fill the area at roughly cava's 2:1
-/// bar-to-gap ratio; cava's own 2-wide/1-gap geometry is the floor, keeping
-/// dense fonts on the classic chunky-column look instead of pencil bars.
+/// Cap on the cava style's bar count: the classic cava look at a normal font.
+/// Past this the renderer widens bars to fill the terminal, so dense fonts get
+/// chunky columns instead of one pencil bar per 3 columns.
+#[allow(dead_code)]
+const MAX_CAVA_BARS: usize = 40;
+
+/// cava's own bar geometry, 2 columns of bar plus a 1-column gap. It is the
+/// floor for `cava_bar_layout`, and the divisor `visualizer_bar_count` uses to
+/// pick a count that fits.
+const CAVA_BAR_FOOTPRINT: u16 = 3;
+
+/// Bars the analyzer should produce for the visualizer block's `inner_width`.
+/// Each style has its own geometry; the analyzer clamps counts its sample rate
+/// cannot support, and renderers draw from `bands.len()`, so a stale count
+/// during a resize race only mis-sizes one frame.
+#[allow(dead_code)]
+pub fn visualizer_bar_count(style: VisualizerStyle, inner_width: u16) -> usize {
+  let inner_width = usize::from(inner_width);
+  match style {
+    // Braille has 2x horizontal resolution: one real bar per half-cell.
+    VisualizerStyle::BarGraph => (inner_width * 2).max(2),
+    // Below ~120 columns this degrades to exactly cava's auto rule.
+    VisualizerStyle::Cava => {
+      ((inner_width + 1) / usize::from(CAVA_BAR_FOOTPRINT)).clamp(2, MAX_CAVA_BARS)
+    }
+  }
+}
+
+/// Bar width and spacing for the cava style. The bar count is capped at
+/// `MAX_CAVA_BARS`, so bars widen with the terminal to fill the area at
+/// roughly cava's 2:1 bar-to-gap ratio, with `CAVA_BAR_FOOTPRINT` as the floor.
 fn cava_bar_layout(inner_width: u16, bars: u16) -> (u16, u16) {
   if bars == 0 {
-    return (2, 1);
+    return (CAVA_BAR_FOOTPRINT - 1, 1);
   }
   // u32 internals, footprint capped at the width: keeps the math (and the
   // renderer's bar_width + spacing sums) off u16 overflow at any input.
+  let floor = u32::from(CAVA_BAR_FOOTPRINT);
   let footprint = ((u32::from(inner_width) + 1) / u32::from(bars))
-    .max(3)
-    .min(u32::from(inner_width).max(3));
-  let spacing = ((footprint + 1) / 3).max(1);
+    .clamp(floor, u32::from(inner_width).max(floor));
+  let spacing = ((footprint + 1) / floor).max(1);
   ((footprint - spacing) as u16, spacing as u16)
 }
 
@@ -241,7 +293,7 @@ fn render_cava(f: &mut Frame<'_>, bands: &[f32], area: Rect, color: Color) {
       let glyph = EIGHTH_GLYPHS[filled as usize];
       let y = area.y + area.height - 1 - row;
       for dx in 0..bar_width {
-        buf[(x0 + dx, y)].set_char(glyph).set_style(style);
+        buf[(x0 + dx, y)].set_symbol(glyph).set_style(style);
       }
     }
   }
@@ -287,9 +339,44 @@ mod tests {
   #[test]
   fn cell_glyphs_build_bottom_up() {
     // 11 eighths in a 3-row column: full block, then three eighths, then air.
-    let glyphs: Vec<char> = (0..3)
+    let glyphs: Vec<&str> = (0..3)
       .map(|row| EIGHTH_GLYPHS[cell_eighths(11, row) as usize])
       .collect();
-    assert_eq!(glyphs, vec!['█', '▃', ' ']);
+    assert_eq!(glyphs, vec!["█", "▃", " "]);
+  }
+
+  #[test]
+  fn visualizer_bar_count_follows_each_styles_geometry() {
+    // BarGraph gets two Braille bars per cell.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 100), 200);
+
+    // Cava: one bar per 3 columns (bar width 2 + spacing 1).
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 80), 27);
+  }
+
+  #[test]
+  fn visualizer_bar_count_clamps_degenerate_widths() {
+    // Zero-width terminals still request a drawable minimum.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 0), 2);
+    assert_eq!(visualizer_bar_count(VisualizerStyle::BarGraph, 0), 2);
+
+    // The bar cap holds on wide terminals and dense fonts.
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 4000), 40);
+    assert_eq!(visualizer_bar_count(VisualizerStyle::Cava, 216), 40);
+  }
+
+  #[test]
+  fn requested_bar_count_and_drawn_geometry_agree() {
+    // The two halves of the cava contract: the count the runner asks for must
+    // fit the width the renderer lays it out in, at every width.
+    for inner_width in [20u16, 40, 80, 119, 120, 216, 400] {
+      let bars = visualizer_bar_count(VisualizerStyle::Cava, inner_width) as u16;
+      let (bar_width, spacing) = cava_bar_layout(inner_width, bars);
+      let drawn = bars * (bar_width + spacing) - spacing;
+      assert!(
+        drawn <= inner_width,
+        "{bars} bars drawn as {drawn} columns overflow width {inner_width}"
+      );
+    }
   }
 }

--- a/src/tui/ui/audio_analysis.rs
+++ b/src/tui/ui/audio_analysis.rs
@@ -2,16 +2,14 @@ use crate::core::app::App;
 use crate::core::layout::main_layout_margin;
 use crate::core::user_config::{normalize_tick_rate_milliseconds, VisualizerStyle};
 use ratatui::{
-  buffer::Buffer,
   layout::{Constraint, Layout, Rect},
-  style::Style,
+  style::{Color, Style},
   text::{Line, Span},
-  widgets::{Block, Borders, Paragraph, Widget},
+  widgets::{Block, Borders, Paragraph},
   Frame,
 };
 
 use tui_bar_graph::{BarGraph, BarStyle, ColorMode};
-use tui_equalizer::{Band, Equalizer};
 
 pub fn draw(f: &mut Frame<'_>, app: &App) {
   let margin = main_layout_margin(app);
@@ -76,13 +74,18 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
 
     // Render the appropriate visualizer based on user setting
     match visualizer_style {
-      VisualizerStyle::Equalizer => {
-        f.render_widget(bar_chart_block, visualizer_area);
-        render_equalizer(f, &spectrum.bands, inner_area);
-      }
       VisualizerStyle::BarGraph => {
         f.render_widget(bar_chart_block, visualizer_area);
         render_bar_graph(f, &spectrum.bands, inner_area);
+      }
+      VisualizerStyle::Cava => {
+        f.render_widget(bar_chart_block, visualizer_area);
+        render_cava(
+          f,
+          &spectrum.bands,
+          inner_area,
+          app.user_config.theme.analysis_bar,
+        );
       }
     }
   } else {
@@ -113,110 +116,6 @@ pub fn draw(f: &mut Frame<'_>, app: &App) {
   }
 }
 
-/// Render equalizer-style visualization using tui-equalizer
-/// https://github.com/joshka/tui-equalizer
-///
-/// The tui-equalizer widget renders each band at 2 chars wide, left-aligned.
-/// We pass the 12 frequency bands directly for a clean look.
-fn render_equalizer(f: &mut Frame<'_>, bands: &[f32], area: Rect) {
-  if bands.is_empty() || area.width == 0 || area.height == 0 {
-    return;
-  }
-
-  // tui-equalizer renders best (and fastest) with a small, fixed number of bands.
-  // We deliberately keep this to the raw analyzer band count (12).
-  let eq_bands: Vec<Band> = bands
-    .iter()
-    .map(|&v| {
-      // Visually boost quieter signals so the equalizer "reaches" higher.
-      const EQ_GAMMA: f64 = 0.65; // < 1.0 boosts lows
-      const EQ_GAIN: f64 = 1.35; // overall gain
-      let value = (v.clamp(0.0, 1.0) as f64).powf(EQ_GAMMA) * EQ_GAIN;
-      Band::from(value.clamp(0.0, 1.0))
-    })
-    .collect();
-
-  let equalizer = Equalizer {
-    bands: eq_bands,
-    brightness: 1.0,
-  };
-
-  // Cap height to keep rendering fast on very tall terminals.
-  const MAX_EQ_HEIGHT: u16 = 24;
-  let render_height = area.height.clamp(1, MAX_EQ_HEIGHT);
-  let base_width = (bands.len() as u16) * 2;
-
-  // Render into a small off-screen buffer, then "stretch" each band horizontally by repeating it.
-  // This fills the available width without generating additional (interpolated) bands.
-  let tmp_area = Rect::new(0, 0, base_width, render_height);
-  let mut tmp = Buffer::empty(tmp_area);
-  equalizer.render(tmp_area, &mut tmp);
-
-  // tui-equalizer draws only the left cell of each 2-cell band. Duplicate it into the right cell
-  // so we don't alternate colored/default cells (a major perf hit on Windows terminals).
-  for band_index in 0..(bands.len() as u16) {
-    let left_x = band_index * 2;
-    let right_x = left_x + 1;
-    for y in 0..render_height {
-      let left_cell = tmp[(left_x, y)].clone();
-      tmp[(right_x, y)] = left_cell;
-    }
-  }
-
-  let target_width = area.width & !1;
-  if target_width < base_width {
-    // Too narrow to fit all bands; just render what we can centered.
-    let render_width = target_width.max(2);
-    let render_x = area.x + area.width.saturating_sub(render_width) / 2;
-    let render_area = Rect {
-      x: render_x,
-      y: area.y + area.height.saturating_sub(render_height),
-      width: render_width,
-      height: render_height,
-    };
-    let buf = f.buffer_mut();
-    for y in 0..render_height {
-      for x in 0..render_width {
-        buf[(render_area.x + x, render_area.y + y)] = tmp[(x, y)].clone();
-      }
-    }
-    return;
-  }
-
-  // Distribute width evenly across bands in 2-cell "pairs" so each band stays aligned.
-  let pairs_total = (target_width / 2) as usize;
-  let band_count = bands.len();
-  let pairs_per_band = pairs_total / band_count;
-  if pairs_per_band == 0 {
-    return;
-  }
-  let extra_pairs = pairs_total % band_count;
-
-  let render_area = Rect {
-    x: area.x,
-    y: area.y + area.height.saturating_sub(render_height),
-    width: target_width,
-    height: render_height,
-  };
-
-  let buf = f.buffer_mut();
-  let mut x_cursor: u16 = 0;
-  for band_index in 0..band_count {
-    let band_pairs = pairs_per_band + usize::from(band_index < extra_pairs);
-    let band_width = (band_pairs as u16) * 2;
-    let src_x = (band_index as u16) * 2;
-
-    for y in 0..render_height {
-      let cell = tmp[(src_x, y)].clone();
-      for dx in 0..band_width {
-        buf[(render_area.x + x_cursor + dx, render_area.y + y)] = cell.clone();
-      }
-    }
-
-    x_cursor += band_width;
-  }
-}
-
 /// Render bar graph-style visualization using tui-bar-graph
 /// https://github.com/joshka/tui-widgets/tree/main/tui-bar-graph
 ///
@@ -226,9 +125,18 @@ fn render_bar_graph(f: &mut Frame<'_>, bands: &[f32], area: Rect) {
     return;
   }
 
-  // In Braille mode the widget has 2x horizontal resolution, so feed 2 values per cell.
+  // Bands normally arrive sized for Braille resolution (2 per cell, computed
+  // by the runner), each a real analyzer bar. When they don't match - the
+  // analyzer caps bar counts at what the sample rate supports (513 at
+  // 44.1/48 kHz, i.e. terminals wider than ~257 columns), or a style switch /
+  // resize lags one frame - stretch them across the full width instead of
+  // leaving the right side blank (the widget draws left-aligned).
   let target_width = (area.width as usize) * 2;
-  let data = interpolate_bands(bands, target_width);
+  let data: Vec<f64> = if bands.len() == target_width {
+    bands.iter().map(|&v| f64::from(v)).collect()
+  } else {
+    interpolate_bands(bands, target_width)
+  };
 
   let bar_graph = BarGraph::new(data)
     .with_gradient(colorgrad::preset::turbo())
@@ -239,13 +147,14 @@ fn render_bar_graph(f: &mut Frame<'_>, bands: &[f32], area: Rect) {
   f.render_widget(bar_graph, area);
 }
 
-/// Interpolate band values to fill the target width for smoother display
+/// Linearly interpolate band values onto `target_width` points (only used when
+/// the analyzer could not supply one real bar per Braille half-column).
 fn interpolate_bands(bands: &[f32], target_width: usize) -> Vec<f64> {
   if bands.is_empty() {
     return vec![0.0; target_width];
   }
   if bands.len() == 1 {
-    return vec![bands[0] as f64; target_width];
+    return vec![f64::from(bands[0]); target_width];
   }
 
   let mut result = Vec::with_capacity(target_width);
@@ -257,13 +166,130 @@ fn interpolate_bands(bands: &[f32], target_width: usize) -> Vec<f64> {
     let frac = pos - idx as f64;
 
     let value = if idx + 1 < bands.len() {
-      bands[idx] as f64 * (1.0 - frac) + bands[idx + 1] as f64 * frac
+      f64::from(bands[idx]) * (1.0 - frac) + f64::from(bands[idx + 1]) * frac
     } else {
-      bands[idx.min(bands.len() - 1)] as f64
+      f64::from(bands[idx.min(bands.len() - 1)])
     };
 
     result.push(value);
   }
 
   result
+}
+
+/// Bar glyphs from empty to full block, indexed by filled eighths (0-8).
+const EIGHTH_GLYPHS: [char; 9] = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+/// Total filled eighths for a bar value in a column `rows` cells tall, with
+/// cava's idle floor of one eighth (the signature resting line). u32 math:
+/// rows * 8 would overflow u16 on pathological (>8191-row) terminal heights.
+fn bar_eighths(value: f32, rows: u16) -> u32 {
+  let max_eighths = u32::from(rows) * 8;
+  let total = (value.clamp(0.0, 1.0) * max_eighths as f32) as u32;
+  total.clamp(1, max_eighths)
+}
+
+/// Eighths filled (0-8) in the cell `row` rows above the column's bottom.
+fn cell_eighths(total_eighths: u32, row: u16) -> u32 {
+  total_eighths.saturating_sub(u32::from(row) * 8).min(8)
+}
+
+/// Bar width and spacing for the cava style. The bar count is capped (~40),
+/// so bars widen with the terminal to fill the area at roughly cava's 2:1
+/// bar-to-gap ratio; cava's own 2-wide/1-gap geometry is the floor, keeping
+/// dense fonts on the classic chunky-column look instead of pencil bars.
+fn cava_bar_layout(inner_width: u16, bars: u16) -> (u16, u16) {
+  if bars == 0 {
+    return (2, 1);
+  }
+  // u32 internals, footprint capped at the width: keeps the math (and the
+  // renderer's bar_width + spacing sums) off u16 overflow at any input.
+  let footprint = ((u32::from(inner_width) + 1) / u32::from(bars))
+    .max(3)
+    .min(u32::from(inner_width).max(3));
+  let spacing = ((footprint + 1) / 3).max(1);
+  ((footprint - spacing) as u16, spacing as u16)
+}
+
+/// Render cava-style visualization: one independent bar per band drawn in
+/// eighth blocks, widened to fill the width (see `cava_bar_layout`), centered.
+fn render_cava(f: &mut Frame<'_>, bands: &[f32], area: Rect, color: Color) {
+  if bands.is_empty() || area.width == 0 || area.height == 0 {
+    return;
+  }
+
+  let (bar_width, spacing) = cava_bar_layout(area.width, bands.len() as u16);
+  let step = bar_width + spacing;
+  let drawn_width = (bands.len() as u16) * step - spacing;
+  let x_offset = area.width.saturating_sub(drawn_width) / 2;
+  let style = Style::default().fg(color);
+  let buf = f.buffer_mut();
+
+  for (i, &value) in bands.iter().enumerate() {
+    let x0 = area.x + x_offset + (i as u16) * step;
+    // Clip bars that no longer fit (the bar count lags one frame on resize).
+    if x0 + bar_width > area.x + area.width {
+      break;
+    }
+
+    let total_eighths = bar_eighths(value, area.height);
+    for row in 0..area.height {
+      let filled = cell_eighths(total_eighths, row);
+      if filled == 0 {
+        break;
+      }
+      let glyph = EIGHTH_GLYPHS[filled as usize];
+      let y = area.y + area.height - 1 - row;
+      for dx in 0..bar_width {
+        buf[(x0 + dx, y)].set_char(glyph).set_style(style);
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn bar_eighths_has_cavas_idle_floor() {
+    assert_eq!(bar_eighths(0.0, 10), 1);
+  }
+
+  #[test]
+  fn bar_eighths_fills_the_column_at_full_scale() {
+    assert_eq!(bar_eighths(1.0, 10), 80);
+  }
+
+  #[test]
+  fn bar_eighths_clamps_overshoot() {
+    assert_eq!(bar_eighths(1.7, 10), 80);
+  }
+
+  #[test]
+  fn cava_bar_layout_widens_bars_to_fill_dense_terminals() {
+    // 216 columns, 40 bars: 5 columns per bar -> 3-wide bars, 2-wide gaps.
+    assert_eq!(cava_bar_layout(216, 40), (3, 2));
+    // 400 columns: 10 per bar -> 7-wide bars, 3-wide gaps (~2:1 holds).
+    assert_eq!(cava_bar_layout(400, 40), (7, 3));
+  }
+
+  #[test]
+  fn cava_bar_layout_floors_at_cavas_own_geometry() {
+    // Exactly enough room for 40 bars at cava's default 2+1 geometry.
+    assert_eq!(cava_bar_layout(119, 40), (2, 1));
+    // Narrow terminals (fewer bars requested) keep the 2+1 default.
+    assert_eq!(cava_bar_layout(80, 27), (2, 1));
+    // Too narrow to fit: geometry floors at 2+1 and the renderer clips.
+    assert_eq!(cava_bar_layout(5, 40), (2, 1));
+  }
+
+  #[test]
+  fn cell_glyphs_build_bottom_up() {
+    // 11 eighths in a 3-row column: full block, then three eighths, then air.
+    let glyphs: Vec<char> = (0..3)
+      .map(|row| EIGHTH_GLYPHS[cell_eighths(11, row) as usize])
+      .collect();
+    assert_eq!(glyphs, vec!['█', '▃', ' ']);
+  }
 }

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -247,6 +247,11 @@ pub fn get_help_docs(app: &App) -> Vec<Vec<String>> {
       String::from("General"),
     ],
     vec![
+      String::from("Cycle visualizer style (in audio analysis)"),
+      String::from("V"),
+      String::from("General"),
+    ],
+    vec![
       String::from("Go to lyrics view"),
       key_bindings.lyrics_view.to_string(),
       String::from("General"),


### PR DESCRIPTION
# Summary

Replaces the Equalizer visualizer with a cava-style one driven by a vendored, patched port of cava's core DSP engine.

- **Vendored cavacore** (`src/infra/audio/cavacore/`): Rust port of cava's engine (from the archived `cavacore-rs` crate), carrying three correctness patches (autosens raise-on-signal, float cutoff math, time-reversed input buffer) plus a spotatui extension capping autosens gain so near-silent input is not normalized to full-scale bars. Provenance and every patch site are documented in the module header.
- **Analyzer rewrite** (`src/infra/audio/analyzer.rs`): the hand-rolled FFT/band mapping is gone; the analyzer now wraps cavacore with stereo input, log-spaced bars, gravity/integral smoothing, and cava's mirrored stereo display order (bass meets in the middle).
- **New Cava render style** (`src/tui/ui/audio_analysis.rs`): eighth-block bars capped at ~40, widened to fill the terminal at roughly cava's 2:1 bar-to-gap ratio. `Equalizer` is removed; old config values (`Equalizer`, `Classic`) deserialize to `Cava` via serde aliases, with a test. The `tui-equalizer` dependency is dropped.
- **Bar count follows the terminal**: the runner asks the analyzer for exactly the bars the current width can draw (per style), and the analyzer rebuilds its plan on resize or style switch, clamping counts the sample rate cannot support.
- **Both capture backends now feed stereo** (cpal and PipeWire); the channel rule (0/1 pass through, mono duplicates) lives in the analyzer, so callbacks push raw frames with no per-callback allocation. PipeWire also adopts the negotiated sample rate from `param_changed`.
- A follow-up cleanup pass single-sources the geometry contract (bar count vs layout) next to the renderer, collapses the analyzer's three plan-rebuild bodies into one constructor, exposes cavacore's validation bounds (`MAX_SAMPLE_RATE`, `max_bars_per_channel`, `Cava::input_len`) instead of hand-copying them app-side, and collapses the three duplicate `SpectrumData` structs into one.

# Testing

- `cargo fmt --all`
- `cargo clippy -- -D warnings` (default leg): clean
- `cargo clippy --no-default-features --features telemetry -- -D warnings` (slim leg): clean
- `cargo test` (default leg): 876 passed
- `cargo test --no-default-features --features telemetry` (slim leg): 579 passed
- Smoke tested on Windows with the full `cargo run` build (cpal/WASAPI loopback)

The PipeWire backend (`audio-viz`, Linux-only) compiles only on the `all-sources` CI leg; its changes mirror the cpal backend mechanically.

# Additional notes

- New key: `V` cycles visualizer style inside the analysis screen (help row added).
- `set_bars` now also drops the pending sample backlog on rebuild (under 16 ms of audio, on a resize that already resets smoothing state).
- Pre-existing and untouched: `PipeWireCapture::new` sleeps 300 ms on the UI thread while holding the App lock; `behavior.visualizer_style` has never had settings-screen arms (config file or `V` key only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Cava visualizer with centered, dynamic audio bars.
  * Added responsive BarGraph visualization.
  * Visualizer bar counts now adapt to available screen width.
  * Added the `V` shortcut for cycling visualizer styles.
  * Improved stereo and mono audio visualization.

* **Bug Fixes**
  * Improved handling of varying sample rates, channel layouts, and audio buffer sizes.
  * Legacy Equalizer and Classic settings continue to load as Cava.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->