### PR TITLE
ci: ratchet gates.count against merge-base

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,6 +55,10 @@ across a **six-leg** feature matrix:
   `#[allow(dead_code)]`.
 - The `all-sources` leg must stay in sync with `cd.yml`'s Linux release row
   (macOS releases ship a smaller set - no decoded sources).
+- A pull_request-only `Gates ratchet` job diffs `tools/gates.count` against the
+  merge-base (`tools/check_gates_ratchet.sh`): coupling counters may only fall
+  and `test_attribute_total` may only rise. Lower a baseline in the same PR
+  that improves it; never raise one.
 
 ## Run a Single Test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,9 +193,12 @@ jobs:
     needs: prepare
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@master
+      # Pinned to an immutable SHA per review; the pre-existing jobs' @master
+      # refs are a separate hygiene pass.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Compare tools/gates.count against merge-base
         run: |
           git fetch origin "${{ github.base_ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,3 +181,22 @@ jobs:
         with:
           command: clippy
           args: ${{ matrix.args }} -- -D warnings
+
+  # The src/gates.rs test pins tools/gates.count to the measured counters; this
+  # job closes the remaining hole by comparing the file against the merge-base,
+  # so a PR cannot raise a coupling baseline or lower the test floor alongside
+  # the code that would need it. Pull requests only: pushes to main have no base
+  # to ratchet against.
+  gates-ratchet:
+    name: Gates ratchet
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Compare tools/gates.count against merge-base
+        run: |
+          git fetch origin "${{ github.base_ref }}"
+          bash tools/check_gates_ratchet.sh FETCH_HEAD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ across a **six-leg** feature matrix:
   `#[allow(dead_code)]`.
 - The `all-sources` leg must stay in sync with `cd.yml`'s Linux release row
   (macOS releases ship a smaller set - no decoded sources).
+- A pull_request-only `Gates ratchet` job diffs `tools/gates.count` against the
+  merge-base (`tools/check_gates_ratchet.sh`): coupling counters may only fall
+  and `test_attribute_total` may only rise. Lower a baseline in the same PR
+  that improves it; never raise one.
 
 ## Run a Single Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ across a **six-leg** feature matrix:
   `#[allow(dead_code)]`.
 - The `all-sources` leg must stay in sync with `cd.yml`'s Linux release row
   (macOS releases ship a smaller set - no decoded sources).
+- A pull_request-only `Gates ratchet` job diffs `tools/gates.count` against the
+  merge-base (`tools/check_gates_ratchet.sh`): coupling counters may only fall
+  and `test_attribute_total` may only rise. Lower a baseline in the same PR
+  that improves it; never raise one.
 
 ## Run a Single Test
 

--- a/tools/check_gates_ratchet.sh
+++ b/tools/check_gates_ratchet.sh
@@ -32,11 +32,31 @@ old_pairs=$(parse "$old_content")
 new_pairs=$(parse "$(cat "$file")")
 
 fail=0
+
+# Reject malformed content outright instead of letting parse() drop it: after
+# comment stripping, every non-blank line must be `key = <digits>`.
+check_wellformed() { # $1 = label, $2 = content
+  local bad
+  bad=$(printf '%s\n' "$2" | sed 's/#.*//;s/\r//g' | awk 'NF' |
+    grep -vE '^[ \t]*[A-Za-z0-9_]+[ \t]*=[ \t]*[0-9]+[ \t]*$' || true)
+  if [ -n "$bad" ]; then
+    echo "FAIL: malformed line(s) in $1:"
+    printf '  %s\n' "$bad"
+    fail=1
+  fi
+}
+check_wellformed "$file" "$(cat "$file")"
+check_wellformed "$file at merge-base $merge_base" "$old_content"
+
 while read -r key old_value; do
   [ -z "$key" ] && continue
-  new_value=$(printf '%s\n' "$new_pairs" | awk -v k="$key" '$1 == k { print $2 }')
+  # tail -n 1 mirrors the Rust parser's last-wins on duplicate keys.
+  new_value=$(printf '%s\n' "$new_pairs" | awk -v k="$key" '$1 == k { print $2 }' | tail -n 1)
   if [ -z "$new_value" ]; then
     echo "FAIL: counter $key ($old_value at merge-base) was removed"
+    fail=1
+  elif ! [[ "$old_value" =~ ^[0-9]+$ && "$new_value" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: non-numeric value for $key (merge-base: $old_value, current: $new_value)"
     fail=1
   elif [ "$key" = "test_attribute_total" ]; then
     if [ "$new_value" -lt "$old_value" ]; then

--- a/tools/check_gates_ratchet.sh
+++ b/tools/check_gates_ratchet.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Merge-base ratchet check for tools/gates.count.
+#
+# Usage: check_gates_ratchet.sh <base-ref>
+#
+# Compares the working tree's tools/gates.count against the version at the
+# merge-base of <base-ref> and HEAD. Coupling counters may only fall or hold;
+# test_attribute_total (the floor) may only rise or hold. The src/gates.rs
+# test already pins the file to the measured values, so together the two
+# checks mean a PR can neither drift from reality nor move a baseline the
+# wrong way. A missing file at the merge-base is the documented bootstrap:
+# the check passes with a note.
+set -euo pipefail
+
+base_ref=${1:?usage: check_gates_ratchet.sh <base-ref>}
+file=tools/gates.count
+
+merge_base=$(git merge-base "$base_ref" HEAD)
+
+if ! old_content=$(git show "$merge_base:$file" 2>/dev/null); then
+  echo "bootstrap: $file does not exist at merge-base $merge_base; nothing to compare"
+  exit 0
+fi
+
+# `key = value` lines; `#` starts a comment. \r stripped for CRLF checkouts.
+parse() {
+  printf '%s\n' "$1" | sed 's/#.*//' |
+    awk -F= 'NF == 2 { gsub(/[ \t\r]/, "", $1); gsub(/[ \t\r]/, "", $2); print $1, $2 }'
+}
+
+old_pairs=$(parse "$old_content")
+new_pairs=$(parse "$(cat "$file")")
+
+fail=0
+while read -r key old_value; do
+  [ -z "$key" ] && continue
+  new_value=$(printf '%s\n' "$new_pairs" | awk -v k="$key" '$1 == k { print $2 }')
+  if [ -z "$new_value" ]; then
+    echo "FAIL: counter $key ($old_value at merge-base) was removed"
+    fail=1
+  elif [ "$key" = "test_attribute_total" ]; then
+    if [ "$new_value" -lt "$old_value" ]; then
+      echo "FAIL: $key fell from $old_value (merge-base) to $new_value; the test floor may only rise"
+      fail=1
+    fi
+  elif [ "$new_value" -gt "$old_value" ]; then
+    echo "FAIL: $key rose from $old_value (merge-base) to $new_value; coupling baselines may only fall"
+    fail=1
+  fi
+done <<<"$old_pairs"
+
+if [ "$fail" -ne 0 ]; then
+  echo "tools/gates.count moved against the ratchet relative to merge-base $merge_base"
+  exit 1
+fi
+echo "ok: tools/gates.count respects the ratchet against merge-base $merge_base"


### PR DESCRIPTION
# Summary

Closes #453. Adds a `pull_request`-only **Gates ratchet** CI job that compares `tools/gates.count` against its merge-base version, closing the one hole the in-tree `src/gates.rs` test cannot cover: a PR editing a baseline in the wrong direction alongside the code that would need it.

- Coupling counters may only fall or hold; an increase fails with both values named.
- `test_attribute_total` (the floor) may only rise or hold; a decrease fails.
- A counter removed relative to the merge-base fails.
- Bootstrap: if `tools/gates.count` does not exist at the merge-base, the check passes with a note.
- History is fetched with `fetch-depth: 0` plus an explicit fetch of the base ref, per the issue's shallow-checkout requirement.

The comparison logic lives in `tools/check_gates_ratchet.sh` so it can be run locally (`bash tools/check_gates_ratchet.sh origin/main`).

# Testing

All three paths exercised locally against real history:

- Bootstrap: merge-base `f7a728a` (predates the file) passes with the bootstrap note.
- Equality: merge-base `e876d4c` passes.
- Failures: a raised coupling counter, a lowered floor, and a deleted counter each produce a named FAIL and exit 1.

# Additional notes

The job is advisory until added to the ruleset's required status checks (`Gates ratchet`); promoting it is a repo-settings decision.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated pull-request validation for gate metrics and test-attribute totals.
  - Validation detects regressions, preserves required counters, and reports clear failures.

- **Bug Fixes**
  - Prevents quality baselines from increasing unexpectedly.
  - Supports projects without historical gate data.

- **Documentation**
  - Added guidance explaining validation checks, comparison rules, and expected metric behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->