### PR TITLE
ci: add tui feature and headless leg

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 # Full build (native streaming + audio viz + Lua scripting + OS integrations)
 cargo run
 
-# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's five legs
+# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
 cargo run --no-default-features --features telemetry
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
@@ -28,15 +28,16 @@ cargo test --no-default-features --features telemetry
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
 (`.github/workflows/ci.yml`, on `ubuntu-latest`) runs `check`, `test`, and `clippy`
-across a **five-leg** feature matrix:
+across a **six-leg** feature matrix:
 
 | Leg | Features |
 |-----|----------|
 | `default` | a plain `cargo test`: streaming + audio-viz-cpal + scripting + self-update + OS integrations |
 | `all-sources` | the **Linux** release feature set from `cd.yml` (adds cover-art, mcp-server, ai-dj, audio-viz, all four sources) |
-| `mcp-only` | `telemetry,mcp-server` |
-| `ai-dj-only` | `telemetry,ai-dj` |
-| `slim` | `telemetry` |
+| `mcp-only` | `telemetry,tui,mcp-server` |
+| `ai-dj-only` | `telemetry,tui,ai-dj` |
+| `slim` | `telemetry,tui` |
+| `headless` | `telemetry` - the only leg without `tui` (an empty feature while `mod tui` is still ungated); once the GUI substrate migration gates the module, this leg turns `crate::tui` imports from core/infra/cli into compile errors |
 
 - `mcp-only` and `ai-dj-only` matter more than their size suggests: both enable
   `dj-core` **without** `streaming` (a combination nothing else covers), and each

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 cargo run
 
 # Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
-cargo run --no-default-features --features telemetry
+cargo run --no-default-features --features telemetry,tui
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
 # in `default`, so a plain `cargo run` is Spotify-only; use the `all-sources` alias
@@ -22,8 +22,8 @@ cargo run --features all-sources
 
 ```bash
 cargo fmt --all
-cargo clippy --no-default-features --features telemetry -- -D warnings
-cargo test --no-default-features --features telemetry
+cargo clippy --no-default-features --features telemetry,tui -- -D warnings
+cargo test --no-default-features --features telemetry,tui
 ```
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
@@ -59,9 +59,9 @@ across a **six-leg** feature matrix:
 ## Run a Single Test
 
 ```bash
-cargo test --no-default-features --features telemetry <test_name>
+cargo test --no-default-features --features telemetry,tui <test_name>
 # Example:
-cargo test --no-default-features --features telemetry global_shift_w_adds_current_track_from_anywhere
+cargo test --no-default-features --features telemetry,tui global_shift_w_adds_current_track_from_anywhere
 ```
 
 A filter that matches nothing still exits 0 - when running feature-gated tests in

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,9 +79,9 @@ jobs:
       - name: Build release binary
         run: |
           if [ -z "${{ matrix.audio_features }}" ]; then
-            cargo build --release --target ${{ matrix.target }} --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj
+            cargo build --release --target ${{ matrix.target }} --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj
           else
-            cargo build --release --target ${{ matrix.target }} --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,${{ matrix.audio_features }}
+            cargo build --release --target ${{ matrix.target }} --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,${{ matrix.audio_features }}
           fi
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           # whenever a feature is added there, or the release build becomes the
           # first place a break shows up.
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # `mcp-server` and `ai-dj` are two front doors on the same `dj-core`
           # implementation, and each has to build without the other: the
           # field-level `#[cfg(feature = "ai-dj")]` on `DjState::setup` exists
@@ -49,11 +49,18 @@ jobs:
           # on, so only a single-door leg can catch one leaking into the other.
           # Both are slim, so they cost a fraction of the all-sources leg.
           - name: mcp-only
-            args: "--locked --no-default-features --features telemetry,mcp-server"
+            args: "--locked --no-default-features --features telemetry,tui,mcp-server"
           - name: ai-dj-only
-            args: "--locked --no-default-features --features telemetry,ai-dj"
+            args: "--locked --no-default-features --features telemetry,tui,ai-dj"
           # Slim build used for fast local iteration (matches CLAUDE.md).
           - name: slim
+            args: "--locked --no-default-features --features telemetry,tui"
+          # Headless: the only leg without `tui`. Identical to slim while
+          # `mod tui` is still ungated; once the GUI substrate migration gates
+          # the module, this leg turns any `crate::tui` import from
+          # core/infra/cli into a compile error, which is what keeps a second
+          # frontend from silently re-coupling to the terminal one.
+          - name: headless
             args: "--locked --no-default-features --features telemetry"
     env:
       RUSTFLAGS: "-C linker-features=-lld"
@@ -85,13 +92,16 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # See the check job for why the two single-door DJ legs exist.
           - name: mcp-only
-            args: "--locked --no-default-features --features telemetry,mcp-server"
+            args: "--locked --no-default-features --features telemetry,tui,mcp-server"
           - name: ai-dj-only
-            args: "--locked --no-default-features --features telemetry,ai-dj"
+            args: "--locked --no-default-features --features telemetry,tui,ai-dj"
           - name: slim
+            args: "--locked --no-default-features --features telemetry,tui"
+          # See the check job for why the headless leg exists.
+          - name: headless
             args: "--locked --no-default-features --features telemetry"
     env:
       RUSTFLAGS: "-C linker-features=-lld"
@@ -141,13 +151,16 @@ jobs:
           - name: default
             args: "--locked"
           - name: all-sources
-            args: "--locked --no-default-features --features telemetry,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
+            args: "--locked --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube"
           # See the check job for why the two single-door DJ legs exist.
           - name: mcp-only
-            args: "--locked --no-default-features --features telemetry,mcp-server"
+            args: "--locked --no-default-features --features telemetry,tui,mcp-server"
           - name: ai-dj-only
-            args: "--locked --no-default-features --features telemetry,ai-dj"
+            args: "--locked --no-default-features --features telemetry,tui,ai-dj"
           - name: slim
+            args: "--locked --no-default-features --features telemetry,tui"
+          # See the check job for why the headless leg exists.
+          - name: headless
             args: "--locked --no-default-features --features telemetry"
     env:
       RUSTFLAGS: "-C linker-features=-lld"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 # Full build (native streaming + audio viz + Lua scripting + OS integrations)
 cargo run
 
-# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's five legs
+# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
 cargo run --no-default-features --features telemetry
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
@@ -30,15 +30,16 @@ cargo test --no-default-features --features telemetry
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
 (`.github/workflows/ci.yml`, on `ubuntu-latest`) runs `check`, `test`, and `clippy`
-across a **five-leg** feature matrix:
+across a **six-leg** feature matrix:
 
 | Leg | Features |
 |-----|----------|
 | `default` | a plain `cargo test`: streaming + audio-viz-cpal + scripting + self-update + OS integrations |
 | `all-sources` | the **Linux** release feature set from `cd.yml` (adds cover-art, mcp-server, ai-dj, audio-viz, all four sources) |
-| `mcp-only` | `telemetry,mcp-server` |
-| `ai-dj-only` | `telemetry,ai-dj` |
-| `slim` | `telemetry` |
+| `mcp-only` | `telemetry,tui,mcp-server` |
+| `ai-dj-only` | `telemetry,tui,ai-dj` |
+| `slim` | `telemetry,tui` |
+| `headless` | `telemetry` - the only leg without `tui` (an empty feature while `mod tui` is still ungated); once the GUI substrate migration gates the module, this leg turns `crate::tui` imports from core/infra/cli into compile errors |
 
 - `mcp-only` and `ai-dj-only` matter more than their size suggests: both enable
   `dj-core` **without** `streaming` (a combination nothing else covers), and each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 cargo run
 
 # Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
-cargo run --no-default-features --features telemetry
+cargo run --no-default-features --features telemetry,tui
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
 # in `default`, so a plain `cargo run` is Spotify-only; use the `all-sources` alias
@@ -24,8 +24,8 @@ cargo run --features all-sources
 
 ```bash
 cargo fmt --all
-cargo clippy --no-default-features --features telemetry -- -D warnings
-cargo test --no-default-features --features telemetry
+cargo clippy --no-default-features --features telemetry,tui -- -D warnings
+cargo test --no-default-features --features telemetry,tui
 ```
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
@@ -61,9 +61,9 @@ across a **six-leg** feature matrix:
 ## Run a Single Test
 
 ```bash
-cargo test --no-default-features --features telemetry <test_name>
+cargo test --no-default-features --features telemetry,tui <test_name>
 # Example:
-cargo test --no-default-features --features telemetry global_shift_w_adds_current_track_from_anywhere
+cargo test --no-default-features --features telemetry,tui global_shift_w_adds_current_track_from_anywhere
 ```
 
 A filter that matches nothing still exits 0 - when running feature-gated tests in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 # Full build (native streaming + audio viz + Lua scripting + OS integrations)
 cargo run
 
-# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's five legs
+# Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
 cargo run --no-default-features --features telemetry
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
@@ -30,15 +30,16 @@ cargo test --no-default-features --features telemetry
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
 (`.github/workflows/ci.yml`, on `ubuntu-latest`) runs `check`, `test`, and `clippy`
-across a **five-leg** feature matrix:
+across a **six-leg** feature matrix:
 
 | Leg | Features |
 |-----|----------|
 | `default` | a plain `cargo test`: streaming + audio-viz-cpal + scripting + self-update + OS integrations |
 | `all-sources` | the **Linux** release feature set from `cd.yml` (adds cover-art, mcp-server, ai-dj, audio-viz, all four sources) |
-| `mcp-only` | `telemetry,mcp-server` |
-| `ai-dj-only` | `telemetry,ai-dj` |
-| `slim` | `telemetry` |
+| `mcp-only` | `telemetry,tui,mcp-server` |
+| `ai-dj-only` | `telemetry,tui,ai-dj` |
+| `slim` | `telemetry,tui` |
+| `headless` | `telemetry` - the only leg without `tui` (an empty feature while `mod tui` is still ungated); once the GUI substrate migration gates the module, this leg turns `crate::tui` imports from core/infra/cli into compile errors |
 
 - `mcp-only` and `ai-dj-only` matter more than their size suggests: both enable
   `dj-core` **without** `streaming` (a combination nothing else covers), and each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file is maintained as three near-identical copies: `CLAUDE.md`, `AGENTS.md`
 cargo run
 
 # Slim build - no librespot/audio/scripting; fastest iteration, one of CI's six legs
-cargo run --no-default-features --features telemetry
+cargo run --no-default-features --features telemetry,tui
 
 # With the free alternative sources (Local/Subsonic/Radio/YouTube). These are NOT
 # in `default`, so a plain `cargo run` is Spotify-only; use the `all-sources` alias
@@ -24,8 +24,8 @@ cargo run --features all-sources
 
 ```bash
 cargo fmt --all
-cargo clippy --no-default-features --features telemetry -- -D warnings
-cargo test --no-default-features --features telemetry
+cargo clippy --no-default-features --features telemetry,tui -- -D warnings
+cargo test --no-default-features --features telemetry,tui
 ```
 
 These slim commands are the *fast local gate*, not the full picture. GitHub Actions
@@ -61,9 +61,9 @@ across a **six-leg** feature matrix:
 ## Run a Single Test
 
 ```bash
-cargo test --no-default-features --features telemetry <test_name>
+cargo test --no-default-features --features telemetry,tui <test_name>
 # Example:
-cargo test --no-default-features --features telemetry global_shift_w_adds_current_track_from_anywhere
+cargo test --no-default-features --features telemetry,tui global_shift_w_adds_current_track_from_anywhere
 ```
 
 A filter that matches nothing still exits 0 - when running feature-gated tests in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,14 @@ objc2 = { version = "0.6", optional = true }
 block2 = { version = "0.6", optional = true }
 
 [features]
-default = ["telemetry", "streaming", "audio-viz-cpal", "macos-media", "discord-rpc", "mpris", "self-update", "windows-media", "scripting"]
+default = ["telemetry", "streaming", "audio-viz-cpal", "macos-media", "discord-rpc", "mpris", "self-update", "windows-media", "scripting", "tui"]
 telemetry = []
+# The terminal frontend. In `default` and currently ungated (`mod tui` is always
+# compiled, ratatui/crossterm stay non-optional), so building without it changes
+# nothing yet. The headless CI leg omits it so that, once `mod tui` is
+# feature-gated as part of the GUI substrate migration, any `crate::tui` import
+# from core/infra/cli becomes a compile error there.
+tui = []
 self-update = ["dep:self_update", "dep:sha2", "dep:hex"]
 streaming = ["librespot-core", "librespot-playback", "librespot-connect", "librespot-oauth", "librespot-metadata", "librespot-protocol", "protobuf"]
 # Audio backend features


### PR DESCRIPTION
# Summary

Adds an empty `tui` feature, in `default` and in every explicit ci.yml/cd.yml feature string, plus a sixth `headless` CI leg built with `--no-default-features --features telemetry` (the only leg without `tui`). No dependency or code changes, and `Cargo.lock` is untouched, so the `--locked` legs need no regeneration.

Building without `tui` changes nothing while `mod tui` is still ungated; once the GUI substrate migration gates the module, the headless leg turns any `crate::tui` import from core/infra/cli into a compile error. The six-leg matrix table is updated in all three doc copies (CLAUDE.md, AGENTS.md, copilot-instructions.md).

# Testing

- `cargo check --locked --no-default-features --features telemetry,tui`
- `cargo test --no-default-features --features telemetry,tui gates` (5 passed)
- `cargo fmt --all`

# Additional notes

Stacked on #450: this branch's CI run also exercises the ratchet test on the new headless leg.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The terminal user interface is now enabled by default.
  - Release builds include support for the terminal interface across supported configurations.
  - Added a headless build configuration for environments that do not require an interactive terminal.

- **Documentation**
  - Updated build and configuration guidance to describe the expanded feature matrix and terminal interface options.

- **Tests**
  - Extended automated validation across terminal-enabled, headless, slim, and specialized build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->