### PR TITLE
ci: fix event payload code injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,15 @@ jobs:
     if: |
       !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[skip ci]')
     steps:
+      # Debug output only. Read the payload from $GITHUB_EVENT_PATH instead of
+      # templating ${{ toJson(github.event) }} into the script: expression
+      # expansion happens before the shell runs, so attacker-controlled payload
+      # fields (PR title/body, commit message) could escape the heredoc and
+      # execute (CodeQL: actions/cache-poisoning/code-injection).
       - run: |
-          cat <<'MESSAGE'
-          github.event_name: ${{ toJson(github.event_name) }}
-          github.event:
-          ${{ toJson(github.event) }}
-          MESSAGE
+          echo "github.event_name: $GITHUB_EVENT_NAME"
+          echo "github.event:"
+          cat "$GITHUB_EVENT_PATH"
 
   check:
     name: Check (${{ matrix.name }})


### PR DESCRIPTION
# Summary

Fixes CodeQL alert  (`actions/cache-poisoning/code-injection`, High): the `prepare` job templated `${{ toJson(github.event) }}` directly into its `run:` script. Expression expansion happens before the shell executes, so the quoted heredoc offered no protection - a PR title/body or a commit message containing a `MESSAGE` line followed by shell commands would escape the heredoc and run, and on the `push` trigger that runs in main's scope with write access to the Actions cache other workflows restore.

The step is debug output only, so it now reads the same payload as data: `$GITHUB_EVENT_NAME` and `cat "$GITHUB_EVENT_PATH"`. No other workflow interpolates event fields into a script (`nix.yml` and the `if:` guards are expression contexts; `triage.yml` already goes through `env:`).

# Testing

- Workflow-only change; the edited `prepare` job runs on this PR itself and prints the same event dump.

# Additional notes

- The pre-existing `actions/checkout@master` refs in this file are a separate hygiene pass.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow logging by including the event name and raw event details.
  * Simplified event information output for clearer troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->