### PR TITLE
refactor: split cover art into store and renderer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -308,6 +308,10 @@ never config:
   mpris, discord-rpc, self-update, scripting`. Notably **not** in default:
   `cover-art` (so a plain `cargo run` has no album art, though every shipped
   binary enables it), the four sources, and the DJ features.
+- Cover art is two features: `art-decode` is the frontend-agnostic decode half
+  (`dep:image`, fills `core::art::CoverArtStore`, feeds the adaptive theme;
+  never enabled by hand); `cover-art` layers the ratatui-image terminal
+  rendering on top and keeps its pre-split meaning for users and CI.
 - `audio-viz` (PipeWire, Linux-only) and `audio-viz-cpal` are **visualizer
   capture** backends, not playback. The librespot *playback* backend is chosen by
   `[target.'cfg(...)']` dependency blocks in Cargo.toml, not by the `*-backend`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,10 @@ never config:
   mpris, discord-rpc, self-update, scripting`. Notably **not** in default:
   `cover-art` (so a plain `cargo run` has no album art, though every shipped
   binary enables it), the four sources, and the DJ features.
+- Cover art is two features: `art-decode` is the frontend-agnostic decode half
+  (`dep:image`, fills `core::art::CoverArtStore`, feeds the adaptive theme;
+  never enabled by hand); `cover-art` layers the ratatui-image terminal
+  rendering on top and keeps its pre-split meaning for users and CI.
 - `audio-viz` (PipeWire, Linux-only) and `audio-viz-cpal` are **visualizer
   capture** backends, not playback. The librespot *playback* backend is chosen by
   `[target.'cfg(...)']` dependency blocks in Cargo.toml, not by the `*-backend`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,10 @@ never config:
   mpris, discord-rpc, self-update, scripting`. Notably **not** in default:
   `cover-art` (so a plain `cargo run` has no album art, though every shipped
   binary enables it), the four sources, and the DJ features.
+- Cover art is two features: `art-decode` is the frontend-agnostic decode half
+  (`dep:image`, fills `core::art::CoverArtStore`, feeds the adaptive theme;
+  never enabled by hand); `cover-art` layers the ratatui-image terminal
+  rendering on top and keeps its pre-split meaning for users and CI.
 - `audio-viz` (PipeWire, Linux-only) and `audio-viz-cpal` are **visualizer
   capture** backends, not playback. The librespot *playback* backend is chosen by
   `[target.'cfg(...)']` dependency blocks in Cargo.toml, not by the `*-backend`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,12 @@ mpris = ["mpris-server"]  # MPRIS D-Bus integration (Linux only)
 macos-media = ["objc2-media-player", "objc2-foundation", "objc2-app-kit", "objc2", "block2", "streaming"]  # macOS Now Playing integration
 windows-media = ["smtc-tokio", "streaming"] # windows SMTC integration
 discord-rpc = ["discord-rich-presence"]
-cover-art = ["ratatui-image", "image"]
+# The frontend-agnostic decode half of cover art: fetch + `image`-decode into
+# the store frontends render from (also feeds the adaptive theme's palette
+# extraction). Not meant to be enabled by hand: `cover-art` layers the
+# terminal rendering on top and keeps its pre-split meaning for users and CI.
+art-decode = ["dep:image"]
+cover-art = ["tui", "art-decode", "dep:ratatui-image"]
 scripting = ["dep:mlua"]
 # Shared audio decode/output engine (rodio bundles symphonia). Pulled by any
 # source that plays decoded audio through the local sink (local files, Subsonic).

--- a/src/core/app/album_theme.rs
+++ b/src/core/app/album_theme.rs
@@ -1,32 +1,11 @@
 use super::*;
 
-/// Status of the currently-playing track's cover art, mirroring [`LyricsStatus`].
-/// Drives the placeholder message shown when art can't be displayed, so a
-/// missing image reads as an explicit state rather than silently showing
-/// nothing (or, worse, the previous track's art).
-#[cfg(feature = "cover-art")]
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-pub enum CoverArtStatus {
-  /// Nothing is playing / no art has been requested yet.
-  #[default]
-  NotStarted,
-  /// A fetch/decode for the current track is in flight.
-  Loading,
-  /// Art for the current track is loaded and rendering.
-  Loaded,
-  /// The current source has no cover art to show (e.g. internet radio, or a
-  /// local file with no embedded picture).
-  Unavailable,
-  /// A fetch/decode was attempted for the current track but failed.
-  Failed,
-}
-
 impl App {
   /// The user's own theme: the restore target while an album-derived theme is
   /// applied (or fading out), otherwise the live theme. Settings rows must be
   /// built from this, never from the live theme, or album accents would leak
   /// into `custom_theme` and persist on the next settings save.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn user_theme(&self) -> crate::core::user_config::Theme {
     use crate::core::cover_theme::CoverThemeState;
     match self.cover_theme_state {
@@ -35,18 +14,18 @@ impl App {
     }
   }
 
-  #[cfg(not(feature = "cover-art"))]
+  #[cfg(not(feature = "art-decode"))]
   pub fn user_theme(&self) -> crate::core::user_config::Theme {
     self.user_config.theme
   }
 
   /// Whether an adaptive-theme fade is animating (drives the fast tick rate).
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn theme_fade_active(&self) -> bool {
     self.theme_transition.is_some()
   }
 
-  #[cfg(not(feature = "cover-art"))]
+  #[cfg(not(feature = "art-decode"))]
   pub fn theme_fade_active(&self) -> bool {
     false
   }
@@ -54,7 +33,7 @@ impl App {
   /// Store freshly decoded cover art together with the palette extracted from
   /// it. The single entry point that keeps the adaptive theme in sync with the
   /// art: `None` for the palette fades back to the user's own theme.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn store_cover_art(
     &mut self,
     key: String,
@@ -70,7 +49,7 @@ impl App {
 
   /// Drop the stored cover art together with its palette; the adaptive theme
   /// follows the art and fades back to the user's own theme.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn clear_cover_art(&mut self) {
     self.cover_art.clear();
     self.clear_cover_art_palette();
@@ -78,7 +57,7 @@ impl App {
 
   /// Store the palette extracted from freshly loaded cover art and, when
   /// Adaptive Theme is on, fade the UI accents toward it.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   fn set_cover_art_palette(&mut self, palette: crate::core::cover_theme::AlbumPalette) {
     self.cover_art_palette = Some(palette);
     self.apply_cover_theme();
@@ -87,7 +66,7 @@ impl App {
   /// Drop the stored palette and fade back to the user's own theme. A cheap
   /// no-op when nothing is applied, so it is safe on every tick of the
   /// "no art" path.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   fn clear_cover_art_palette(&mut self) {
     self.cover_art_palette = None;
     self.restore_cover_theme();
@@ -95,7 +74,7 @@ impl App {
 
   /// Fade toward the theme derived from the stored palette, capturing the
   /// user's theme as the restore base on first application.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   fn apply_cover_theme(&mut self) {
     use crate::core::cover_theme::{derive_theme, CoverThemeState};
     if !self.user_config.behavior.cover_art_theme {
@@ -114,7 +93,7 @@ impl App {
   }
 
   /// Fade back to the user's own theme, if an album theme is applied.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   fn restore_cover_theme(&mut self) {
     use crate::core::cover_theme::CoverThemeState;
     if let CoverThemeState::Active { base } = self.cover_theme_state {
@@ -129,7 +108,7 @@ impl App {
   /// Start fading the live theme toward `target`. Returns false when the
   /// theme is already there (nothing to animate). A transition already headed
   /// to the same target is left to finish rather than restarted.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   fn begin_theme_transition(&mut self, target: crate::core::user_config::Theme) -> bool {
     use crate::core::cover_theme::ThemeTransition;
     if let Some(transition) = &self.theme_transition {
@@ -151,7 +130,7 @@ impl App {
   /// new base; what was actually on screen (`live_before`) is put back so the
   /// fade continues from there. `enabled_before` is the Adaptive Theme flag
   /// before the save, so a flip re-applies or restores.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub(super) fn reconcile_cover_theme_after_settings(
     &mut self,
     live_before: crate::core::user_config::Theme,
@@ -182,11 +161,11 @@ impl App {
   }
 }
 
-#[cfg(all(test, feature = "cover-art"))]
+#[cfg(all(test, feature = "art-decode"))]
 mod tests {
   use super::*;
 
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   mod cover_theme_tests {
     use super::*;
     use crate::core::cover_theme::{derive_theme, AlbumPalette, CoverThemeState};

--- a/src/core/app/construction.rs
+++ b/src/core/app/construction.rs
@@ -248,17 +248,15 @@ impl Default for App {
       native_playback_generation: 0,
       #[cfg(all(feature = "mpris", target_os = "linux"))]
       mpris_manager: None,
-      #[cfg(feature = "cover-art")]
-      cover_art: crate::tui::cover_art::CoverArt::new(),
-      #[cfg(feature = "cover-art")]
-      cover_art_status: CoverArtStatus::default(),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
+      cover_art: crate::core::art::CoverArtStore::default(),
+      #[cfg(feature = "art-decode")]
       desired_cover_art_key: None,
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       cover_art_palette: None,
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       cover_theme_state: crate::core::cover_theme::CoverThemeState::default(),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       theme_transition: None,
       #[cfg(feature = "dj-core")]
       dj: crate::infra::dj::DjState::default(),

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -112,8 +112,6 @@ mod volume;
 #[cfg(test)]
 mod test_support;
 
-#[cfg(feature = "cover-art")]
-pub use album_theme::*;
 pub use discover::*;
 pub use friends::*;
 pub use help::*;
@@ -199,25 +197,25 @@ pub struct App {
   /// replay of the slot can honor a user's pause.
   #[cfg(feature = "streaming")]
   pub queue_slot_desired_playing: bool,
-  #[cfg(feature = "cover-art")]
-  pub cover_art: crate::tui::cover_art::CoverArt,
-  /// Status of the current track's cover art, driving the placeholder message.
-  #[cfg(feature = "cover-art")]
-  pub cover_art_status: CoverArtStatus,
+  /// Decoded cover art for the current track plus its load status. The TUI
+  /// renderer (`tui::cover_art`) caches its terminal protocols on this
+  /// store's key.
+  #[cfg(feature = "art-decode")]
+  pub cover_art: crate::core::art::CoverArtStore,
   /// Image key currently desired by the UI. Detached decode results for older
   /// keys are discarded.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub desired_cover_art_key: Option<String>,
   /// Accent colors extracted from the current cover art. Stored even while
   /// Adaptive Theme is off, so toggling it on recolors immediately without a
   /// refetch. Cleared together with the art itself.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub cover_art_palette: Option<crate::core::cover_theme::AlbumPalette>,
   /// Whether an album-derived theme is applied, and the user theme to restore.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub cover_theme_state: crate::core::cover_theme::CoverThemeState,
   /// In-flight fade of the live theme, advanced by `update_on_tick`.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub theme_transition: Option<crate::core::cover_theme::ThemeTransition>,
   /// AI DJ session state: transcript, auto-queue toggle, vibe, and the
   /// generation counter that invalidates in-flight background work.

--- a/src/core/app/settings_apply.rs
+++ b/src/core/app/settings_apply.rs
@@ -8,15 +8,15 @@ impl App {
     let mut settings_error: Option<String> = None;
     // What is actually on screen right now, put back by the reconciliation at
     // the end so an adaptive-theme fade continues from it.
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     let cover_theme_live_before = self.user_config.theme;
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     let cover_art_theme_before = self.user_config.behavior.cover_art_theme;
     // Run the arms against the user's own colors rather than the live blend:
     // settings_items holds only the current category's rows, so a save from
     // another category rewrites no theme field at all, and analysis_bar has no
     // row in any category. Whatever survives the arms IS the new base theme.
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     {
       self.user_config.theme = self.user_theme();
     }
@@ -292,7 +292,7 @@ impl App {
             self.user_config.behavior.draw_cover_art = v;
           }
         }
-        #[cfg(feature = "cover-art")]
+        #[cfg(feature = "art-decode")]
         "behavior.cover_art_theme" => {
           if let SettingValue::Bool(v) = setting.value {
             self.user_config.behavior.cover_art_theme = v;
@@ -710,7 +710,7 @@ impl App {
         _ => {}
       }
     }
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     self.reconcile_cover_theme_after_settings(cover_theme_live_before, cover_art_theme_before);
     if let Some(message) = settings_error {
       self.set_status_message(message, 4);

--- a/src/core/app/settings_schema.rs
+++ b/src/core/app/settings_schema.rs
@@ -774,7 +774,7 @@ impl App {
               .to_string(),
             value: SettingValue::Bool(self.user_config.behavior.banner_gradient),
           },
-          #[cfg(feature = "cover-art")]
+          #[cfg(feature = "art-decode")]
           SettingItem {
             id: "behavior.cover_art_theme".to_string(),
             name: "Adaptive Theme".to_string(),

--- a/src/core/app/tick.rs
+++ b/src/core/app/tick.rs
@@ -41,7 +41,7 @@ impl App {
 
     // Advance an adaptive-theme fade. Real elapsed time, not tick count, so
     // the fade speed is independent of the configured tick rates.
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if let Some(transition) = self.theme_transition.as_mut() {
       transition.advance(elapsed);
       self.user_config.theme = transition.current();

--- a/src/core/art.rs
+++ b/src/core/art.rs
@@ -14,6 +14,13 @@ use std::sync::OnceLock;
 /// decode needs it all in memory).
 const MAX_COVER_ART_BYTES: u64 = 16 * 1024 * 1024;
 
+/// Cap on either decoded dimension. [`MAX_COVER_ART_BYTES`] bounds only the
+/// compressed body, and a tiny file can still declare enormous dimensions
+/// (`image`'s default `max_alloc` is best-effort, not strict), so the decoder
+/// gets strict width/height limits too. 4096 px is far beyond what any
+/// terminal cell grid can show.
+const MAX_COVER_ART_DIMENSION: u32 = 4096;
+
 static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 /// The process-wide cover-art HTTP client, so keep-alive connections to the
@@ -129,7 +136,20 @@ pub async fn fetch_and_decode(url: &str) -> anyhow::Result<image::DynamicImage> 
   }
   debug!("finished reading response: {} bytes", file.len());
 
-  image::load_from_memory(&file).map_err(|e| anyhow!(e))
+  decode_bounded(&file)
+}
+
+/// Decode a downloaded cover-art body with strict dimension limits, so a
+/// small compressed file cannot expand into an oversized decoded allocation.
+fn decode_bounded(bytes: &[u8]) -> anyhow::Result<image::DynamicImage> {
+  let mut reader = image::ImageReader::new(std::io::Cursor::new(bytes))
+    .with_guessed_format()
+    .map_err(|e| anyhow!(e))?;
+  let mut limits = image::Limits::default();
+  limits.max_image_width = Some(MAX_COVER_ART_DIMENSION);
+  limits.max_image_height = Some(MAX_COVER_ART_DIMENSION);
+  reader.limits(limits);
+  reader.decode().map_err(|e| anyhow!(e))
 }
 
 /// The decoded cover art for the current track, keyed by the request that
@@ -236,6 +256,28 @@ mod tests {
       .unwrap_err();
     assert!(err.to_string().contains("exceeded"), "got: {err}");
     let _ = server.join();
+  }
+
+  #[test]
+  fn cover_art_dimensions_beyond_the_limit_are_rejected() {
+    // A blank one-row PNG wider than the cap compresses to a tiny body, so it
+    // passes the byte cap and must be stopped by the decoder's limits.
+    let mut png = Vec::new();
+    image::DynamicImage::new_rgb8(MAX_COVER_ART_DIMENSION + 1, 1)
+      .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+      .unwrap();
+    assert!((png.len() as u64) < MAX_COVER_ART_BYTES);
+
+    assert!(decode_bounded(&png).is_err());
+    // The same pipeline still decodes an in-bounds image.
+    let mut ok_png = Vec::new();
+    image::DynamicImage::new_rgb8(2, 2)
+      .write_to(
+        &mut std::io::Cursor::new(&mut ok_png),
+        image::ImageFormat::Png,
+      )
+      .unwrap();
+    assert!(decode_bounded(&ok_png).is_ok());
   }
 
   #[test]

--- a/src/core/art.rs
+++ b/src/core/art.rs
@@ -1,0 +1,181 @@
+//! Frontend-agnostic cover art: what to fetch ([`CoverArtRequest`]), the
+//! fetch/decode itself ([`fetch_and_decode`]), and the decoded image plus its
+//! load status ([`CoverArtStore`]) that frontends render from. Turning the
+//! decoded image into a terminal graphics protocol is the TUI's job
+//! (`tui::cover_art`); nothing in here may depend on ratatui.
+
+use anyhow::anyhow;
+use log::{debug, info};
+
+/// What to fetch for the current track's cover art. Built once per track change
+/// by the shared detector and handled off the `App` lock in the network layer.
+#[derive(Clone, Debug)]
+pub enum CoverArtRequest {
+  /// Download and decode an image from a URL (Spotify album art, YouTube
+  /// thumbnail, Subsonic getCoverArt).
+  Url(String),
+  /// Read the embedded cover picture out of a local audio file. `key` is the
+  /// track's `file://` URI (used as the cache identity); `path` is the resolved
+  /// filesystem path handed to the blocking tag reader.
+  #[cfg(feature = "local-files")]
+  LocalFile {
+    key: String,
+    path: std::path::PathBuf,
+  },
+}
+
+impl CoverArtRequest {
+  /// The cache-identity key for this request: the image URL, or the file URI.
+  /// Used to skip re-fetching art already held for the same track.
+  pub fn key(&self) -> &str {
+    match self {
+      CoverArtRequest::Url(url) => url,
+      #[cfg(feature = "local-files")]
+      CoverArtRequest::LocalFile { key, .. } => key,
+    }
+  }
+}
+
+/// Status of the currently-playing track's cover art, mirroring `LyricsStatus`.
+/// Drives the placeholder message shown when art can't be displayed, so a
+/// missing image reads as an explicit state rather than silently showing
+/// nothing (or, worse, the previous track's art).
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub enum CoverArtStatus {
+  /// Nothing is playing / no art has been requested yet.
+  #[default]
+  NotStarted,
+  /// A fetch/decode for the current track is in flight.
+  Loading,
+  /// Art for the current track is loaded and rendering.
+  Loaded,
+  /// The current source has no cover art to show (e.g. internet radio, or a
+  /// local file with no embedded picture).
+  Unavailable,
+  /// A fetch/decode was attempted for the current track but failed.
+  Failed,
+}
+
+/// Downloads and decodes the cover-art image at `url`, off any external lock.
+///
+/// This is a **free function** on purpose: it borrows no `App` state, so its
+/// `.await` points can be reached with the `App` mutex fully dropped. The
+/// network fetch and the (synchronous, CPU-bound) image decode are the
+/// expensive parts and must never run while the `App` guard is held, or the
+/// render loop — which locks the same mutex every frame — freezes for the
+/// whole CDN round-trip (#142).
+///
+/// The reqwest client is built with explicit timeouts so a hung CDN cannot
+/// stall the fetch forever even off-lock (`reqwest::get` uses a default client
+/// with none).
+pub async fn fetch_and_decode(url: &str) -> anyhow::Result<image::DynamicImage> {
+  info!("getting new cover art image...");
+
+  let client = reqwest::Client::builder()
+    .connect_timeout(std::time::Duration::from_secs(10))
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .map_err(|e| anyhow!(e))?;
+
+  let res = client
+    .get(url)
+    .send()
+    .await
+    .and_then(|r| r.error_for_status());
+
+  let file = match res {
+    Ok(res) => {
+      // Allocate Vec "file" with capacity if content_length is provided
+      let mut file = match res.content_length() {
+        Some(s) => Vec::with_capacity(s as usize),
+        None => Vec::new(),
+      };
+
+      let bytes = res.bytes().await?;
+      file.extend_from_slice(&bytes);
+
+      debug!("finished reading response: {} bytes", file.len());
+      file
+    }
+    Err(e) => return Err(anyhow!(e)),
+  };
+
+  image::load_from_memory(&file).map_err(|e| anyhow!(e))
+}
+
+/// The decoded cover art for the current track, keyed by the request that
+/// produced it, plus its load status. Lives on `App` so any frontend can read
+/// it; the TUI caches its terminal protocols on [`Self::key`] and rebuilds
+/// them only when the key changes.
+#[derive(Default)]
+pub struct CoverArtStore {
+  art: Option<(String, image::DynamicImage)>,
+  /// Status of the current track's cover art, driving the placeholder message.
+  pub status: CoverArtStatus,
+}
+
+impl CoverArtStore {
+  /// The cache-identity key of the stored image (the URL or file URI it was
+  /// decoded from), if any art is loaded.
+  pub fn key(&self) -> Option<&str> {
+    self.art.as_ref().map(|(key, _)| key.as_str())
+  }
+
+  /// The decoded image, if any art is loaded. Read by whichever frontend
+  /// renders it; a decode-only build (`art-decode` without `cover-art`)
+  /// fetches art solely for the adaptive theme and has no reader.
+  #[cfg_attr(not(feature = "cover-art"), allow(dead_code))]
+  pub fn image(&self) -> Option<&image::DynamicImage> {
+    self.art.as_ref().map(|(_, image)| image)
+  }
+
+  pub fn available(&self) -> bool {
+    self.art.is_some()
+  }
+
+  /// Store an already-decoded image under its cache key, replacing whatever
+  /// was held. Cheap: the slow fetch/decode happens in [`fetch_and_decode`],
+  /// off the `App` lock.
+  pub fn store_decoded(&mut self, key: String, image: image::DynamicImage) {
+    info!("got new cover art: {key}");
+    self.art = Some((key, image));
+  }
+
+  /// Drop any stored cover art so the pane renders nothing. Used when
+  /// switching to a track/source with no art, or after a failed fetch, so
+  /// stale art from the previous track can never linger on screen.
+  pub fn clear(&mut self) {
+    self.art = None;
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn request_key_is_the_url() {
+    let request = CoverArtRequest::Url("https://img.example/cover.jpg".to_string());
+    assert_eq!(request.key(), "https://img.example/cover.jpg");
+  }
+
+  #[test]
+  fn store_replaces_and_clear_drops_the_held_art() {
+    let mut store = CoverArtStore::default();
+    assert!(!store.available());
+    assert_eq!(store.key(), None);
+
+    store.store_decoded("a".to_string(), image::DynamicImage::new_rgb8(1, 1));
+    assert!(store.available());
+    assert_eq!(store.key(), Some("a"));
+    assert!(store.image().is_some());
+
+    store.store_decoded("b".to_string(), image::DynamicImage::new_rgb8(2, 2));
+    assert_eq!(store.key(), Some("b"));
+
+    store.clear();
+    assert!(!store.available());
+    assert_eq!(store.key(), None);
+    assert!(store.image().is_none());
+  }
+}

--- a/src/core/art.rs
+++ b/src/core/art.rs
@@ -6,6 +6,31 @@
 
 use anyhow::anyhow;
 use log::{debug, info};
+use std::sync::OnceLock;
+
+/// Cap on a cover-art response body, checked against both the declared and
+/// the actual size. Real covers are a few hundred KiB; the cap only exists so
+/// a misbehaving server cannot make the app buffer an unbounded body (the
+/// decode needs it all in memory).
+const MAX_COVER_ART_BYTES: u64 = 16 * 1024 * 1024;
+
+static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// The process-wide cover-art HTTP client, so keep-alive connections to the
+/// art CDN are reused across track changes. Built fallibly *outside*
+/// `get_or_init` so a TLS setup failure surfaces as a fetch error instead of
+/// a panic; a lost build race just discards the extra client.
+fn client() -> anyhow::Result<&'static reqwest::Client> {
+  if let Some(client) = CLIENT.get() {
+    return Ok(client);
+  }
+  let client = reqwest::Client::builder()
+    .connect_timeout(std::time::Duration::from_secs(10))
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .map_err(|e| anyhow!(e))?;
+  Ok(CLIENT.get_or_init(|| client))
+}
 
 /// What to fetch for the current track's cover art. Built once per track change
 /// by the shared detector and handled off the `App` lock in the network layer.
@@ -65,40 +90,44 @@ pub enum CoverArtStatus {
 /// render loop — which locks the same mutex every frame — freezes for the
 /// whole CDN round-trip (#142).
 ///
-/// The reqwest client is built with explicit timeouts so a hung CDN cannot
-/// stall the fetch forever even off-lock (`reqwest::get` uses a default client
-/// with none).
+/// The shared client carries explicit timeouts so a hung CDN cannot stall the
+/// fetch forever even off-lock (`reqwest::get` uses a default client with
+/// none), and the body is read through a bounded loop: `content_length()` is
+/// only a hint and `bytes()` would buffer an arbitrarily large body, so the
+/// [`MAX_COVER_ART_BYTES`] cap is enforced on the declared size first and
+/// again while accumulating the actual bytes.
 pub async fn fetch_and_decode(url: &str) -> anyhow::Result<image::DynamicImage> {
   info!("getting new cover art image...");
 
-  let client = reqwest::Client::builder()
-    .connect_timeout(std::time::Duration::from_secs(10))
-    .timeout(std::time::Duration::from_secs(30))
-    .build()
-    .map_err(|e| anyhow!(e))?;
-
-  let res = client
+  let res = client()?
     .get(url)
     .send()
     .await
     .and_then(|r| r.error_for_status());
-
-  let file = match res {
-    Ok(res) => {
-      // Allocate Vec "file" with capacity if content_length is provided
-      let mut file = match res.content_length() {
-        Some(s) => Vec::with_capacity(s as usize),
-        None => Vec::new(),
-      };
-
-      let bytes = res.bytes().await?;
-      file.extend_from_slice(&bytes);
-
-      debug!("finished reading response: {} bytes", file.len());
-      file
-    }
+  let mut res = match res {
+    Ok(res) => res,
     Err(e) => return Err(anyhow!(e)),
   };
+
+  if let Some(declared) = res.content_length() {
+    if declared > MAX_COVER_ART_BYTES {
+      return Err(anyhow!(
+        "cover art response declares {declared} bytes (limit {MAX_COVER_ART_BYTES})"
+      ));
+    }
+  }
+
+  // The declared size only pre-allocates; the cap above bounds it.
+  let mut file = Vec::with_capacity(res.content_length().unwrap_or(0) as usize);
+  while let Some(chunk) = res.chunk().await.map_err(|e| anyhow!(e))? {
+    if (file.len() + chunk.len()) as u64 > MAX_COVER_ART_BYTES {
+      return Err(anyhow!(
+        "cover art response exceeded the {MAX_COVER_ART_BYTES}-byte limit"
+      ));
+    }
+    file.extend_from_slice(&chunk);
+  }
+  debug!("finished reading response: {} bytes", file.len());
 
   image::load_from_memory(&file).map_err(|e| anyhow!(e))
 }
@@ -152,6 +181,62 @@ impl CoverArtStore {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::io::{Read, Write};
+
+  /// Serve one hand-written HTTP response on a real loopback listener, so the
+  /// fetch path is exercised without any mock layer (house HTTP-test pattern).
+  fn one_shot_server(
+    response: impl FnOnce(&mut std::net::TcpStream) + Send + 'static,
+  ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = std::thread::spawn(move || {
+      let (mut stream, _) = listener.accept().unwrap();
+      // Read (some of) the request so the client sees a well-formed exchange.
+      let mut buf = [0u8; 1024];
+      let _ = stream.read(&mut buf);
+      response(&mut stream);
+    });
+    (addr, handle)
+  }
+
+  #[tokio::test]
+  async fn oversized_declared_cover_art_body_is_rejected() {
+    let (addr, server) = one_shot_server(|stream| {
+      let _ = stream.write_all(
+        b"HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\nContent-Type: image/jpeg\r\n\r\n",
+      );
+    });
+
+    let err = fetch_and_decode(&format!("http://{addr}/art.jpg"))
+      .await
+      .unwrap_err();
+    assert!(err.to_string().contains("declares"), "got: {err}");
+    server.join().unwrap();
+  }
+
+  #[tokio::test]
+  async fn cover_art_body_exceeding_the_cap_is_rejected_mid_read() {
+    let (addr, server) = one_shot_server(|stream| {
+      // No Content-Length, close-delimited body: the declared-size check
+      // cannot fire, so the accumulation cap has to. Write errors are
+      // expected once the client bails mid-body.
+      let _ = stream
+        .write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: image/jpeg\r\n\r\n");
+      let chunk = vec![0u8; 1024 * 1024];
+      for _ in 0..17 {
+        if stream.write_all(&chunk).is_err() {
+          break;
+        }
+      }
+    });
+
+    let err = fetch_and_decode(&format!("http://{addr}/art.jpg"))
+      .await
+      .unwrap_err();
+    assert!(err.to_string().contains("exceeded"), "got: {err}");
+    let _ = server.join();
+  }
 
   #[test]
   fn request_key_is_the_url() {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,8 +1,10 @@
 pub mod app;
+#[cfg(feature = "art-decode")]
+pub mod art;
 pub mod auth;
 pub mod banner;
 pub mod config;
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 pub mod cover_theme;
 pub mod first_run;
 pub mod format;

--- a/src/core/user_config.rs
+++ b/src/core/user_config.rs
@@ -13,12 +13,12 @@ const FILE_NAME: &str = "config.yml";
 pub const DEFAULT_TICK_RATE_MILLISECONDS: u64 = 250;
 pub const DEFAULT_ANIMATION_TICK_RATE_MILLISECONDS: u64 = 16;
 pub const MAX_TICK_RATE_MILLISECONDS: u64 = 999;
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 pub const MIN_PLAYBAR_COVER_ART_SIZE_PERCENT: u16 = 25;
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 pub const MAX_PLAYBAR_COVER_ART_SIZE_PERCENT: u16 = 200;
 
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 pub fn clamp_playbar_cover_art_size_percent(value: u16) -> u16 {
   value.clamp(
     MIN_PLAYBAR_COVER_ART_SIZE_PERCENT,
@@ -26,6 +26,9 @@ pub fn clamp_playbar_cover_art_size_percent(value: u16) -> u16 {
   )
 }
 
+// Only the settings arm for the playbar size (a render-side setting) calls
+// this, so it follows `cover-art` while its `clamp` sibling stays with the
+// decode half for config loading.
 #[cfg(feature = "cover-art")]
 pub fn normalize_playbar_cover_art_size_percent(value: i64) -> u16 {
   value.clamp(
@@ -454,13 +457,13 @@ pub struct BehaviorConfigString {
   pub startup_behavior: Option<StartupBehavior>,
   pub disable_auto_update: Option<bool>,
   pub auto_update_delay: Option<String>,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub draw_cover_art: Option<bool>,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub draw_cover_art_forced: Option<bool>,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub playbar_cover_art_size_percent: Option<u16>,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub cover_art_theme: Option<bool>,
   #[cfg(feature = "mcp-server")]
   pub mcp_enabled: Option<bool>,
@@ -570,15 +573,15 @@ pub struct BehaviorConfig {
   pub startup_behavior: StartupBehavior,
   pub disable_auto_update: bool,
   pub auto_update_delay: String,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub draw_cover_art: bool,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub draw_cover_art_forced: bool,
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub playbar_cover_art_size_percent: u16,
   /// Recolor the UI accents from the current track's cover art, fading on
   /// track change. Off by default so a chosen preset stays untouched.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub cover_art_theme: bool,
   /// Whether to open the local MCP control socket so `spotatui mcp` (and through
   /// it Claude Code, Codex, or any MCP client) can drive playback.
@@ -1016,13 +1019,13 @@ impl UserConfig {
         startup_behavior: StartupBehavior::Continue,
         disable_auto_update: false,
         auto_update_delay: "0".to_string(),
-        #[cfg(feature = "cover-art")]
+        #[cfg(feature = "art-decode")]
         draw_cover_art: true,
-        #[cfg(feature = "cover-art")]
+        #[cfg(feature = "art-decode")]
         draw_cover_art_forced: false,
-        #[cfg(feature = "cover-art")]
+        #[cfg(feature = "art-decode")]
         playbar_cover_art_size_percent: 100,
-        #[cfg(feature = "cover-art")]
+        #[cfg(feature = "art-decode")]
         cover_art_theme: false,
         #[cfg(feature = "mcp-server")]
         mcp_enabled: false,
@@ -1462,21 +1465,21 @@ impl UserConfig {
       self.behavior.auto_update_delay = auto_update_delay;
     }
 
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if let Some(draw_cover_art) = behavior_config.draw_cover_art {
       self.behavior.draw_cover_art = draw_cover_art;
     }
 
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if let Some(draw_cover_art_forced) = behavior_config.draw_cover_art_forced {
       self.behavior.draw_cover_art_forced = draw_cover_art_forced;
     }
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if let Some(playbar_cover_art_size_percent) = behavior_config.playbar_cover_art_size_percent {
       self.behavior.playbar_cover_art_size_percent =
         clamp_playbar_cover_art_size_percent(playbar_cover_art_size_percent);
     }
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if let Some(cover_art_theme) = behavior_config.cover_art_theme {
       self.behavior.cover_art_theme = cover_art_theme;
     }
@@ -2049,13 +2052,13 @@ impl UserConfig {
       startup_behavior: Some(self.behavior.startup_behavior),
       disable_auto_update: Some(self.behavior.disable_auto_update),
       auto_update_delay: Some(self.behavior.auto_update_delay.clone()),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       draw_cover_art: Some(self.behavior.draw_cover_art),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       draw_cover_art_forced: Some(self.behavior.draw_cover_art_forced),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       playbar_cover_art_size_percent: Some(self.behavior.playbar_cover_art_size_percent),
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       cover_art_theme: Some(self.behavior.cover_art_theme),
       #[cfg(feature = "mcp-server")]
       mcp_enabled: Some(self.behavior.mcp_enabled),
@@ -2285,7 +2288,7 @@ impl UserConfig {
   pub fn padded_playing_icon(&self) -> String {
     format!("{} ", self.behavior.playing_icon)
   }
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn do_draw_cover_art(&self, full_image_support: bool) -> bool {
     self.behavior.draw_cover_art && (self.behavior.draw_cover_art_forced || full_image_support)
   }
@@ -2294,7 +2297,7 @@ impl UserConfig {
   /// or the adaptive theme, which extracts its palette from the decoded image
   /// even when the pane itself is hidden (disabled, or a terminal without
   /// image support). Draw sites keep their own `do_draw_cover_art` gate.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   pub fn needs_cover_art(&self, full_image_support: bool) -> bool {
     self.do_draw_cover_art(full_image_support) || self.behavior.cover_art_theme
   }
@@ -2690,7 +2693,7 @@ mod tests {
     assert!(config.load_behaviorconfig(behavior).is_err());
   }
 
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   #[test]
   fn missing_playbar_cover_art_size_keeps_default() {
     use super::{BehaviorConfigString, UserConfig};
@@ -2702,7 +2705,7 @@ mod tests {
     assert_eq!(config.behavior.playbar_cover_art_size_percent, 100);
   }
 
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   #[test]
   fn playbar_cover_art_size_loads_from_yaml() {
     use super::{BehaviorConfigString, UserConfig};
@@ -2715,7 +2718,7 @@ mod tests {
     assert_eq!(config.behavior.playbar_cover_art_size_percent, 150);
   }
 
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   #[test]
   fn playbar_cover_art_size_clamps_out_of_range_values() {
     use super::{BehaviorConfigString, UserConfig};

--- a/src/infra/local/mod.rs
+++ b/src/infra/local/mod.rs
@@ -503,9 +503,9 @@ pub(crate) fn file_uri_to_path(uri: &str) -> Result<PathBuf> {
 /// and image decode), so callers must run this on a blocking thread rather than
 /// the async runtime. Returns an error when the file has no embedded artwork.
 ///
-/// Gated on both `local-files` (for `lofty`) and `cover-art` (for `image`), so
+/// Gated on both `local-files` (for `lofty`) and `art-decode` (for `image`), so
 /// builds enabling only one of them do not pull in the other's dependency.
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 pub(crate) fn extract_embedded_cover(path: &Path) -> Result<image::DynamicImage> {
   let tagged = read_from_path(path).with_context(|| format!("reading tags from {:?}", path))?;
   let tag = tagged

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -283,8 +283,8 @@ pub enum IoEvent {
   /// track-change detector; handled off the `App` lock so the render loop never
   /// blocks on the download/decode. Source-agnostic and independent of Spotify
   /// auth.
-  #[cfg(feature = "cover-art")]
-  FetchCoverArt(crate::tui::cover_art::CoverArtRequest),
+  #[cfg(feature = "art-decode")]
+  FetchCoverArt(crate::core::art::CoverArtRequest),
   /// A DJ tool call that needs the live Spotify client, plus the channel to
   /// answer on.
   ///
@@ -445,7 +445,7 @@ impl Network {
   /// source dispatchers handle upstream (only reaching here as no-ops when their
   /// feature is disabled).
   fn event_bypasses_spotify_auth(io_event: &IoEvent) -> bool {
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if matches!(io_event, IoEvent::FetchCoverArt(_)) {
       return true;
     }
@@ -524,7 +524,7 @@ impl Network {
     if !Self::event_bypasses_spotify_auth(io_event) {
       return false;
     }
-    #[cfg(feature = "cover-art")]
+    #[cfg(feature = "art-decode")]
     if matches!(io_event, IoEvent::FetchCoverArt(_)) {
       return true;
     }
@@ -877,7 +877,7 @@ impl Network {
       IoEvent::GetLyrics(track, artists, duration) => {
         self.get_lyrics(track, artists, duration).await;
       }
-      #[cfg(feature = "cover-art")]
+      #[cfg(feature = "art-decode")]
       IoEvent::FetchCoverArt(request) => {
         self.fetch_cover_art(request).await;
       }

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -84,8 +84,8 @@ pub trait PlaybackNetwork {
   async fn add_item_to_queue(&mut self, item: PlayableId<'static>);
   async fn get_queue(&mut self);
   /// Fetch, decode and store the current track's cover art (off the `App` lock).
-  #[cfg(feature = "cover-art")]
-  async fn fetch_cover_art(&mut self, request: crate::tui::cover_art::CoverArtRequest);
+  #[cfg(feature = "art-decode")]
+  async fn fetch_cover_art(&mut self, request: crate::core::art::CoverArtRequest);
 }
 
 fn trim_api_playback_uris(
@@ -1282,10 +1282,9 @@ impl PlaybackNetwork for Network {
   /// store the finished image and update the status. Cover art is non-essential,
   /// so a failure only logs and flips the status to `Failed` (never surfaces a
   /// blocking error).
-  #[cfg(feature = "cover-art")]
-  async fn fetch_cover_art(&mut self, request: crate::tui::cover_art::CoverArtRequest) {
-    use crate::core::app::CoverArtStatus;
-    use crate::tui::cover_art::{CoverArt, CoverArtRequest};
+  #[cfg(feature = "art-decode")]
+  async fn fetch_cover_art(&mut self, request: crate::core::art::CoverArtRequest) {
+    use crate::core::art::{fetch_and_decode, CoverArtRequest, CoverArtStatus};
 
     let key = request.key().to_string();
 
@@ -1296,14 +1295,14 @@ impl PlaybackNetwork for Network {
       if app.desired_cover_art_key.as_deref() != Some(key.as_str()) {
         return;
       }
-      if app.cover_art.get_url().as_deref() == Some(key.as_str()) {
-        app.cover_art_status = CoverArtStatus::Loaded;
+      if app.cover_art.key() == Some(key.as_str()) {
+        app.cover_art.status = CoverArtStatus::Loaded;
         return;
       }
     }
 
     let result = match request {
-      CoverArtRequest::Url(url) => CoverArt::fetch_and_decode(&url).await,
+      CoverArtRequest::Url(url) => fetch_and_decode(&url).await,
       #[cfg(feature = "local-files")]
       CoverArtRequest::LocalFile { path, .. } => {
         // Tag read + image decode are blocking; keep them off the async runtime.
@@ -1332,14 +1331,14 @@ impl PlaybackNetwork for Network {
     match result {
       Ok(img) => {
         app.store_cover_art(key, img, palette);
-        app.cover_art_status = CoverArtStatus::Loaded;
+        app.cover_art.status = CoverArtStatus::Loaded;
       }
       Err(err) => {
         log::warn!("cover art load failed: {err}");
         // Drop any stale art so the pane shows the "unavailable" placeholder
         // rather than the previous track's image.
         app.clear_cover_art();
-        app.cover_art_status = CoverArtStatus::Failed;
+        app.cover_art.status = CoverArtStatus::Failed;
       }
     }
   }

--- a/src/tui/cover_art.rs
+++ b/src/tui/cover_art.rs
@@ -17,7 +17,7 @@ use ratatui_image::{
   protocol::StatefulProtocol,
   Resize, StatefulImage,
 };
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 
 /// The message shown in place of the image when none is loaded, so "no art"
 /// always reads as a deliberate outcome rather than a blank pane. Shared by the
@@ -88,7 +88,7 @@ pub fn sync(store: &CoverArtStore) {
     return;
   };
   for surface in [&renderer.playbar, &renderer.fullscreen, &renderer.plugin] {
-    let mut lock = surface.lock().unwrap();
+    let mut lock = lock_surface(surface);
     let stale = lock
       .as_ref()
       .is_some_and(|surface| store.key() != Some(surface.key.as_str()));
@@ -157,6 +157,14 @@ struct Surface {
   protocol: StatefulProtocol,
 }
 
+/// Lock a surface's protocol cache, recovering a poisoned guard: the caches
+/// are pure derived state (rebuilt from the store at the next render), so a
+/// panic that unwound while a guard was held must not turn every later frame
+/// into a poison panic.
+fn lock_surface(surface: &Mutex<Option<Surface>>) -> MutexGuard<'_, Option<Surface>> {
+  surface.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
 impl CoverArtRenderer {
   fn new(picker: Picker) -> Self {
     Self {
@@ -183,7 +191,7 @@ impl CoverArtRenderer {
     surface: &'a Mutex<Option<Surface>>,
     store: &CoverArtStore,
   ) -> MutexGuard<'a, Option<Surface>> {
-    let mut lock = surface.lock().unwrap();
+    let mut lock = lock_surface(surface);
     match store.key() {
       None => *lock = None,
       Some(key) => {

--- a/src/tui/cover_art.rs
+++ b/src/tui/cover_art.rs
@@ -1,7 +1,13 @@
-use crate::core::app::CoverArtStatus;
+//! Terminal rendering for the decoded cover art held in
+//! `core::art::CoverArtStore`. This is the only place the store's image meets
+//! `ratatui-image`: a process-wide renderer owns the `Picker` (probed once in
+//! `start_ui`, after `ratatui::init()`, so `App` construction never touches
+//! stdout) and caches one `StatefulProtocol` per drawing surface, keyed by the
+//! store's key — a protocol is rebuilt when the art changes, never per frame.
+
+use crate::core::art::{CoverArtStatus, CoverArtStore};
 use crate::core::plugin_api::PluginCoverArtFit;
-use anyhow::anyhow;
-use log::{debug, info, warn};
+use log::{info, warn};
 use ratatui::{
   layout::{Rect, Size},
   Frame,
@@ -11,36 +17,7 @@ use ratatui_image::{
   protocol::StatefulProtocol,
   Resize, StatefulImage,
 };
-use std::sync::Mutex;
-
-/// What to fetch for the current track's cover art. Built once per track change
-/// by the shared detector and handled off the `App` lock in the network layer.
-#[derive(Clone, Debug)]
-pub enum CoverArtRequest {
-  /// Download and decode an image from a URL (Spotify album art, YouTube
-  /// thumbnail, Subsonic getCoverArt).
-  Url(String),
-  /// Read the embedded cover picture out of a local audio file. `key` is the
-  /// track's `file://` URI (used as the cache identity); `path` is the resolved
-  /// filesystem path handed to the blocking tag reader.
-  #[cfg(feature = "local-files")]
-  LocalFile {
-    key: String,
-    path: std::path::PathBuf,
-  },
-}
-
-impl CoverArtRequest {
-  /// The cache-identity key for this request: the image URL, or the file URI.
-  /// Used to skip re-fetching art already held for the same track.
-  pub fn key(&self) -> &str {
-    match self {
-      CoverArtRequest::Url(url) => url,
-      #[cfg(feature = "local-files")]
-      CoverArtRequest::LocalFile { key, .. } => key,
-    }
-  }
-}
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 /// The message shown in place of the image when none is loaded, so "no art"
 /// always reads as a deliberate outcome rather than a blank pane. Shared by the
@@ -65,192 +42,193 @@ impl PluginCoverArtFit {
   }
 }
 
-pub struct CoverArt {
-  pub state: Mutex<Option<CoverArtState>>,
-  /// Separate protocol state for fullscreen cover art view, avoiding conflicts
-  /// when the same image is rendered in both the playbar and fullscreen in one frame.
-  pub fullscreen_state: Mutex<Option<CoverArtState>>,
-  /// Separate protocol state for a plugin screen's `cover_art` widget, for the
-  /// same reason: a plugin can size its image differently from the playbar, and
-  /// a shared protocol would re-encode on every switch between them.
-  pub plugin_state: Mutex<Option<CoverArtState>>,
-  picker: Picker,
-}
+/// One renderer per process: the picker describes the one terminal this
+/// process draws to. Until [`init_renderer`] runs, every render below is a
+/// no-op and [`full_image_support`] reports false.
+static RENDERER: OnceLock<CoverArtRenderer> = OnceLock::new();
 
-pub struct CoverArtState {
-  url: String,
-  image: StatefulProtocol,
-}
-
-impl CoverArtState {
-  fn new(url: String, image: StatefulProtocol) -> Self {
-    Self { url, image }
-  }
-}
-
-impl CoverArt {
-  pub fn new() -> Self {
+/// Probe the terminal for its image protocol and install the process-wide
+/// renderer. Called from `start_ui` after `ratatui::init()`: the probe is a
+/// stdio round-trip and must not run during `App` construction.
+pub fn init_renderer() {
+  RENDERER.get_or_init(|| {
     let picker = Picker::from_query_stdio().unwrap_or_else(|err| {
       warn!("cover art renderer fallback to halfblocks: {err}");
       Picker::halfblocks()
     });
 
     info!(
-      "cover art rendered detected a {:?} backend",
+      "cover art renderer detected a {:?} backend",
       picker.protocol_type()
     );
+    CoverArtRenderer::new(picker)
+  });
+}
+
+/// Install a halfblocks renderer without probing stdio, so `TestBackend`
+/// tests can render actual image cells.
+#[cfg(test)]
+pub fn init_test_renderer() {
+  RENDERER.get_or_init(|| CoverArtRenderer::new(Picker::halfblocks()));
+}
+
+/// Whether the detected terminal draws real pixels (Kitty/iTerm2/Sixel) as
+/// opposed to the halfblocks character fallback.
+pub fn full_image_support() -> bool {
+  RENDERER
+    .get()
+    .is_some_and(CoverArtRenderer::full_image_support)
+}
+
+/// Drop cached protocols that no longer match the store, so cleared art
+/// releases its memory even while no cover surface is being drawn. Called once
+/// per frame by the runner; rebuilds happen lazily at the next render.
+pub fn sync(store: &CoverArtStore) {
+  let Some(renderer) = RENDERER.get() else {
+    return;
+  };
+  for surface in [&renderer.playbar, &renderer.fullscreen, &renderer.plugin] {
+    let mut lock = surface.lock().unwrap();
+    let stale = lock
+      .as_ref()
+      .is_some_and(|surface| store.key() != Some(surface.key.as_str()));
+    if stale {
+      *lock = None;
+    }
+  }
+}
+
+/// Render into the playbar's cover slot.
+pub fn render(f: &mut Frame, area: Rect, store: &CoverArtStore) {
+  if let Some(renderer) = RENDERER.get() {
+    renderer.render_surface(&renderer.playbar, f, area, Resize::Fit(None), store);
+  }
+}
+
+/// Measure the playbar image's fitted size, so the layout can size its slot.
+pub fn size_for(area: Rect, store: &CoverArtStore) -> Option<Rect> {
+  let renderer = RENDERER.get()?;
+  renderer.surface_size_for(&renderer.playbar, area, Resize::Fit(None), store)
+}
+
+/// Render into the fullscreen cover art view.
+pub fn render_fullscreen(f: &mut Frame, area: Rect, store: &CoverArtStore) {
+  if let Some(renderer) = RENDERER.get() {
+    renderer.render_surface(&renderer.fullscreen, f, area, Resize::Fit(None), store);
+  }
+}
+
+/// Measure the fullscreen image's fitted size, so the caller can center it.
+pub fn fullscreen_size_for(area: Rect, store: &CoverArtStore) -> Option<Rect> {
+  let renderer = RENDERER.get()?;
+  renderer.surface_size_for(&renderer.fullscreen, area, Resize::Fit(None), store)
+}
+
+/// Render into a plugin screen's `cover_art` widget slot.
+pub fn render_plugin(f: &mut Frame, area: Rect, fit: PluginCoverArtFit, store: &CoverArtStore) {
+  if let Some(renderer) = RENDERER.get() {
+    renderer.render_surface(&renderer.plugin, f, area, fit.resize(), store);
+  }
+}
+
+/// Measure the plugin slot's fitted size, so the caller can center it.
+pub fn plugin_size_for(area: Rect, fit: PluginCoverArtFit, store: &CoverArtStore) -> Option<Rect> {
+  let renderer = RENDERER.get()?;
+  renderer.surface_size_for(&renderer.plugin, area, fit.resize(), store)
+}
+
+struct CoverArtRenderer {
+  picker: Picker,
+  /// Playbar protocol state.
+  playbar: Mutex<Option<Surface>>,
+  /// Separate protocol state for the fullscreen cover art view, avoiding
+  /// conflicts when the same image is rendered in both the playbar and
+  /// fullscreen in one frame.
+  fullscreen: Mutex<Option<Surface>>,
+  /// Separate protocol state for a plugin screen's `cover_art` widget, for the
+  /// same reason: a plugin can size its image differently from the playbar, and
+  /// a shared protocol would re-encode on every switch between them.
+  plugin: Mutex<Option<Surface>>,
+}
+
+/// A surface's cached protocol together with the store key it was built from.
+struct Surface {
+  key: String,
+  protocol: StatefulProtocol,
+}
+
+impl CoverArtRenderer {
+  fn new(picker: Picker) -> Self {
     Self {
       picker,
-      state: Mutex::new(None),
-      fullscreen_state: Mutex::new(None),
-      plugin_state: Mutex::new(None),
+      playbar: Mutex::new(None),
+      fullscreen: Mutex::new(None),
+      plugin: Mutex::new(None),
     }
   }
 
-  pub fn full_image_support(&self) -> bool {
+  fn full_image_support(&self) -> bool {
     match self.picker.protocol_type() {
       ProtocolType::Kitty | ProtocolType::Iterm2 | ProtocolType::Sixel => true,
       ProtocolType::Halfblocks => false,
     }
   }
 
-  pub fn get_url(&self) -> Option<String> {
-    self.state.lock().unwrap().as_ref().map(|s| s.url.clone())
-  }
-
-  pub fn set_state(&self, state: CoverArtState) {
-    let mut lock = self.state.lock().unwrap();
-    *lock = Some(state);
-  }
-
-  /// Downloads and decodes the cover-art image at `url`, off any external lock.
-  ///
-  /// This is a **self-free associated function** on purpose: it borrows neither
-  /// `self` nor any `App` state, so its `.await` points can be reached with the
-  /// `App` mutex fully dropped. The network fetch and the (synchronous, CPU-bound)
-  /// image decode are the expensive parts and must never run while the `App`
-  /// guard is held, or the render loop — which locks the same mutex every frame —
-  /// freezes for the whole CDN round-trip (#142).
-  ///
-  /// The reqwest client is built with explicit timeouts so a hung CDN cannot
-  /// stall the fetch forever even off-lock (`reqwest::get` uses a default client
-  /// with none).
-  pub async fn fetch_and_decode(url: &str) -> anyhow::Result<image::DynamicImage> {
-    info!("getting new cover art image...");
-
-    let client = reqwest::Client::builder()
-      .connect_timeout(std::time::Duration::from_secs(10))
-      .timeout(std::time::Duration::from_secs(30))
-      .build()
-      .map_err(|e| anyhow!(e))?;
-
-    let res = client
-      .get(url)
-      .send()
-      .await
-      .and_then(|r| r.error_for_status());
-
-    let file = match res {
-      Ok(res) => {
-        // Allocate Vec "file" with capacity if content_length is provided
-        let mut file = match res.content_length() {
-          Some(s) => Vec::with_capacity(s as usize),
-          None => Vec::new(),
-        };
-
-        let bytes = res.bytes().await?;
-        file.extend_from_slice(&bytes);
-
-        debug!("finished reading response: {} bytes", file.len());
-        file
+  /// Reconcile a surface's cached protocol with the store: rebuild it when the
+  /// store holds art under a different key, drop it when the store is empty.
+  /// This is the per-key cache that keeps a protocol from being rebuilt for a
+  /// frame that renders the same art.
+  fn ensure<'a>(
+    &self,
+    surface: &'a Mutex<Option<Surface>>,
+    store: &CoverArtStore,
+  ) -> MutexGuard<'a, Option<Surface>> {
+    let mut lock = surface.lock().unwrap();
+    match store.key() {
+      None => *lock = None,
+      Some(key) => {
+        let cached = lock.as_ref().is_some_and(|surface| surface.key == key);
+        if !cached {
+          if let Some(image) = store.image() {
+            *lock = Some(Surface {
+              key: key.to_string(),
+              protocol: self.picker.new_resize_protocol(image.clone()),
+            });
+          }
+        }
       }
-      Err(e) => return Err(anyhow!(e)),
-    };
-
-    image::load_from_memory(&file).map_err(|e| anyhow!(e))
-  }
-
-  /// Stores an already-decoded cover-art image into playbar + fullscreen state.
-  ///
-  /// Synchronous and cheap: `new_resize_protocol` defers the actual encoding to
-  /// render time. Call this under the (briefly re-acquired) `App` guard after
-  /// [`fetch_and_decode`] has done the slow work off-lock.
-  pub fn store_decoded(&self, url: String, img: image::DynamicImage) {
-    // Create separate protocol instances so the playbar, fullscreen view and a
-    // plugin screen's cover_art widget can render independently without
-    // conflicting. All three are set here and dropped together in `clear`;
-    // callers rely on that lockstep (`available`/`get_url` only read `state`).
-    let image_protocol = self.picker.new_resize_protocol(img.clone());
-    let fullscreen_protocol = self.picker.new_resize_protocol(img.clone());
-    let plugin_protocol = self.picker.new_resize_protocol(img);
-
-    self.set_state(CoverArtState::new(url.clone(), image_protocol));
-    {
-      let mut lock = self.fullscreen_state.lock().unwrap();
-      *lock = Some(CoverArtState::new(url.clone(), fullscreen_protocol));
     }
-    {
-      let mut lock = self.plugin_state.lock().unwrap();
-      *lock = Some(CoverArtState::new(url.clone(), plugin_protocol));
-    }
-    info!("got new cover art: {url}");
+    lock
   }
 
-  pub fn available(&self) -> bool {
-    self.state.lock().unwrap().is_some()
-  }
-
-  /// Drop any stored cover art (playbar, fullscreen and plugin protocol state)
-  /// so the pane renders nothing. Used when switching to a track/source with no
-  /// art, or after a failed fetch, so stale art from the previous track can
-  /// never linger on screen.
-  pub fn clear(&self) {
-    *self.state.lock().unwrap() = None;
-    *self.fullscreen_state.lock().unwrap() = None;
-    *self.plugin_state.lock().unwrap() = None;
-  }
-
-  pub fn render(&self, f: &mut Frame, area: Rect) {
-    Self::render_state(&self.state, f, area, Resize::Fit(None));
-  }
-
-  pub fn size_for(&self, area: Rect) -> Option<Rect> {
-    Self::size_for_state(&self.state, area, Resize::Fit(None))
-  }
-
-  pub fn render_fullscreen(&self, f: &mut Frame, area: Rect) {
-    Self::render_state(&self.fullscreen_state, f, area, Resize::Fit(None));
-  }
-
-  pub fn fullscreen_size_for(&self, area: Rect) -> Option<Rect> {
-    Self::size_for_state(&self.fullscreen_state, area, Resize::Fit(None))
-  }
-
-  /// Render into a plugin screen's `cover_art` widget slot.
-  pub fn render_plugin(&self, f: &mut Frame, area: Rect, fit: PluginCoverArtFit) {
-    Self::render_state(&self.plugin_state, f, area, fit.resize());
-  }
-
-  /// Measure the plugin slot's fitted size, so the caller can center it.
-  pub fn plugin_size_for(&self, area: Rect, fit: PluginCoverArtFit) -> Option<Rect> {
-    Self::size_for_state(&self.plugin_state, area, fit.resize())
-  }
-
-  fn render_state(state: &Mutex<Option<CoverArtState>>, f: &mut Frame, area: Rect, resize: Resize) {
-    let mut lock = state.lock().unwrap();
-    if let Some(sp) = lock.as_mut() {
-      f.render_stateful_widget(StatefulImage::new().resize(resize), area, &mut sp.image);
-    }
-  }
-
-  fn size_for_state(
-    state: &Mutex<Option<CoverArtState>>,
+  fn render_surface(
+    &self,
+    surface: &Mutex<Option<Surface>>,
+    f: &mut Frame,
     area: Rect,
     resize: Resize,
+    store: &CoverArtStore,
+  ) {
+    let mut lock = self.ensure(surface, store);
+    if let Some(surface) = lock.as_mut() {
+      f.render_stateful_widget(
+        StatefulImage::new().resize(resize),
+        area,
+        &mut surface.protocol,
+      );
+    }
+  }
+
+  fn surface_size_for(
+    &self,
+    surface: &Mutex<Option<Surface>>,
+    area: Rect,
+    resize: Resize,
+    store: &CoverArtStore,
   ) -> Option<Rect> {
-    let lock = state.lock().unwrap();
-    lock.as_ref().map(|sp| {
-      let size = sp.image.size_for(
+    let lock = self.ensure(surface, store);
+    lock.as_ref().map(|surface| {
+      let size = surface.protocol.size_for(
         resize,
         Size {
           width: area.width,

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -188,12 +188,12 @@ fn track_identity(snapshot: &crate::infra::media_metadata::PlaybackSnapshot) -> 
 /// art (Spotify album art, YouTube thumbnail, Subsonic getCoverArt) surfaces it
 /// as `snapshot.metadata.image_url`. `None` means the current track has no art
 /// to show (e.g. internet radio, or a Spotify item without images).
-#[cfg(feature = "cover-art")]
+#[cfg(feature = "art-decode")]
 fn cover_art_request_for(
   app: &App,
   snapshot: &crate::infra::media_metadata::PlaybackSnapshot,
-) -> Option<crate::tui::cover_art::CoverArtRequest> {
-  use crate::tui::cover_art::CoverArtRequest;
+) -> Option<crate::core::art::CoverArtRequest> {
+  use crate::core::art::CoverArtRequest;
 
   #[cfg(feature = "local-files")]
   if let Some(local) = app.local_playback.as_ref() {
@@ -212,6 +212,21 @@ fn cover_art_request_for(
     .image_url
     .clone()
     .map(CoverArtRequest::Url)
+}
+
+/// Whether the terminal renders real pixels. False until the renderer is
+/// initialized, and always false in a decode-only build (`art-decode` without
+/// `cover-art`), where art is fetched solely for the adaptive theme.
+#[cfg(feature = "art-decode")]
+fn cover_art_full_image_support() -> bool {
+  #[cfg(feature = "cover-art")]
+  {
+    crate::tui::cover_art::full_image_support()
+  }
+  #[cfg(not(feature = "cover-art"))]
+  {
+    false
+  }
 }
 
 fn playback_window_title(app: &App) -> String {
@@ -738,6 +753,10 @@ pub async fn start_ui(
   let _ = &mpris_manager;
 
   let mut terminal = ratatui::init();
+  // Probe the terminal's image protocol only now that the terminal is set up;
+  // `App` construction must not touch stdout.
+  #[cfg(feature = "cover-art")]
+  crate::tui::cover_art::init_renderer();
   execute!(stdout(), EnableMouseCapture)?;
   let keyboard_enhancement_supported = supports_keyboard_enhancement().unwrap_or(false);
   let keyboard_enhancement_enabled = keyboard_enhancement_supported
@@ -780,7 +799,7 @@ pub async fn start_ui(
   let mut last_track_identity: Option<TrackIdentity> = None;
   // Cache key (URL / file URI) of the cover art last requested, so the per-tick
   // cover-art evaluation dispatches a fetch only when the resolved art changes.
-  #[cfg(feature = "cover-art")]
+  #[cfg(feature = "art-decode")]
   let mut last_cover_art_key: Option<String> = None;
   let mut is_first_render = true;
 
@@ -907,6 +926,11 @@ pub async fn start_ui(
         app.user_config.behavior.tick_rate_milliseconds
       };
       events.set_tick_rate(current_tick_rate);
+
+      // Drop protocol caches for art the store no longer holds; rebuilds are
+      // lazy, so this is a no-op whenever the art is unchanged.
+      #[cfg(feature = "cover-art")]
+      crate::tui::cover_art::sync(&app.cover_art);
 
       terminal.draw(|f| {
         use ratatui::{prelude::Style, widgets::Block};
@@ -1105,12 +1129,12 @@ pub async fn start_ui(
           // stuck or missing until restart. Comparing against
           // `last_cover_art_key` keeps this a no-op on quiet ticks and fires
           // exactly once whenever the resolved art actually changes.
-          #[cfg(feature = "cover-art")]
+          #[cfg(feature = "art-decode")]
           {
-            use crate::core::app::CoverArtStatus;
+            use crate::core::art::CoverArtStatus;
             let enabled = app
               .user_config
-              .needs_cover_art(app.cover_art.full_image_support());
+              .needs_cover_art(cover_art_full_image_support());
             let desired = if enabled {
               snapshot
                 .as_ref()
@@ -1125,7 +1149,7 @@ pub async fn start_ui(
                   last_cover_art_key = Some(request.key().to_string());
                   // Keep the previous image on screen until the new one
                   // resolves (smooth swap); the fetch runs off-lock.
-                  app.cover_art_status = CoverArtStatus::Loading;
+                  app.cover_art.status = CoverArtStatus::Loading;
                   app.dispatch(IoEvent::FetchCoverArt(request));
                 }
               }
@@ -1136,7 +1160,7 @@ pub async fn start_ui(
                 if last_cover_art_key.take().is_some() || app.cover_art.available() {
                   app.clear_cover_art();
                 }
-                app.cover_art_status = if enabled && snapshot.is_some() {
+                app.cover_art.status = if enabled && snapshot.is_some() {
                   CoverArtStatus::Unavailable
                 } else {
                   CoverArtStatus::NotStarted

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -162,13 +162,15 @@ fn playbar_layout_areas(app: &App, layout_chunk: Rect) -> PlaybarLayoutAreas {
 
     let (other, cover_art) = if app
       .user_config
-      .do_draw_cover_art(app.cover_art.full_image_support())
+      .do_draw_cover_art(crate::tui::cover_art::full_image_support())
     {
       let cover_layout = playbar_cover_layout(
         other,
         app.user_config.behavior.playbar_cover_art_size_percent,
       );
-      if let Some(rendered_size) = app.cover_art.size_for(cover_layout.image_area) {
+      if let Some(rendered_size) =
+        crate::tui::cover_art::size_for(cover_layout.image_area, &app.cover_art)
+      {
         let cover_layout = cover_layout.with_rendered_size(rendered_size);
         let (artist_area, controls_area, progress_area) = split_cover_playbar_rows(
           other,
@@ -721,7 +723,7 @@ fn draw_cover_art_content(f: &mut Frame<'_>, app: &App, area: Rect) {
   if !app.cover_art.available() {
     // No image is loaded: show an explicit message for the current state rather
     // than a blank pane, so "no art" always reads as a deliberate outcome.
-    let message = crate::tui::cover_art::status_message(app.cover_art_status);
+    let message = crate::tui::cover_art::status_message(app.cover_art.status);
     let p = Paragraph::new(message)
       .style(Style::default().fg(app.user_config.theme.inactive.into()))
       .alignment(Alignment::Center);
@@ -756,13 +758,12 @@ fn draw_cover_art_content(f: &mut Frame<'_>, app: &App, area: Rect) {
     image_bounds.width.saturating_sub(2),
     image_bounds.height.saturating_sub(2),
   );
-  let fitted_image_size = app
-    .cover_art
-    .fullscreen_size_for(available_image_size)
-    .unwrap_or(available_image_size);
+  let fitted_image_size =
+    crate::tui::cover_art::fullscreen_size_for(available_image_size, &app.cover_art)
+      .unwrap_or(available_image_size);
   let centered_area = center_rect_within(image_bounds, fitted_image_size);
 
-  app.cover_art.render_fullscreen(f, centered_area);
+  crate::tui::cover_art::render_fullscreen(f, centered_area, &app.cover_art);
 
   // Draw song info below the cover art
   if let Some(name) = track_name {
@@ -1114,7 +1115,7 @@ fn render_local_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect, view: 
   // a blank indent where the image belongs (Spotify's path does the same).
   #[cfg(feature = "cover-art")]
   if let Some(cover_art) = playbar_areas.cover_art {
-    app.cover_art.render(f, cover_art);
+    crate::tui::cover_art::render(f, cover_art, &app.cover_art);
   }
 }
 
@@ -1444,7 +1445,7 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
 
       #[cfg(feature = "cover-art")]
       if let Some(cover_art) = playbar_areas.cover_art {
-        app.cover_art.render(f, cover_art);
+        crate::tui::cover_art::render(f, cover_art, &app.cover_art);
       }
 
       drew_playbar = true;

--- a/src/tui/ui/plugin_screen.rs
+++ b/src/tui/ui/plugin_screen.rs
@@ -184,12 +184,12 @@ fn draw_cover_art(f: &mut Frame<'_>, app: &App, area: Rect, fit: PluginCoverArtF
       f,
       app,
       area,
-      crate::tui::cover_art::status_message(app.cover_art_status),
+      crate::tui::cover_art::status_message(app.cover_art.status),
     );
     return;
   }
 
-  let fitted = app.cover_art.plugin_size_for(area, fit).unwrap_or(area);
+  let fitted = crate::tui::cover_art::plugin_size_for(area, fit, &app.cover_art).unwrap_or(area);
   let target = center_rect_within(area, fitted);
 
   // Clear the whole slot, not just `target`: a previous track's image may have
@@ -202,7 +202,7 @@ fn draw_cover_art(f: &mut Frame<'_>, app: &App, area: Rect, fit: PluginCoverArtF
     Block::default().style(app.user_config.theme.base_style()),
     area,
   );
-  app.cover_art.render_plugin(f, target, fit);
+  crate::tui::cover_art::render_plugin(f, target, fit, &app.cover_art);
 }
 
 #[cfg(not(feature = "cover-art"))]
@@ -500,6 +500,7 @@ mod tests {
   #[cfg(feature = "cover-art")]
   #[test]
   fn cover_art_image_slot_restores_the_theme_background() {
+    crate::tui::cover_art::init_test_renderer();
     let content = PluginScreenContent {
       title: "Demo".to_string(),
       widgets: vec![PluginWidget::new(PluginWidgetKind::CoverArt {

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 153              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1345            # floor: may only rise
+test_attribute_total = 1346            # floor: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 153              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1343            # floor: may only rise
+test_attribute_total = 1345            # floor: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -4,9 +4,9 @@
 # A counter may only move toward its target. When a PR improves one, lower
 # the baseline here in the same PR. Never raise a baseline.
 
-crate_tui_refs_outside_tui = 8         # target 0
+crate_tui_refs_outside_tui = 2         # target 0
 app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 153              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1341            # floor: may only rise
+test_attribute_total = 1343            # floor: may only rise


### PR DESCRIPTION
# Summary

Splits cover art into a frontend-agnostic decode half and a terminal-rendering half, so `App` no longer holds terminal graphics state and constructing it no longer probes stdout.

- New `core/art.rs` (feature `cover-art`): `CoverArtRequest` and `CoverArtStatus` moved verbatim, `fetch_and_decode` as a free function, and `CoverArtStore` — the decoded image keyed by its request URL/URI plus the load status. `App.cover_art` is now this store; the separate `cover_art_status` field folded into it.
- `tui/cover_art.rs` is now renderer-only: a process-wide renderer owning the `ratatui-image` `Picker` plus one cached `StatefulProtocol` per surface (playbar / fullscreen / plugin widget), keyed on the store's key so a protocol is rebuilt when the art changes, never per frame. `Picker::from_query_stdio()` moved out of `App` construction into `start_ui`, right after `ratatui::init()` and before the input reader thread spawns (the probe reads its response from stdin).
- Feature split: new internal `art-decode = ["dep:image"]` carries the decode half + adaptive-theme palette extraction; `cover-art = ["tui", "art-decode", "dep:ratatui-image"]` keeps its pre-split meaning (decode + terminal rendering), so every existing build command, ci.yml, cd.yml, and the docs are unchanged. A decode-only build (`art-decode` alone) compiles and still feeds the adaptive theme.
- `IoEvent::FetchCoverArt` and the network fetch handler re-point to `core::art`; `crate::tui` references outside `tui/` drop 8 → 2 (both in `runtime.rs`, scheduled for the frontend gating step), ratcheted in `tools/gates.count`.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings` — clean
- `cargo test --no-default-features --features telemetry,tui` — 588 passed (includes the gates ratchet against the new baselines)
- `cargo test` (default features) — 886 passed
- `cargo test --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz-cpal,local-files,subsonic,internet-radio,youtube` (all-sources leg minus the Linux-only audio-viz/mpris) — 1 pre-existing failure only: `infra::local::tests::uri_round_trip`, a Windows-only issue (`Url::to_file_path` rejects `file:///home/...` without a drive letter); untouched by this diff, and CI runs that leg on Linux
- `cargo check` on the `mcp-only`, `ai-dj-only`, `headless`, and decode-only (`telemetry,tui,art-decode`) sets — clean
- `bash tools/check_gates_ratchet.sh origin/main` — ok
- New unit tests for `CoverArtStore`; the plugin-screen cover-art render test now installs a halfblocks test renderer and still passes
- Cargo.lock untouched (feature-only manifest change)

# Additional notes

- Rendering behavior is intended to be identical (same picker probe, same per-surface protocol separation, same placeholder messages). Needs an eyeball on a real terminal for playbar art, the fullscreen view (`G`), and a plugin `cover_art` widget, since CI can't see pixels.
- With art disabled/cleared, the renderer's cached protocols are dropped by a once-per-frame `sync` call in the runner, matching the old `clear()` memory behavior.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone cover-art decoding with asynchronous loading, status tracking, caching, and image replacement or clearing.
  * Cover-art themes and settings now work independently of terminal rendering.
  * Terminal rendering detects capabilities at startup and refreshes artwork efficiently when it changes.

* **Bug Fixes**
  * Improved handling of unavailable or failed artwork, including stale-image cleanup and consistent status updates.
  * Added safeguards for oversized downloads and images exceeding supported dimensions.

* **Documentation**
  * Documented the separation between image decoding and terminal rendering features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->