### PR TITLE
build: switch to published spotatui-librespot crates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -183,10 +183,12 @@ pipeline, escalating to full backend replacement with parked-request replay.
 Durable intent (recovery snapshot, parked `StartPlayback`, client-side shuffle
 session) lives in `src/core/app/native_{backend,recovery,shuffle}.rs`.
 
-- It rides a **pinned librespot fork** (`[patch.crates-io]` in Cargo.toml, one
-  immutable rev). The fork carries upstream backports *and* a fork-only
+- It rides our **maintained librespot fork**, published on crates.io as
+  `spotatui-librespot-*` and consumed through `package =` renames, so imports
+  stay `librespot_*`. The fork carries upstream backports *and* a fork-only
   `SessionDisconnectReason` API the app depends on - it cannot be swapped for
-  upstream 0.8. Update the Cargo.toml comment block when the rev moves.
+  upstream 0.8. All seven crates are `=`-pinned in lockstep; bump them together
+  when the fork publishes a new version.
 - Direct spirc `load` is the **primary** route for all native starts, context ones
   included - a `me/player/play` round trip would head-of-line-block the serial
   pump (#386). The Web API route (`start_native_context_via_api`) is a fallback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,10 +185,12 @@ pipeline, escalating to full backend replacement with parked-request replay.
 Durable intent (recovery snapshot, parked `StartPlayback`, client-side shuffle
 session) lives in `src/core/app/native_{backend,recovery,shuffle}.rs`.
 
-- It rides a **pinned librespot fork** (`[patch.crates-io]` in Cargo.toml, one
-  immutable rev). The fork carries upstream backports *and* a fork-only
+- It rides our **maintained librespot fork**, published on crates.io as
+  `spotatui-librespot-*` and consumed through `package =` renames, so imports
+  stay `librespot_*`. The fork carries upstream backports *and* a fork-only
   `SessionDisconnectReason` API the app depends on - it cannot be swapped for
-  upstream 0.8. Update the Cargo.toml comment block when the rev moves.
+  upstream 0.8. All seven crates are `=`-pinned in lockstep; bump them together
+  when the fork publishes a new version.
 - Direct spirc `load` is the **primary** route for all native starts, context ones
   included - a `me/player/play` round trip would head-of-line-block the serial
   pump (#386). The Web API route (`start_native_context_via_api`) is a fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,10 +185,12 @@ pipeline, escalating to full backend replacement with parked-request replay.
 Durable intent (recovery snapshot, parked `StartPlayback`, client-side shuffle
 session) lives in `src/core/app/native_{backend,recovery,shuffle}.rs`.
 
-- It rides a **pinned librespot fork** (`[patch.crates-io]` in Cargo.toml, one
-  immutable rev). The fork carries upstream backports *and* a fork-only
+- It rides our **maintained librespot fork**, published on crates.io as
+  `spotatui-librespot-*` and consumed through `package =` renames, so imports
+  stay `librespot_*`. The fork carries upstream backports *and* a fork-only
   `SessionDisconnectReason` API the app depends on - it cannot be swapped for
-  upstream 0.8. Update the Cargo.toml comment block when the rev moves.
+  upstream 0.8. All seven crates are `=`-pinned in lockstep; bump them together
+  when the fork publishes a new version.
 - Direct spirc `load` is the **primary** route for all native starts, context ones
   included - a `me/player/play` round trip would head-of-line-block the serial
   pump (#386). The Web API route (`start_native_context_via_api`) is a fallback

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,171 +3080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "librespot-audio"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "aes",
- "bytes",
- "ctr",
- "futures-util",
- "http-body-util",
- "hyper",
- "hyper-util",
- "librespot-core",
- "log",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "librespot-connect"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "futures-util",
- "librespot-core",
- "librespot-playback",
- "librespot-protocol",
- "log",
- "protobuf",
- "rand 0.9.2",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "uuid 1.19.0",
-]
-
-[[package]]
-name = "librespot-core"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "aes",
- "base64",
- "byteorder",
- "bytes",
- "data-encoding",
- "flate2",
- "form_urlencoded",
- "futures-core",
- "futures-util",
- "governor",
- "hmac",
- "http",
- "http-body-util",
- "httparse",
- "hyper",
- "hyper-proxy2",
- "hyper-tls",
- "hyper-util",
- "librespot-oauth",
- "librespot-protocol",
- "log",
- "nonzero_ext",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "pbkdf2",
- "pin-project-lite",
- "priority-queue",
- "protobuf",
- "protobuf-json-mapping",
- "quick-xml 0.38.4",
- "rand 0.9.2",
- "rand_distr 0.5.1",
- "rsa",
- "serde",
- "serde_json",
- "sha1 0.10.6",
- "shannon",
- "sysinfo",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite 0.28.0",
- "tokio-util",
- "url",
- "uuid 1.19.0",
- "vergen-gitcl",
-]
-
-[[package]]
-name = "librespot-metadata"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "async-trait",
- "bytes",
- "librespot-core",
- "librespot-protocol",
- "log",
- "protobuf",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "uuid 1.19.0",
-]
-
-[[package]]
-name = "librespot-oauth"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "log",
- "oauth2",
- "open",
- "reqwest 0.12.28",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
-name = "librespot-playback"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "alsa 0.10.0",
- "cpal 0.16.0",
- "form_urlencoded",
- "futures-util",
- "gstreamer",
- "gstreamer-app",
- "gstreamer-audio",
- "jack",
- "libpulse-binding",
- "libpulse-simple-binding",
- "librespot-audio",
- "librespot-core",
- "librespot-metadata",
- "log",
- "portable-atomic",
- "portaudio-rs",
- "rand 0.9.2",
- "rand_distr 0.5.1",
- "rodio 0.21.1",
- "sdl2",
- "shell-words",
- "symphonia 0.5.5",
- "thiserror 2.0.18",
- "tokio",
- "zerocopy",
-]
-
-[[package]]
-name = "librespot-protocol"
-version = "0.8.0"
-source = "git+https://github.com/LargeModGames/spotatui-librespot?rev=f775c396ab3fc14d9331c7a018e18aba3749f8cf#f775c396ab3fc14d9331c7a018e18aba3749f8cf"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
-]
-
-[[package]]
 name = "libspa"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,12 +5737,6 @@ dependencies = [
  "icy-metadata",
  "image",
  "keepawake",
- "librespot-connect",
- "librespot-core",
- "librespot-metadata",
- "librespot-oauth",
- "librespot-playback",
- "librespot-protocol",
  "lofty",
  "log",
  "md-5",
@@ -5935,6 +5764,12 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "smtc-tokio",
+ "spotatui-librespot-connect",
+ "spotatui-librespot-core",
+ "spotatui-librespot-metadata",
+ "spotatui-librespot-oauth",
+ "spotatui-librespot-playback",
+ "spotatui-librespot-protocol",
  "stream-download",
  "symphonia 0.6.0",
  "tempfile",
@@ -5944,6 +5779,178 @@ dependencies = [
  "unicode-width",
  "url",
  "vergen",
+]
+
+[[package]]
+name = "spotatui-librespot-audio"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907dfd5a229ad94bf77953270aa630beb0b05c02756c5851e5c80a938aee73de"
+dependencies = [
+ "aes",
+ "bytes",
+ "ctr",
+ "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "spotatui-librespot-core",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "spotatui-librespot-connect"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ac3a8eacf659cbb460476afe3d9ced421f7b1584609e18eecf3092d7d3f48b"
+dependencies = [
+ "futures-util",
+ "log",
+ "protobuf",
+ "rand 0.9.2",
+ "serde_json",
+ "spotatui-librespot-core",
+ "spotatui-librespot-playback",
+ "spotatui-librespot-protocol",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "uuid 1.19.0",
+]
+
+[[package]]
+name = "spotatui-librespot-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77186290aafc55be221355bbf2c6566a209e4f5c7ab01fd03a8ecfc7d2d3159"
+dependencies = [
+ "aes",
+ "base64",
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "flate2",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "governor",
+ "hmac",
+ "http",
+ "http-body-util",
+ "httparse",
+ "hyper",
+ "hyper-proxy2",
+ "hyper-tls",
+ "hyper-util",
+ "log",
+ "nonzero_ext",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "pbkdf2",
+ "pin-project-lite",
+ "priority-queue",
+ "protobuf",
+ "protobuf-json-mapping",
+ "quick-xml 0.38.4",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.10.6",
+ "shannon",
+ "spotatui-librespot-oauth",
+ "spotatui-librespot-protocol",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.28.0",
+ "tokio-util",
+ "url",
+ "uuid 1.19.0",
+ "vergen-gitcl",
+]
+
+[[package]]
+name = "spotatui-librespot-metadata"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02195470768bb7bd1ddeb55212a9c90ba9e6bdf6a6b3695adfdb8ece10c39e89"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "protobuf",
+ "serde",
+ "serde_json",
+ "spotatui-librespot-core",
+ "spotatui-librespot-protocol",
+ "thiserror 2.0.18",
+ "uuid 1.19.0",
+]
+
+[[package]]
+name = "spotatui-librespot-oauth"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da63cf261d9d5484500529930aac3b38a2d53b750a4eb7119b252f4804013705"
+dependencies = [
+ "log",
+ "oauth2",
+ "open",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "spotatui-librespot-playback"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d693d7b98c13782eb7e7b412f9e9d09a78c341b779c401c71587ff24e90e31ac"
+dependencies = [
+ "alsa 0.10.0",
+ "cpal 0.16.0",
+ "form_urlencoded",
+ "futures-util",
+ "gstreamer",
+ "gstreamer-app",
+ "gstreamer-audio",
+ "jack",
+ "libpulse-binding",
+ "libpulse-simple-binding",
+ "log",
+ "portable-atomic",
+ "portaudio-rs",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rodio 0.21.1",
+ "sdl2",
+ "shell-words",
+ "spotatui-librespot-audio",
+ "spotatui-librespot-core",
+ "spotatui-librespot-metadata",
+ "symphonia 0.5.5",
+ "thiserror 2.0.18",
+ "tokio",
+ "zerocopy",
+]
+
+[[package]]
+name = "spotatui-librespot-protocol"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b6c5821d142db9057c00410b2333bb8f96178bf609a5435bcc507dc450cd46"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,18 @@ lofty = { version = "0.24", optional = true }
 # Bluetooth (see the portaudio note above and issues #9/#20).
 rodio = { version = "0.22", optional = true }
 
-# Streaming dependencies (librespot)
-librespot-core = { version = "0.8", optional = true }
-librespot-connect = { version = "0.8", optional = true }
-librespot-oauth = { version = "0.8", optional = true }
-librespot-metadata = { version = "0.8", optional = true }
-librespot-protocol = { version = "0.8", optional = true, default-features = false }
+# Streaming dependencies: our maintained librespot fork, published on crates.io
+# as spotatui-librespot-* (upstream 0.8.0 + CDN 530 fallback for silent playback,
+# dealer reconnect/session-loss recovery, OAuth callback listener hardening, and
+# a fork-only session disconnect-reason API the app depends on - upstream 0.8
+# cannot be substituted). The `package =` rename keeps `librespot_*` imports and
+# `librespot-*/feature` refs unchanged; `=`-pinned so all seven crates upgrade in
+# lockstep. See SPOTATUI_FORK.md in the fork repo for the carried patches.
+librespot-core = { version = "=0.8.1", package = "spotatui-librespot-core", optional = true }
+librespot-connect = { version = "=0.8.1", package = "spotatui-librespot-connect", optional = true }
+librespot-oauth = { version = "=0.8.1", package = "spotatui-librespot-oauth", optional = true }
+librespot-metadata = { version = "=0.8.1", package = "spotatui-librespot-metadata", optional = true }
+librespot-protocol = { version = "=0.8.1", package = "spotatui-librespot-protocol", optional = true, default-features = false }
 protobuf = { version = "3.7", optional = true }
 futures = "0.3.32"
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
@@ -89,18 +95,18 @@ keepawake = "0.6"
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 arboard = { version = "3.4", features = ["wayland-data-control"] }
 pipewire = { version = "0.10", optional = true }
-librespot-playback = { version = "0.8", optional = true, default-features = false, features = ["alsa-backend"] }
+librespot-playback = { version = "=0.8.1", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["alsa-backend"] }
 
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 arboard = { version = "3.4", features = ["wayland-data-control"] }
-librespot-playback = { version = "0.8", optional = true, default-features = false, features = ["rodio-backend"] }
+librespot-playback = { version = "=0.8.1", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 arboard = "3.4"
 # On Windows we default to rodio for audio output.
 # Without this, librespot-playback falls back to the `pipe` sink which writes raw audio bytes
 # to stdout (breaking the TUI and producing no audible output).
-librespot-playback = { version = "0.8", optional = true, default-features = false, features = ["rodio-backend"] }
+librespot-playback = { version = "=0.8.1", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
 smtc-tokio = { version = "0.1.0", optional = true }
 
 # MPRIS D-Bus support (Linux only)
@@ -113,7 +119,7 @@ mpris-server = { version = "0.10", optional = true }
 # causing SIGSEGV crashes. See Issue #9 and #20.
 [target.'cfg(target_os = "macos")'.dependencies]
 arboard = "3.4"
-librespot-playback = { version = "0.8", optional = true, default-features = false, features = ["portaudio-backend"] }
+librespot-playback = { version = "=0.8.1", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["portaudio-backend"] }
 objc2-media-player = { version = "0.3", optional = true }
 objc2-foundation = { version = "0.3", optional = true }
 objc2-app-kit = { version = "0.3", optional = true, default-features = false, features = ["NSImage"] }
@@ -249,23 +255,3 @@ pkg-fmt = "tgz"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-url = "{ repo }/releases/download/v{ version }/spotatui-windows-x86_64.zip"
 pkg-fmt = "zip"
-
-# Native streaming fixes: librespot 0.8.0 + backport of upstream PR #1722 (fall back to the
-# next CDN URL when one returns a non-206 status, e.g. HTTP 530) + port of upstream PR #1692
-# (dealer reconnects handled in place without restarting spirc; prompt spirc-task exit with
-# saved playback state on session TCP loss instead of hanging, enabling seamless recovery)
-# + cherry-pick of upstream PR #1706 and follow-up hardening of the OAuth callback listener,
-# which used to accept one connection and give up if it was not the redirect, closing port
-# 8989 before the real callback arrived (issue #414, upstream issue #1705).
-# Pinned to our maintained fork (spotatui-librespot) until a fixed librespot is published to
-# crates.io. Pinned by immutable `rev` (not a branch) so release builds stay reproducible even
-# as the `spotatui` branch advances. Note: crates.io publishes ignore [patch], so `cargo install`
-# users need the upstream release.
-[patch.crates-io]
-librespot-core     = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-audio    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-playback = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-connect  = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-oauth    = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-metadata = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }
-librespot-protocol = { git = "https://github.com/LargeModGames/spotatui-librespot", rev = "f775c396ab3fc14d9331c7a018e18aba3749f8cf" }

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,5 @@
 { pkgs ? import <nixpkgs> {} }:
-let
-  librespotOutputHash = "sha256-vUBIP+e9HYq3PKilYbdRtJk4qJAT7Vjn0l1ALe5qNbA=";
-in
+
   pkgs.rustPlatform.buildRustPackage rec {
     pname = "spotatui";
     version = "0.34.3";
@@ -10,15 +8,6 @@ in
 
   cargoLock = {
     lockFile = ./Cargo.lock;
-    outputHashes = {
-      "librespot-audio-0.8.0" = librespotOutputHash;
-      "librespot-connect-0.8.0" = librespotOutputHash;
-      "librespot-core-0.8.0" = librespotOutputHash;
-      "librespot-metadata-0.8.0" = librespotOutputHash;
-      "librespot-oauth-0.8.0" = librespotOutputHash;
-      "librespot-playback-0.8.0" = librespotOutputHash;
-      "librespot-protocol-0.8.0" = librespotOutputHash;
-    };
   };
 
   nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -40,9 +40,6 @@
             pkgs.apple-sdk
             pkgs.portaudio
           ];
-        # Update alongside the [patch.crates-io] rev in Cargo.toml; the Nix build
-        # fails with a hash mismatch that reports the correct value otherwise.
-        librespotOutputHash = "sha256-vUBIP+e9HYq3PKilYbdRtJk4qJAT7Vjn0l1ALe5qNbA=";
       in
       {
         # Build dependencies for rust
@@ -54,15 +51,6 @@
 
             cargoLock = {
               lockFile = ./Cargo.lock;
-              outputHashes = {
-                "librespot-audio-0.8.0" = librespotOutputHash;
-                "librespot-connect-0.8.0" = librespotOutputHash;
-                "librespot-core-0.8.0" = librespotOutputHash;
-                "librespot-metadata-0.8.0" = librespotOutputHash;
-                "librespot-oauth-0.8.0" = librespotOutputHash;
-                "librespot-playback-0.8.0" = librespotOutputHash;
-                "librespot-protocol-0.8.0" = librespotOutputHash;
-              };
             };
             inherit nativeBuildInputs buildInputs;
             meta = with pkgs.lib; {


### PR DESCRIPTION
# Summary

Switch the librespot dependencies from the `[patch.crates-io]` git pin to our published fork crates (`spotatui-librespot-*` 0.8.1 on crates.io), consumed via `package =` renames so all `librespot_*` imports and `librespot-*/feature` references stay unchanged. Zero source changes.

Why: cargo strips `[patch]` tables on publish and rewrites the packaged Cargo.lock, so crates.io installs of spotatui have always built against upstream librespot 0.8.0, without any of the fork fixes (including the CDN 530 silent-playback fallback). Since the session disconnect-reason work landed, the app uses a fork-only API, which would make the next `cargo publish` fail outright. With the fork on the registry, `cargo install spotatui` gets the real streaming stack, locked or not.

Also in this PR:

- Delete the `outputHashes` blocks (and their shared hash binding) from `flake.nix` and `default.nix`. Registry dependencies are covered by ordinary Cargo.lock checksums, so the Nix builds no longer carry a hand-maintained git hash that went stale on every fork rev bump.
- Update the pinned-fork wording in `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` (edited together per convention).
- All seven crates are `=`-pinned in lockstep; future fork releases bump the seven pins together.

# Testing

- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings` clean
- `cargo test --no-default-features --features telemetry,tui`: 588 passed
- `cargo test` (default, builds streaming against the registry crates): 886 passed
- `cargo check` for the `mcp-only`, `ai-dj-only`, and `headless` legs: clean
- `cargo check --locked`: lockfile consistent
- `bash tools/check_gates_ratchet.sh origin/main`: ok

# Additional notes

The fork publishing process is documented in `SPOTATUI_FORK.md` in the [fork repo](https://github.com/LargeModGames/spotatui-librespot). Native playback still deserves a manual smoke test with the full `cargo run` build before merge, per house convention for streaming changes.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated native streaming guidance to describe the maintained librespot fork and its package naming.
  - Documented exact version pinning requirements and compatibility details.

- **Chores**
  - Updated streaming dependencies to the maintained fork with consistent version pins across platforms.
  - Simplified Nix build configuration by relying on the Cargo lock file for dependency integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->