### PR TITLE
refactor(core): move console I/O behind an onboarding trait

### DIFF
--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -671,7 +671,7 @@ impl App {
     if let Some(io_tx) = &self.io_tx {
       if let Err(e) = io_tx.send(action) {
         self.is_loading = false;
-        println!("Error from dispatch {}", e);
+        log::error!("Error from dispatch {}", e);
         // TODO: handle error
       };
     }

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,4 +1,5 @@
 use crate::core::config::{ClientConfig, ConfigPaths, NCSPOT_CLIENT_ID};
+use crate::core::onboarding::Onboarding;
 use crate::infra::redirect_uri::redirect_uri_web_server_async;
 use anyhow::{anyhow, Result};
 use log::{info, warn};
@@ -7,7 +8,7 @@ use rspotify::{
   {AuthCodePkceSpotify, Config, Credentials, OAuth, Token, TokenCallback},
 };
 use std::{
-  fs, io,
+  fs,
   path::{Path, PathBuf},
   sync::{Arc, OnceLock},
   time::{Duration, SystemTime},
@@ -310,6 +311,7 @@ async fn ensure_auth_token(
   token_cache_path: &PathBuf,
   auth_port: u16,
   interactive: bool,
+  onboarding: &dyn Onboarding,
 ) -> Result<Option<rspotify::model::PrivateUser>> {
   let mut needs_auth = match load_token_from_file(spotify, token_cache_path).await {
     Ok(true) => false,
@@ -389,18 +391,18 @@ async fn ensure_auth_token(
     info!("starting spotify authentication flow on port {}", auth_port);
     let auth_url = spotify.get_authorize_url(None)?;
 
-    println!("\nAttempting to open this URL in your browser:");
-    println!("{}\n", auth_url);
+    onboarding.info("\nAttempting to open this URL in your browser:");
+    onboarding.info(&format!("{}\n", auth_url));
 
     if let Err(e) = open::that(&auth_url) {
-      println!("Failed to open browser automatically: {}", e);
-      println!("Please manually open the URL above in your browser.");
+      onboarding.info(&format!("Failed to open browser automatically: {}", e));
+      onboarding.info("Please manually open the URL above in your browser.");
     }
 
-    println!(
+    onboarding.info(&format!(
       "Waiting for authorization callback on http://127.0.0.1:{}...\n",
       auth_port
-    );
+    ));
 
     // Async server, same as the in-TUI login path: the blocking variant used
     // to park a tokio worker thread in a std accept() loop with no timeout,
@@ -420,11 +422,12 @@ async fn ensure_auth_token(
       }
       Err(()) => {
         info!("redirect uri web server failed, using manual authentication");
-        println!("Starting webserver failed. Continuing with manual authentication");
-        println!("Please open this URL in your browser: {}", auth_url);
-        println!("Enter the URL you were redirected to: ");
-        let mut input = String::new();
-        io::stdin().read_line(&mut input)?;
+        onboarding.info("Starting webserver failed. Continuing with manual authentication");
+        onboarding.info(&format!(
+          "Please open this URL in your browser: {}",
+          auth_url
+        ));
+        let input = onboarding.prompt_line("Enter the URL you were redirected to: \n")?;
         if let Some(code) = spotify.parse_response_code(&input) {
           info!("authorization code received from manual input, requesting access token");
           spotify.request_token(&code).await?;
@@ -448,8 +451,9 @@ async fn ensure_auth_token(
 pub async fn authenticate_with_fallback(
   client_config: &mut ClientConfig,
   config_paths: &ConfigPaths,
+  onboarding: &dyn Onboarding,
 ) -> Result<AuthenticatedClient> {
-  authenticate_candidates(client_config, config_paths, true).await
+  authenticate_candidates(client_config, config_paths, true, onboarding).await
 }
 
 /// Best-effort silent Spotify load for a free-source launch: returns `Some` only
@@ -457,8 +461,9 @@ pub async fn authenticate_with_fallback(
 pub async fn try_load_spotify_silently(
   client_config: &mut ClientConfig,
   config_paths: &ConfigPaths,
+  onboarding: &dyn Onboarding,
 ) -> Option<AuthenticatedClient> {
-  authenticate_candidates(client_config, config_paths, false)
+  authenticate_candidates(client_config, config_paths, false, onboarding)
     .await
     .ok()
 }
@@ -507,6 +512,7 @@ async fn authenticate_candidates(
   client_config: &mut ClientConfig,
   config_paths: &ConfigPaths,
   interactive: bool,
+  onboarding: &dyn Onboarding,
 ) -> Result<AuthenticatedClient> {
   let mut client_candidates = vec![client_config.client_id.clone()];
   if let Some(fallback_id) = client_config.fallback_client_id.clone() {
@@ -533,8 +539,14 @@ async fn authenticate_candidates(
     let mut candidate =
       build_pkce_spotify_client(client_id, redirect_uri.clone(), token_cache_path.clone());
 
-    let auth_result =
-      ensure_auth_token(&mut candidate, &token_cache_path, auth_port, interactive).await;
+    let auth_result = ensure_auth_token(
+      &mut candidate,
+      &token_cache_path,
+      auth_port,
+      interactive,
+      onboarding,
+    )
+    .await;
 
     match auth_result {
       Ok(me) => {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,9 +1,10 @@
 use crate::core::banner::BANNER;
+use crate::core::onboarding::Onboarding;
 use anyhow::{anyhow, Context, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::{
   fs,
-  io::{stdin, Write},
+  io::Write,
   path::{Path, PathBuf},
 };
 
@@ -137,7 +138,7 @@ impl ClientConfig {
     Ok(())
   }
 
-  pub fn load_config(&mut self) -> Result<()> {
+  pub fn load_config(&mut self, onboarding: &dyn Onboarding) -> Result<()> {
     let paths = self.get_or_build_paths()?;
     if paths.config_file_path.exists() {
       let config_string = fs::read_to_string(&paths.config_file_path)?;
@@ -156,14 +157,14 @@ impl ClientConfig {
 
       Ok(())
     } else {
-      println!("{}", BANNER);
+      onboarding.info(BANNER);
 
-      println!(
+      onboarding.info(&format!(
         "Config will be saved to {}",
         paths.config_file_path.display()
-      );
+      ));
 
-      self.run_auth_setup_wizard()
+      self.run_auth_setup_wizard(onboarding)
     }
   }
 
@@ -171,8 +172,8 @@ impl ClientConfig {
     self.setup_version < AUTH_SETUP_VERSION
   }
 
-  pub fn reconfigure_auth(&mut self) -> Result<()> {
-    self.run_auth_setup_wizard()
+  pub fn reconfigure_auth(&mut self, onboarding: &dyn Onboarding) -> Result<()> {
+    self.run_auth_setup_wizard(onboarding)
   }
 
   /// Write `client.yml` with ncspot defaults but WITHOUT running the OAuth flow.
@@ -193,20 +194,22 @@ impl ClientConfig {
     self.save_config_file()
   }
 
-  fn run_auth_setup_wizard(&mut self) -> Result<()> {
-    println!("\nClient setup options:\n");
-    println!("  1) Use ncspot client ID (quick setup, may break if Spotify revokes shared access)");
-    println!("  2) Use ncspot client ID + your own fallback app ID (recommended for resilience)");
+  fn run_auth_setup_wizard(&mut self, onboarding: &dyn Onboarding) -> Result<()> {
+    onboarding.info("\nClient setup options:\n");
+    onboarding
+      .info("  1) Use ncspot client ID (quick setup, may break if Spotify revokes shared access)");
+    onboarding
+      .info("  2) Use ncspot client ID + your own fallback app ID (recommended for resilience)");
 
-    let setup_option = ClientConfig::get_setup_option()?;
+    let setup_option = ClientConfig::get_setup_option(onboarding)?;
 
     let (client_id, fallback_client_id) = match setup_option {
       1 => {
-        println!("\nUsing ncspot redirect URI: http://127.0.0.1:8989/login");
+        onboarding.info("\nUsing ncspot redirect URI: http://127.0.0.1:8989/login");
         (NCSPOT_CLIENT_ID.to_string(), None)
       }
       2 => {
-        println!("\nCreate your fallback Spotify app:\n");
+        onboarding.info("\nCreate your fallback Spotify app:\n");
         let instructions = [
           "Go to https://developer.spotify.com/dashboard/applications",
           "Click `Create app` and add your own name and description",
@@ -217,10 +220,10 @@ impl ClientConfig {
         ];
 
         for (number, item) in instructions.iter().enumerate() {
-          println!("  {}. {}", number + 1, item);
+          onboarding.info(&format!("  {}. {}", number + 1, item));
         }
 
-        let fallback = ClientConfig::get_client_key_from_input("Fallback Client ID")?;
+        let fallback = ClientConfig::get_client_key_from_input("Fallback Client ID", onboarding)?;
         (NCSPOT_CLIENT_ID.to_string(), Some(fallback))
       }
       _ => unreachable!(),
@@ -229,12 +232,10 @@ impl ClientConfig {
     let port = if setup_option == 1 {
       8989
     } else {
-      let mut port = String::new();
-      println!(
-        "\nEnter port of fallback redirect uri (default {}): ",
+      let port = onboarding.prompt_line(&format!(
+        "\nEnter port of fallback redirect uri (default {}): \n",
         DEFAULT_PORT
-      );
-      stdin().read_line(&mut port)?;
+      ))?;
       port.trim().parse::<u16>().unwrap_or(DEFAULT_PORT)
     };
 
@@ -256,19 +257,19 @@ impl ClientConfig {
     Ok(())
   }
 
-  fn get_client_key_from_input(type_label: &'static str) -> Result<String> {
-    let mut client_key = String::new();
+  fn get_client_key_from_input(
+    type_label: &'static str,
+    onboarding: &dyn Onboarding,
+  ) -> Result<String> {
     const MAX_RETRIES: u8 = 5;
     let mut num_retries = 0;
     loop {
-      println!("\nEnter your {}: ", type_label);
-      stdin().read_line(&mut client_key)?;
-      client_key = client_key.trim().to_string();
+      let input = onboarding.prompt_line(&format!("\nEnter your {}: \n", type_label))?;
+      let client_key = input.trim().to_string();
       match ClientConfig::validate_client_key(&client_key) {
         Ok(_) => return Ok(client_key),
         Err(error_string) => {
-          println!("{}", error_string);
-          client_key.clear();
+          onboarding.info(&error_string.to_string());
           num_retries += 1;
           if num_retries == MAX_RETRIES {
             return Err(Error::from(std::io::Error::other(format!(
@@ -281,21 +282,18 @@ impl ClientConfig {
     }
   }
 
-  fn get_setup_option() -> Result<u8> {
-    let mut input = String::new();
+  fn get_setup_option(onboarding: &dyn Onboarding) -> Result<u8> {
     const MAX_RETRIES: u8 = 5;
     let mut retries = 0;
 
     loop {
-      println!("\nChoose option (1 or 2): ");
-      stdin().read_line(&mut input)?;
+      let input = onboarding.prompt_line("\nChoose option (1 or 2): \n")?;
       let trimmed = input.trim();
 
       match trimmed.parse::<u8>() {
         Ok(1) | Ok(2) => return Ok(trimmed.parse::<u8>()?),
         _ => {
-          println!("Invalid choice. Please enter 1 or 2.");
-          input.clear();
+          onboarding.info("Invalid choice. Please enter 1 or 2.");
           retries += 1;
           if retries >= MAX_RETRIES {
             return Err(Error::from(std::io::Error::other(format!(
@@ -366,6 +364,31 @@ fn is_client_token_cache_file(file_name: &str) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::core::test_helpers::ScriptedOnboarding;
+
+  #[test]
+  fn setup_option_accepts_a_valid_choice_after_garbage() {
+    let onboarding = ScriptedOnboarding::with_answers(&["x", "2"]);
+    assert_eq!(ClientConfig::get_setup_option(&onboarding).unwrap(), 2);
+    assert!(onboarding.saw("Invalid choice. Please enter 1 or 2."));
+  }
+
+  #[test]
+  fn setup_option_errors_after_max_retries() {
+    let onboarding = ScriptedOnboarding::with_answers(&["x", "0", "3", "", "yes"]);
+    assert!(ClientConfig::get_setup_option(&onboarding).is_err());
+  }
+
+  #[test]
+  fn client_key_prompt_rejects_bad_keys_until_a_valid_one() {
+    let valid = "0123456789abcdef0123456789abcdef";
+    let onboarding = ScriptedOnboarding::with_answers(&["tooshort", valid]);
+    assert_eq!(
+      ClientConfig::get_client_key_from_input("Fallback Client ID", &onboarding).unwrap(),
+      valid
+    );
+    assert!(onboarding.saw("\nEnter your Fallback Client ID: \n"));
+  }
 
   #[test]
   fn legacy_token_cache_migration_moves_base_and_client_token_files() {

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -10,21 +10,18 @@
 //! Only sources whose Cargo feature is compiled in are offered. A build with just
 //! Spotify (slim / current macOS release) shows no picker and keeps the original
 //! behavior.
+//!
+//! This module is the selection *logic*; all presentation goes through the
+//! [`Onboarding`] trait (the terminal picker itself lives in `tui/first_run.rs`).
 
 use crate::core::config::ClientConfig;
+use crate::core::onboarding::Onboarding;
 use crate::core::source::Source;
 use crate::core::state::RuntimeState;
 use crate::core::user_config::UserConfig;
-use anyhow::{anyhow, Result};
-use crossterm::{
-  cursor,
-  event::{read, Event, KeyCode, KeyEventKind, KeyModifiers},
-  execute,
-  style::Stylize,
-  terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
-  tty::IsTty,
-};
-use std::io::{stdin, stdout, Write};
+#[cfg(feature = "subsonic")]
+use anyhow::anyhow;
+use anyhow::Result;
 
 #[cfg(any(feature = "subsonic", feature = "youtube", feature = "local-files"))]
 fn config_file_path_display(user_config: &UserConfig) -> String {
@@ -45,6 +42,7 @@ pub async fn run_first_run_picker(
   user_config: &mut UserConfig,
   runtime_state: &mut RuntimeState,
   client_config: &mut ClientConfig,
+  onboarding: &dyn Onboarding,
 ) -> Result<()> {
   // First run is detected by the absence of the Spotify client config file.
   let paths = client_config.get_or_build_paths()?;
@@ -60,21 +58,21 @@ pub async fn run_first_run_picker(
     return Ok(());
   }
 
-  // Collect the chosen sources. Interactive terminals get the checkbox picker;
-  // piped / non-interactive stdin falls back to the numbered single-select prompt
-  // so headless and scripted runs never hang on a raw-mode read.
-  let selections = if stdout().is_tty() && stdin().is_tty() {
-    match interactive_multiselect(&options)? {
-      Some(selected) => selected,
-      // Cancelled (esc / ctrl-c) or nothing checked: fall through to the Spotify
-      // wizard, matching the historical default.
-      None => return Ok(()),
-    }
-  } else {
-    numbered_fallback(&options)?
+  let selections = match onboarding.pick_sources(&options)? {
+    Some(selected) => selected,
+    // Cancelled (esc / ctrl-c) or nothing checked: fall through to the Spotify
+    // wizard, matching the historical default.
+    None => return Ok(()),
   };
 
-  apply_selections(selections, user_config, runtime_state, client_config).await
+  apply_selections(
+    selections,
+    user_config,
+    runtime_state,
+    client_config,
+    onboarding,
+  )
+  .await
 }
 
 /// Act on the sources the user chose. `active_source` is set to the first checked
@@ -84,6 +82,7 @@ async fn apply_selections(
   user_config: &mut UserConfig,
   runtime_state: &mut RuntimeState,
   client_config: &mut ClientConfig,
+  onboarding: &dyn Onboarding,
 ) -> Result<()> {
   // Spotify only: keep today's behavior and let `load_config` run the wizard.
   if selections == [Source::Spotify] {
@@ -113,139 +112,22 @@ async fn apply_selections(
   // Collect credentials / check prerequisites for each chosen free source.
   for source in &selections {
     if *source != Source::Spotify {
-      configure_source(*source, user_config).await?;
+      configure_source(*source, user_config, onboarding).await?;
     }
   }
 
   if spotify_selected {
     // Fall through: `load_config` runs the existing Spotify auth wizard.
-    println!("\nSetting up your other sources, then we'll log in to Spotify...\n");
+    onboarding.info("\nSetting up your other sources, then we'll log in to Spotify...\n");
     return Ok(());
   }
 
-  println!(
+  onboarding.info(&format!(
     "\nStarting spotatui with {} as your source. Press `d` anytime to switch or to log in to Spotify.\n",
     active.label()
-  );
+  ));
 
   Ok(())
-}
-
-/// Interactive checkbox picker: arrow keys / j,k to move, space to toggle, enter
-/// to confirm, esc to skip. Returns the checked sources in display order, or
-/// `None` when the user cancels or confirms with nothing selected.
-///
-/// Restores the terminal via a [`RawModeGuard`] on every exit path (early return,
-/// `?`, or panic) so a mid-selection error never leaves the terminal in raw mode.
-fn interactive_multiselect(options: &[Source]) -> Result<Option<Vec<Source>>> {
-  println!("\nWelcome to spotatui! Choose your music sources:");
-  println!("You can add or switch sources anytime from the `d` menu.\n");
-
-  enable_raw_mode()?;
-  let _guard = RawModeGuard;
-
-  let mut checked = vec![false; options.len()];
-  let mut hover = 0usize;
-  // Option lines + a blank spacer + the instructions line.
-  let line_count = (options.len() + 2) as u16;
-  let mut out = stdout();
-  let mut first_draw = true;
-
-  loop {
-    if !first_draw {
-      execute!(
-        out,
-        cursor::MoveToPreviousLine(line_count),
-        Clear(ClearType::FromCursorDown)
-      )?;
-    }
-    first_draw = false;
-
-    for (index, source) in options.iter().enumerate() {
-      let pointer = if index == hover { ">" } else { " " };
-      let checkbox = if checked[index] { "[x]" } else { "[ ]" };
-      let line = format!(
-        "  {pointer} {checkbox} {}{}",
-        source.label(),
-        source_note(*source)
-      );
-      if index == hover {
-        print!("{}\r\n", line.cyan().bold());
-      } else {
-        print!("{line}\r\n");
-      }
-    }
-    print!("\r\n");
-    print!(
-      "  {}\r\n",
-      "↑/↓ move · space select · enter confirm · esc skip".dark_grey()
-    );
-    out.flush()?;
-
-    let event = read()?;
-    let key = match event {
-      // Ignore key-release / repeat events (Windows emits them) and non-key events.
-      Event::Key(key) if key.kind == KeyEventKind::Press => key,
-      _ => continue,
-    };
-
-    match key.code {
-      KeyCode::Up | KeyCode::Char('k') => {
-        hover = if hover == 0 {
-          options.len() - 1
-        } else {
-          hover - 1
-        };
-      }
-      KeyCode::Down | KeyCode::Char('j') => {
-        hover = (hover + 1) % options.len();
-      }
-      KeyCode::Char(' ') => checked[hover] = !checked[hover],
-      KeyCode::Enter => {
-        let selected: Vec<Source> = options
-          .iter()
-          .zip(&checked)
-          .filter_map(|(source, &on)| on.then_some(*source))
-          .collect();
-        return Ok(if selected.is_empty() {
-          None
-        } else {
-          Some(selected)
-        });
-      }
-      KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
-      KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(None),
-      _ => {}
-    }
-  }
-}
-
-/// Restores cooked terminal mode when dropped, so any exit path out of the
-/// interactive picker (return, `?`, panic) leaves the terminal usable.
-struct RawModeGuard;
-
-impl Drop for RawModeGuard {
-  fn drop(&mut self) {
-    let _ = disable_raw_mode();
-  }
-}
-
-/// Non-interactive fallback (piped stdin): the original numbered single-select
-/// prompt. Returns a single-element `Vec` for a uniform downstream path.
-fn numbered_fallback(options: &[Source]) -> Result<Vec<Source>> {
-  println!("\nWelcome to spotatui! Choose your music source:\n");
-  for (index, source) in options.iter().enumerate() {
-    println!(
-      "  {}) {}{}",
-      index + 1,
-      source.label(),
-      source_note(*source)
-    );
-  }
-  println!("\nYou can add or switch sources anytime from the `d` menu.");
-
-  let choice = prompt_choice(options.len())?;
-  Ok(vec![options[choice - 1]])
 }
 
 /// The sources whose Cargo feature is compiled into this build, in display order.
@@ -273,30 +155,24 @@ fn compiled_in_sources() -> Vec<Source> {
   options
 }
 
-fn source_note(source: Source) -> &'static str {
-  match source {
-    Source::Spotify => " (needs login)",
-    Source::YouTube => " (free, needs the yt-dlp binary)",
-    Source::Subsonic => " (free, needs a Subsonic/Navidrome server)",
-    Source::Radio => " (free)",
-    Source::Local => " (free)",
-  }
-}
-
-// `user_config` is only read by credential/config-collecting sources; a build
-// with none of them (slim) leaves it unused.
+// `user_config` and `onboarding` are only read by credential/config-collecting
+// sources; a build with none of them (slim) leaves them unused.
 #[cfg_attr(
   not(any(feature = "subsonic", feature = "youtube", feature = "local-files")),
   allow(unused_variables)
 )]
-async fn configure_source(source: Source, user_config: &mut UserConfig) -> Result<()> {
+async fn configure_source(
+  source: Source,
+  user_config: &mut UserConfig,
+  onboarding: &dyn Onboarding,
+) -> Result<()> {
   match source {
     #[cfg(feature = "subsonic")]
-    Source::Subsonic => configure_subsonic(user_config).await?,
+    Source::Subsonic => configure_subsonic(user_config, onboarding).await?,
     #[cfg(feature = "youtube")]
-    Source::YouTube => configure_youtube(user_config),
+    Source::YouTube => configure_youtube(user_config, onboarding),
     #[cfg(feature = "local-files")]
-    Source::Local => configure_local(user_config),
+    Source::Local => configure_local(user_config, onboarding),
     // Radio needs no setup; other sources are handled above when compiled in.
     _ => {}
   }
@@ -304,11 +180,14 @@ async fn configure_source(source: Source, user_config: &mut UserConfig) -> Resul
 }
 
 #[cfg(feature = "subsonic")]
-async fn configure_subsonic(user_config: &mut UserConfig) -> Result<()> {
-  println!("\nSubsonic / Navidrome setup:");
-  let url = prompt_line("Server URL (e.g. https://demo.navidrome.org)")?;
-  let username = prompt_line("Username")?;
-  let password = prompt_line("Password")?;
+async fn configure_subsonic(
+  user_config: &mut UserConfig,
+  onboarding: &dyn Onboarding,
+) -> Result<()> {
+  onboarding.info("\nSubsonic / Navidrome setup:");
+  let url = prompt_required(onboarding, "Server URL (e.g. https://demo.navidrome.org)")?;
+  let username = prompt_required(onboarding, "Username")?;
+  let password = prompt_required(onboarding, "Password")?;
 
   user_config.behavior.subsonic_url = Some(url.clone());
   user_config.behavior.subsonic_username = Some(username.clone());
@@ -317,17 +196,16 @@ async fn configure_subsonic(user_config: &mut UserConfig) -> Result<()> {
 
   // Best-effort connectivity check: a failure is not fatal (the server may just
   // be temporarily down), the details are already saved.
-  print!("Testing connection... ");
-  let _ = stdout().flush();
+  onboarding.progress("Testing connection... ");
   let client = crate::infra::subsonic::SubsonicSource::new(url, username, password);
   match client.ping().await {
-    Ok(()) => println!("OK"),
+    Ok(()) => onboarding.info("OK"),
     Err(e) => {
-      println!("failed: {e}");
-      println!(
+      onboarding.info(&format!("failed: {e}"));
+      onboarding.info(&format!(
         "Saved anyway. Fix the details in {} and relaunch if needed.",
         config_file_path_display(user_config)
-      );
+      ));
     }
   }
 
@@ -335,88 +213,64 @@ async fn configure_subsonic(user_config: &mut UserConfig) -> Result<()> {
 }
 
 #[cfg(feature = "youtube")]
-fn configure_youtube(user_config: &UserConfig) {
+fn configure_youtube(user_config: &UserConfig, onboarding: &dyn Onboarding) {
   let ytdlp = user_config
     .behavior
     .ytdlp_path
     .clone()
     .unwrap_or_else(|| "yt-dlp".to_string());
 
-  print!("\nChecking for yt-dlp... ");
-  let _ = stdout().flush();
+  onboarding.progress("\nChecking for yt-dlp... ");
   match std::process::Command::new(&ytdlp).arg("--version").output() {
     Ok(output) if output.status.success() => {
       let version = String::from_utf8_lossy(&output.stdout);
-      println!("found ({})", version.trim());
+      onboarding.info(&format!("found ({})", version.trim()));
     }
     _ => {
-      println!("not found");
-      println!("YouTube playback needs the `yt-dlp` binary on your PATH.");
-      println!("Install it (e.g. `pipx install yt-dlp` or your distro package) and relaunch.");
-      println!(
+      onboarding.info("not found");
+      onboarding.info("YouTube playback needs the `yt-dlp` binary on your PATH.");
+      onboarding
+        .info("Install it (e.g. `pipx install yt-dlp` or your distro package) and relaunch.");
+      onboarding.info(&format!(
         "If it lives at a custom path, set behavior.ytdlp_path in {}.",
         config_file_path_display(user_config)
-      );
+      ));
     }
   }
 }
 
 #[cfg(feature = "local-files")]
-fn configure_local(user_config: &UserConfig) {
+fn configure_local(user_config: &UserConfig, onboarding: &dyn Onboarding) {
   match &user_config.behavior.local_music_path {
     Some(path) => {
-      println!("\nLocal files will be read from: {path}");
-      println!(
+      onboarding.info(&format!("\nLocal files will be read from: {path}"));
+      onboarding.info(&format!(
         "(Change behavior.local_music_path in {} to use another folder.)",
         config_file_path_display(user_config)
-      );
+      ));
     }
     None => {
-      println!("\nNo music folder was detected automatically.");
-      println!(
+      onboarding.info("\nNo music folder was detected automatically.");
+      onboarding.info(&format!(
         "Set behavior.local_music_path in {}.",
         config_file_path_display(user_config)
-      );
-    }
-  }
-}
-
-fn prompt_choice(max: usize) -> Result<usize> {
-  const MAX_RETRIES: u8 = 5;
-  let mut retries = 0;
-  loop {
-    print!("\nChoose (1-{max}): ");
-    let _ = stdout().flush();
-    let mut input = String::new();
-    stdin().read_line(&mut input)?;
-    match input.trim().parse::<usize>() {
-      Ok(n) if (1..=max).contains(&n) => return Ok(n),
-      _ => {
-        println!("Invalid choice. Please enter a number between 1 and {max}.");
-        retries += 1;
-        if retries >= MAX_RETRIES {
-          return Err(anyhow!("Maximum retries ({MAX_RETRIES}) exceeded."));
-        }
-      }
+      ));
     }
   }
 }
 
 // Only credential-collecting sources (currently Subsonic) use this.
-#[cfg_attr(not(feature = "subsonic"), allow(dead_code))]
-fn prompt_line(label: &str) -> Result<String> {
+#[cfg(feature = "subsonic")]
+fn prompt_required(onboarding: &dyn Onboarding, label: &str) -> Result<String> {
   const MAX_RETRIES: u8 = 5;
   let mut retries = 0;
   loop {
-    print!("  {label}: ");
-    let _ = stdout().flush();
-    let mut input = String::new();
-    stdin().read_line(&mut input)?;
+    let input = onboarding.prompt_line(&format!("  {label}: "))?;
     let trimmed = input.trim().to_string();
     if !trimmed.is_empty() {
       return Ok(trimmed);
     }
-    println!("  (required)");
+    onboarding.info("  (required)");
     retries += 1;
     if retries >= MAX_RETRIES {
       return Err(anyhow!("Maximum retries ({MAX_RETRIES}) exceeded."));

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -2,8 +2,9 @@
 //!
 //! `Key` is the domain vocabulary for keybindings: config parsing
 //! (`core/user_config.rs`), `App` state, and every handler speak this type.
-//! The conversion from crossterm's `KeyEvent` lives with the terminal
-//! frontend in `tui/event/key.rs`, so nothing here depends on a terminal.
+//! The conversion from the terminal backend's `KeyEvent` lives with the
+//! terminal frontend in `tui/event/key.rs`, so nothing here depends on a
+//! terminal.
 
 use std::fmt;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,6 +12,7 @@ pub mod geometry;
 pub mod input;
 pub mod limits;
 pub mod migrations;
+pub mod onboarding;
 pub mod pagination;
 pub mod paths;
 pub mod persisted_playback;

--- a/src/core/onboarding.rs
+++ b/src/core/onboarding.rs
@@ -1,0 +1,39 @@
+//! The first-launch interaction surface.
+//!
+//! Core and infra never talk to the console: every interactive first-run flow
+//! (the source picker, Spotify client setup, OAuth URL display, the manual
+//! redirect paste, source credential prompts) goes through this trait so the
+//! frontend decides how to present it. The terminal frontend's
+//! `ConsoleOnboarding` (`tui/onboarding.rs`) reproduces the historical stdout
+//! byte for byte; a windowed frontend can implement the same surface with
+//! dialogs instead.
+//!
+//! The retry loops, validation, and persistence stay with the callers - this
+//! trait is only the presentation boundary.
+
+use crate::core::source::Source;
+use anyhow::Result;
+
+pub trait Onboarding: Send + Sync {
+  /// Show one informational message, terminated like a line (a `println!` on
+  /// the console). Multi-line text is passed whole.
+  fn info(&self, text: &str);
+
+  /// Show the beginning of an in-progress line ("Testing connection... "),
+  /// completed by a later [`Self::info`] (a flushed `print!` on the console).
+  // Only the source-configuration flows emit progress fragments; builds
+  // without those sources have no caller.
+  #[cfg_attr(not(any(feature = "subsonic", feature = "youtube")), allow(dead_code))]
+  fn progress(&self, text: &str);
+
+  /// Show `prompt` verbatim (nothing appended) and read one line of input,
+  /// returned exactly as read - trailing newline included, as
+  /// [`std::io::BufRead::read_line`] produces it. Callers trim where they
+  /// mean to.
+  fn prompt_line(&self, prompt: &str) -> Result<String>;
+
+  /// First-run source picker over the compiled-in `options`. `None` means the
+  /// user cancelled or confirmed with nothing selected (the caller falls
+  /// through to the Spotify wizard, matching the historical default).
+  fn pick_sources(&self, options: &[Source]) -> Result<Option<Vec<Source>>>;
+}

--- a/src/core/test_helpers.rs
+++ b/src/core/test_helpers.rs
@@ -123,3 +123,51 @@ pub fn full_track(id: &str, name: &str) -> FullTrack {
     r#type: rspotify::model::Type::Track,
   }
 }
+
+/// Scripted [`Onboarding`] double: hands out canned prompt answers in order
+/// (each with the trailing newline `read_line` would produce) and records
+/// everything shown.
+pub struct ScriptedOnboarding {
+  answers: std::sync::Mutex<std::collections::VecDeque<String>>,
+  pub shown: std::sync::Mutex<Vec<String>>,
+}
+
+impl ScriptedOnboarding {
+  pub fn with_answers(answers: &[&str]) -> Self {
+    Self {
+      answers: std::sync::Mutex::new(answers.iter().map(|answer| format!("{answer}\n")).collect()),
+      shown: std::sync::Mutex::new(Vec::new()),
+    }
+  }
+
+  pub fn saw(&self, text: &str) -> bool {
+    self.shown.lock().unwrap().iter().any(|shown| shown == text)
+  }
+}
+
+impl crate::core::onboarding::Onboarding for ScriptedOnboarding {
+  fn info(&self, text: &str) {
+    self.shown.lock().unwrap().push(text.to_string());
+  }
+
+  fn progress(&self, text: &str) {
+    self.shown.lock().unwrap().push(text.to_string());
+  }
+
+  fn prompt_line(&self, prompt: &str) -> anyhow::Result<String> {
+    self.shown.lock().unwrap().push(prompt.to_string());
+    self
+      .answers
+      .lock()
+      .unwrap()
+      .pop_front()
+      .ok_or_else(|| anyhow::anyhow!("script ran out of answers for prompt {prompt:?}"))
+  }
+
+  fn pick_sources(
+    &self,
+    _options: &[crate::core::source::Source],
+  ) -> anyhow::Result<Option<Vec<crate::core::source::Source>>> {
+    Ok(None)
+  }
+}

--- a/src/core/theme.rs
+++ b/src/core/theme.rs
@@ -469,7 +469,7 @@ pub fn parse_theme_item(theme_item: &str) -> Result<Color> {
           b.trim().parse::<u8>()?,
         )
       } else {
-        println!("Unexpected color {}", theme_item);
+        log::warn!("Unexpected color {}", theme_item);
         Color::Black
       }
     }

--- a/src/infra/audio/pipewire_capture.rs
+++ b/src/infra/audio/pipewire_capture.rs
@@ -32,7 +32,7 @@ impl PipeWireCapture {
     // PipeWire requires its own thread with a main loop
     let thread = thread::spawn(move || {
       if let Err(e) = run_pipewire_capture(analyzer_clone, active_clone) {
-        eprintln!("[audio-viz] PipeWire capture error: {:?}", e);
+        log::error!("[audio-viz] PipeWire capture error: {:?}", e);
       }
     });
 
@@ -203,8 +203,6 @@ fn run_pipewire_capture(
       | pw::stream::StreamFlags::RT_PROCESS,
     &mut params,
   )?;
-
-  // eprintln!("[audio-viz] PipeWire stream connected (sink monitor)");
 
   // Run the main loop - this blocks until quit is called
   mainloop.run();

--- a/src/infra/audio/player.rs
+++ b/src/infra/audio/player.rs
@@ -212,7 +212,7 @@ fn open_sink() -> Result<(Player, mpsc::Sender<()>)> {
     .spawn(move || {
       match DeviceSinkBuilder::open_default_sink() {
         Ok(mut stream) => {
-          // rodio `eprintln!`s a drop warning for the `MixerDeviceSink` by
+          // rodio prints a drop warning for the `MixerDeviceSink` to stderr by
           // default (it has no `tracing` feature enabled here). Raw stderr
           // output corrupts the TUI, and the drop is deliberate anyway (device
           // handoff between sources tears the player down) — silence it.
@@ -327,16 +327,14 @@ mod tests {
 
     let player = LocalPlayer::new().expect("open default output device");
     let start = player.position();
-    eprintln!("position at start: {start:?}");
     player.play_file(&wav).expect("play wav");
 
     std::thread::sleep(Duration::from_millis(600));
     let after = player.position();
-    eprintln!("position after ~600ms: {after:?}");
 
     assert!(
       after >= Duration::from_millis(300),
-      "position should advance to roughly playback time, got {after:?}"
+      "position should advance to roughly playback time, got {after:?} (started at {start:?})"
     );
     assert!(
       after < Duration::from_secs(3),

--- a/src/infra/mcp/status.rs
+++ b/src/infra/mcp/status.rs
@@ -42,9 +42,10 @@ impl Check {
   }
 }
 
-/// Run every check and report. Returns the process exit code: `0` when the MCP
-/// setup is fully working, `1` otherwise.
-pub async fn run(as_json: bool) -> i32 {
+/// Run every check and render the report. Returns the rendered report (the
+/// caller prints it - this is library code, the CLI owns stdout) and the
+/// process exit code: `0` when the MCP setup is fully working, `1` otherwise.
+pub async fn run(as_json: bool) -> (String, i32) {
   let mut checks = Vec::new();
 
   // 1. Is the feature even compiled in? Reaching this code proves it is, which is
@@ -105,40 +106,49 @@ pub async fn run(as_json: bool) -> i32 {
 
   let ready = checks.iter().all(|check| check.ok);
 
-  if as_json {
-    let payload = json!({
-      "ready": ready,
-      "checks": checks.iter().map(|check| json!({
-        "name": check.label,
-        "ok": check.ok,
-        "detail": check.detail,
-      })).collect::<Vec<_>>(),
-      "register_command": "claude mcp add spotatui -- spotatui mcp",
-    });
-    println!(
-      "{}",
-      serde_json::to_string_pretty(&payload).unwrap_or_default()
-    );
+  let report = if as_json {
+    render_json(&checks, ready)
   } else {
-    for check in &checks {
-      println!(
+    render_text(&checks, ready)
+  };
+
+  (report, i32::from(!ready))
+}
+
+fn render_json(checks: &[Check], ready: bool) -> String {
+  let payload = json!({
+    "ready": ready,
+    "checks": checks.iter().map(|check| json!({
+      "name": check.label,
+      "ok": check.ok,
+      "detail": check.detail,
+    })).collect::<Vec<_>>(),
+    "register_command": "claude mcp add spotatui -- spotatui mcp",
+  });
+  serde_json::to_string_pretty(&payload).unwrap_or_default()
+}
+
+fn render_text(checks: &[Check], ready: bool) -> String {
+  let mut lines: Vec<String> = checks
+    .iter()
+    .map(|check| {
+      format!(
         "{} {:<14} {}",
         if check.ok { "ok  " } else { "FAIL" },
         check.label,
         check.detail
-      );
-    }
-    println!();
-    if ready {
-      println!("MCP is ready. Register it with your client, e.g.:");
-      println!("  claude mcp add spotatui -- spotatui mcp");
-    } else {
-      println!("MCP is not ready yet — see the failing check(s) above.");
-      println!("Full instructions: docs/mcp-setup.md");
-    }
+      )
+    })
+    .collect();
+  lines.push(String::new());
+  if ready {
+    lines.push("MCP is ready. Register it with your client, e.g.:".into());
+    lines.push("  claude mcp add spotatui -- spotatui mcp".into());
+  } else {
+    lines.push("MCP is not ready yet — see the failing check(s) above.".into());
+    lines.push("Full instructions: docs/mcp-setup.md".into());
   }
-
-  i32::from(!ready)
+  lines.join("\n")
 }
 
 /// Connect, authenticate, and ask the server which protocol it speaks.
@@ -205,6 +215,47 @@ pub(super) async fn probe_for_test(handshake: &Handshake) -> Result<String, Stri
 mod tests {
   use super::*;
   use tokio::net::TcpListener;
+
+  #[test]
+  fn text_report_ends_with_the_register_hint_when_ready() {
+    let checks = vec![Check::pass(
+      "binary",
+      "spotatui with the mcp-server feature",
+    )];
+    let report = render_text(&checks, true);
+    assert!(report.starts_with("ok   binary"), "{report}");
+    assert!(
+      report.ends_with(
+        "\n\nMCP is ready. Register it with your client, e.g.:\n  claude mcp add spotatui -- spotatui mcp"
+      ),
+      "{report}"
+    );
+  }
+
+  #[test]
+  fn text_report_points_at_the_failing_check_when_not_ready() {
+    let checks = vec![
+      Check::pass("binary", "x"),
+      Check::fail("control-file", "missing"),
+    ];
+    let report = render_text(&checks, false);
+    assert!(report.contains("FAIL control-file"), "{report}");
+    assert!(
+      report.ends_with("Full instructions: docs/mcp-setup.md"),
+      "{report}"
+    );
+  }
+
+  #[test]
+  fn json_report_carries_ready_and_every_check() {
+    let checks = vec![Check::fail("control-file", "missing")];
+    let report = render_json(&checks, false);
+    let value: serde_json::Value = serde_json::from_str(&report).unwrap();
+    assert_eq!(value["ready"], false);
+    assert_eq!(value["checks"][0]["name"], "control-file");
+    assert_eq!(value["checks"][0]["ok"], false);
+    assert_eq!(value["checks"][0]["detail"], "missing");
+  }
 
   #[tokio::test]
   async fn probe_reports_the_protocol_when_the_server_answers() {

--- a/src/infra/mpris.rs
+++ b/src/infra/mpris.rs
@@ -102,7 +102,7 @@ impl MprisManager {
         {
           Ok(p) => p,
           Err(e) => {
-            eprintln!("Failed to build MPRIS player: {}", e);
+            log::error!("Failed to build MPRIS player: {}", e);
             return;
           }
         };
@@ -196,7 +196,7 @@ impl MprisManager {
               let metadata = builder.build();
 
               if let Err(e) = player.set_metadata(metadata).await {
-                eprintln!("MPRIS: Failed to set metadata: {}", e);
+                log::warn!("MPRIS: Failed to set metadata: {}", e);
               }
             }
 
@@ -207,7 +207,7 @@ impl MprisManager {
                 PlaybackStatus::Paused
               };
               if let Err(e) = player.set_playback_status(status).await {
-                eprintln!("MPRIS: Failed to set playback status: {}", e);
+                log::warn!("MPRIS: Failed to set playback status: {}", e);
               }
             }
             MprisCommand::Position(position_ms) => {
@@ -219,18 +219,18 @@ impl MprisManager {
               let time = Time::from_millis(position_ms as i64);
               player.set_position(time);
               if let Err(e) = player.seeked(time).await {
-                eprintln!("MPRIS: Failed to emit Seeked signal: {}", e);
+                log::warn!("MPRIS: Failed to emit Seeked signal: {}", e);
               }
             }
             MprisCommand::Volume(volume_percent) => {
               let volume = (volume_percent as f64) / 100.0;
               if let Err(e) = player.set_volume(volume).await {
-                eprintln!("MPRIS: Failed to set volume: {}", e);
+                log::warn!("MPRIS: Failed to set volume: {}", e);
               }
             }
             MprisCommand::Shuffle(shuffle) => {
               if let Err(e) = player.set_shuffle(shuffle).await {
-                eprintln!("MPRIS: Failed to set shuffle: {}", e);
+                log::warn!("MPRIS: Failed to set shuffle: {}", e);
               }
             }
             MprisCommand::LoopStatus(loop_status) => {
@@ -241,12 +241,12 @@ impl MprisManager {
                 LoopStatusEvent::Playlist => LoopStatus::Playlist,
               };
               if let Err(e) = player.set_loop_status(status).await {
-                eprintln!("MPRIS: Failed to set loop status: {}", e);
+                log::warn!("MPRIS: Failed to set loop status: {}", e);
               }
             }
             MprisCommand::Stopped => {
               if let Err(e) = player.set_playback_status(PlaybackStatus::Stopped).await {
-                eprintln!("MPRIS: Failed to set stopped status: {}", e);
+                log::warn!("MPRIS: Failed to set stopped status: {}", e);
               }
             }
           }

--- a/src/infra/player/streaming.rs
+++ b/src/infra/player/streaming.rs
@@ -593,14 +593,16 @@ fn request_streaming_oauth_credentials() -> Result<Credentials> {
 
 /// Populate the reusable credential cache before the TUI enters raw mode.
 /// Deferred player initialization and recovery can then remain cache-only.
-pub fn ensure_streaming_credentials_cached() -> Result<()> {
+pub fn ensure_streaming_credentials_cached(
+  onboarding: &dyn crate::core::onboarding::Onboarding,
+) -> Result<()> {
   let cache_path = get_default_cache_path();
   if let Some(path) = cache_path.as_ref() {
     crate::core::paths::ensure_private_dir(path)?;
   }
   let cache = Cache::new(cache_path, None, None, None)?;
   if cache.credentials().is_none() {
-    println!("Streaming authentication required - opening browser...");
+    onboarding.info("Streaming authentication required - opening browser...");
     let credentials = request_streaming_oauth_credentials()?;
     cache.save_credentials(&credentials);
   }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -129,7 +129,7 @@ fn update_macos_metadata(
   // while the native queue owns the sink: `local_playback` is then a *suspended*
   // context, so fall through to the snapshot path, which describes the queued
   // track actually playing. Mirrors the same filter on the MPRIS twin in
-  // `crate::tui::runner::update_mpris_state`.
+  // `update_mpris_state` in the TUI runner.
   #[cfg(feature = "local-files")]
   if let Some(local) = app
     .local_playback
@@ -925,7 +925,7 @@ fn describe_client_id_notice(notice: auth::ClientIdNotice) -> String {
 /// answer applies to whichever source(s) the user sets up. Non-interactive runs
 /// default to opt-out so telemetry is never enabled for a user we couldn't ask.
 fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
-  use crossterm::tty::IsTty;
+  use std::io::IsTerminal;
 
   let config_paths = match &user_config.path_to_config {
     Some(path) => path,
@@ -956,7 +956,7 @@ fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
     return Ok(());
   }
 
-  let interactive = io::stdin().is_tty() && io::stdout().is_tty();
+  let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
   let enable = if interactive {
     println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     println!("Global Song Counter");
@@ -1164,7 +1164,8 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     // `status` is the safe probe an agent (or a human) can run; bare `mcp` is the
     // server and blocks on stdin until the client closes it.
     if let Some(status_matches) = mcp_matches.subcommand_matches("status") {
-      let code = crate::infra::mcp::run_status(status_matches.get_flag("json")).await;
+      let (report, code) = crate::infra::mcp::run_status(status_matches.get_flag("json")).await;
+      println!("{report}");
       std::process::exit(code);
     }
     crate::infra::mcp::run_relay().await?;
@@ -1301,6 +1302,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     prompt_global_song_count_opt_in(&mut user_config)?;
   }
 
+  // The console implementation of the first-launch surface; core and infra
+  // only ever see the `Onboarding` trait. `Arc` so the blocking streaming
+  // credential task below can hold its own handle.
+  let onboarding: Arc<dyn crate::core::onboarding::Onboarding> =
+    Arc::new(crate::tui::onboarding::ConsoleOnboarding);
+
   let mut client_config = ClientConfig::new();
   // First-run source picker (interactive TUI only): lets the user pick a free
   // source and skip Spotify entirely. Must run before `load_config`, which would
@@ -1311,17 +1318,18 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
       &mut user_config,
       &mut runtime_state,
       &mut client_config,
+      onboarding.as_ref(),
     )
     .await?;
   }
-  client_config.load_config()?;
+  client_config.load_config(onboarding.as_ref())?;
   info!("client authentication config loaded");
 
   let reconfigure_auth = matches.get_flag("reconfigure-auth");
 
   if reconfigure_auth {
     println!("\nReconfiguring client authentication...");
-    client_config.reconfigure_auth()?;
+    client_config.reconfigure_auth(onboarding.as_ref())?;
     println!("Client authentication setup updated.\n");
   } else if matches.subcommand_name().is_none() && client_config.needs_auth_setup_migration() {
     println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -1338,7 +1346,7 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
     let run_migration = input.is_empty() || input == "y" || input == "yes";
 
     if run_migration {
-      client_config.reconfigure_auth()?;
+      client_config.reconfigure_auth(onboarding.as_ref())?;
       println!("Client authentication setup updated.\n");
     } else {
       client_config.mark_auth_setup_migrated()?;
@@ -1362,11 +1370,14 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
   let (authenticated, installed_update) = tokio::join!(
     async {
       if spotify_required {
-        auth::authenticate_with_fallback(&mut client_config, &config_paths)
+        auth::authenticate_with_fallback(&mut client_config, &config_paths, onboarding.as_ref())
           .await
           .map(Some)
       } else {
-        Ok(auth::try_load_spotify_silently(&mut client_config, &config_paths).await)
+        Ok(
+          auth::try_load_spotify_silently(&mut client_config, &config_paths, onboarding.as_ref())
+            .await,
+        )
       }
     },
     run_auto_update(&matches, &user_config)
@@ -1489,9 +1500,12 @@ screens more often and cost more CPU. Animation-heavy views keep their separate 
           // The OAuth flow spins up a blocking local callback server and waits on
           // the browser; keep it off the async reactor so it never ties up a
           // worker thread while the user completes sign-in.
-          let cached = tokio::task::spawn_blocking(player::ensure_streaming_credentials_cached)
-            .await
-            .unwrap_or_else(|e| Err(anyhow::anyhow!("credential caching task panicked: {e}")));
+          let onboarding_for_streaming = onboarding.clone();
+          let cached = tokio::task::spawn_blocking(move || {
+            player::ensure_streaming_credentials_cached(onboarding_for_streaming.as_ref())
+          })
+          .await
+          .unwrap_or_else(|e| Err(anyhow::anyhow!("credential caching task panicked: {e}")));
           if let Err(error) = cached {
             warn!("native streaming authentication unavailable: {error}");
             // Name the actual failure. The generic message left issue #414's

--- a/src/tui/first_run.rs
+++ b/src/tui/first_run.rs
@@ -1,0 +1,177 @@
+//! Console presentation of the first-run source picker.
+//!
+//! The selection *logic* (which sources are compiled in, what happens with the
+//! choice) lives in `core/first_run.rs`; this module is only the terminal UI it
+//! is presented with: a crossterm checkbox picker on a real terminal, a
+//! numbered single-select prompt when stdin is piped.
+
+use crate::core::source::Source;
+use anyhow::{anyhow, Result};
+use crossterm::{
+  cursor,
+  event::{read, Event, KeyCode, KeyEventKind, KeyModifiers},
+  execute,
+  style::Stylize,
+  terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+use std::io::{stdin, stdout, IsTerminal, Write};
+
+/// Console source picker. Interactive terminals get the checkbox picker; piped
+/// / non-interactive stdin falls back to the numbered single-select prompt so
+/// headless and scripted runs never hang on a raw-mode read. `None` means the
+/// user cancelled or confirmed with nothing selected.
+pub fn pick_sources(options: &[Source]) -> Result<Option<Vec<Source>>> {
+  if stdout().is_terminal() && stdin().is_terminal() {
+    interactive_multiselect(options)
+  } else {
+    numbered_fallback(options).map(Some)
+  }
+}
+
+/// Interactive checkbox picker: arrow keys / j,k to move, space to toggle, enter
+/// to confirm, esc to skip. Returns the checked sources in display order, or
+/// `None` when the user cancels or confirms with nothing selected.
+///
+/// Restores the terminal via a [`RawModeGuard`] on every exit path (early return,
+/// `?`, or panic) so a mid-selection error never leaves the terminal in raw mode.
+fn interactive_multiselect(options: &[Source]) -> Result<Option<Vec<Source>>> {
+  println!("\nWelcome to spotatui! Choose your music sources:");
+  println!("You can add or switch sources anytime from the `d` menu.\n");
+
+  enable_raw_mode()?;
+  let _guard = RawModeGuard;
+
+  let mut checked = vec![false; options.len()];
+  let mut hover = 0usize;
+  // Option lines + a blank spacer + the instructions line.
+  let line_count = (options.len() + 2) as u16;
+  let mut out = stdout();
+  let mut first_draw = true;
+
+  loop {
+    if !first_draw {
+      execute!(
+        out,
+        cursor::MoveToPreviousLine(line_count),
+        Clear(ClearType::FromCursorDown)
+      )?;
+    }
+    first_draw = false;
+
+    for (index, source) in options.iter().enumerate() {
+      let pointer = if index == hover { ">" } else { " " };
+      let checkbox = if checked[index] { "[x]" } else { "[ ]" };
+      let line = format!(
+        "  {pointer} {checkbox} {}{}",
+        source.label(),
+        source_note(*source)
+      );
+      if index == hover {
+        print!("{}\r\n", line.cyan().bold());
+      } else {
+        print!("{line}\r\n");
+      }
+    }
+    print!("\r\n");
+    print!(
+      "  {}\r\n",
+      "↑/↓ move · space select · enter confirm · esc skip".dark_grey()
+    );
+    out.flush()?;
+
+    let event = read()?;
+    let key = match event {
+      // Ignore key-release / repeat events (Windows emits them) and non-key events.
+      Event::Key(key) if key.kind == KeyEventKind::Press => key,
+      _ => continue,
+    };
+
+    match key.code {
+      KeyCode::Up | KeyCode::Char('k') => {
+        hover = if hover == 0 {
+          options.len() - 1
+        } else {
+          hover - 1
+        };
+      }
+      KeyCode::Down | KeyCode::Char('j') => {
+        hover = (hover + 1) % options.len();
+      }
+      KeyCode::Char(' ') => checked[hover] = !checked[hover],
+      KeyCode::Enter => {
+        let selected: Vec<Source> = options
+          .iter()
+          .zip(&checked)
+          .filter_map(|(source, &on)| on.then_some(*source))
+          .collect();
+        return Ok(if selected.is_empty() {
+          None
+        } else {
+          Some(selected)
+        });
+      }
+      KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
+      KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(None),
+      _ => {}
+    }
+  }
+}
+
+/// Restores cooked terminal mode when dropped, so any exit path out of the
+/// interactive picker (return, `?`, panic) leaves the terminal usable.
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+  fn drop(&mut self) {
+    let _ = disable_raw_mode();
+  }
+}
+
+/// Non-interactive fallback (piped stdin): the original numbered single-select
+/// prompt. Returns a single-element `Vec` for a uniform downstream path.
+fn numbered_fallback(options: &[Source]) -> Result<Vec<Source>> {
+  println!("\nWelcome to spotatui! Choose your music source:\n");
+  for (index, source) in options.iter().enumerate() {
+    println!(
+      "  {}) {}{}",
+      index + 1,
+      source.label(),
+      source_note(*source)
+    );
+  }
+  println!("\nYou can add or switch sources anytime from the `d` menu.");
+
+  let choice = prompt_choice(options.len())?;
+  Ok(vec![options[choice - 1]])
+}
+
+fn source_note(source: Source) -> &'static str {
+  match source {
+    Source::Spotify => " (needs login)",
+    Source::YouTube => " (free, needs the yt-dlp binary)",
+    Source::Subsonic => " (free, needs a Subsonic/Navidrome server)",
+    Source::Radio => " (free)",
+    Source::Local => " (free)",
+  }
+}
+
+fn prompt_choice(max: usize) -> Result<usize> {
+  const MAX_RETRIES: u8 = 5;
+  let mut retries = 0;
+  loop {
+    print!("\nChoose (1-{max}): ");
+    let _ = stdout().flush();
+    let mut input = String::new();
+    stdin().read_line(&mut input)?;
+    match input.trim().parse::<usize>() {
+      Ok(n) if (1..=max).contains(&n) => return Ok(n),
+      _ => {
+        println!("Invalid choice. Please enter a number between 1 and {max}.");
+        retries += 1;
+        if retries >= MAX_RETRIES {
+          return Err(anyhow!("Maximum retries ({MAX_RETRIES}) exceeded."));
+        }
+      }
+    }
+  }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "cover-art")]
 pub mod cover_art;
 pub mod event;
+pub mod first_run;
 pub mod handlers;
 pub mod layout;
+pub mod onboarding;
 pub mod runner;
 pub mod theme;
 pub mod ui;

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -1,0 +1,36 @@
+//! Console implementation of the first-launch surface.
+//!
+//! Reproduces the pre-trait stdout byte for byte: `info` is a `println!`,
+//! `progress` a flushed `print!`, `prompt_line` shows the prompt verbatim and
+//! reads one raw line, and `pick_sources` is the terminal source picker in
+//! `tui/first_run.rs`.
+
+use crate::core::onboarding::Onboarding;
+use crate::core::source::Source;
+use anyhow::Result;
+use std::io::{stdin, stdout, Write};
+
+pub struct ConsoleOnboarding;
+
+impl Onboarding for ConsoleOnboarding {
+  fn info(&self, text: &str) {
+    println!("{text}");
+  }
+
+  fn progress(&self, text: &str) {
+    print!("{text}");
+    let _ = stdout().flush();
+  }
+
+  fn prompt_line(&self, prompt: &str) -> Result<String> {
+    print!("{prompt}");
+    let _ = stdout().flush();
+    let mut input = String::new();
+    stdin().read_line(&mut input)?;
+    Ok(input)
+  }
+
+  fn pick_sources(&self, options: &[Source]) -> Result<Option<Vec<Source>>> {
+    super::first_run::pick_sources(options)
+  }
+}

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 153              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1346            # floor: may only rise
+test_attribute_total = 1352            # floor: may only rise


### PR DESCRIPTION
# Summary

Core and infra no longer talk to the console. All first-launch interaction (source picker, Spotify client setup wizard, OAuth URL display, manual redirect paste, source credential prompts) now goes through a new `core::onboarding::Onboarding` trait, with the console implementation living in the terminal frontend (`tui/onboarding.rs::ConsoleOnboarding`) and reproducing today's output byte for byte.

- `core/first_run.rs` keeps only the selection logic; the crossterm checkbox picker, numbered fallback prompt, and raw-mode guard moved to `tui/first_run.rs`.
- `core/config.rs` / `core/auth.rs` wizard and OAuth flows print and prompt via the trait; their retry loops stay put and are now unit-testable with a scripted onboarding double (3 new tests).
- `spotatui mcp status` rendering moved out of the printing path: `infra/mcp/status.rs` returns the rendered report plus exit code, the caller prints it (output unchanged; 3 new render tests).
- Stray `println!`/`eprintln!` in library code (`App::dispatch`, theme parsing, MPRIS, PipeWire capture) became `log::` calls, so they no longer corrupt the TUI when they fire mid-session.
- `crossterm::tty::IsTty` in the bootstrap replaced with `std::io::IsTerminal` (std since 1.70).

After this, `git grep println! src/core src/infra` and `git grep crossterm src/core src/infra src/cli` are both empty: only frontends and the CLI (whose stdout is protocol) write to the console. `test_attribute_total` floor rises 1346 -> 1352; the other gate counters are unchanged.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings` clean
- `cargo test --no-default-features --features telemetry,tui` 591 passed
- `cargo test` (default features) 889 passed
- `cargo check` on `telemetry` (headless), `telemetry,tui,mcp-server`, `telemetry,tui,ai-dj`, and `telemetry,tui,all-sources` all clean
- `bash tools/check_gates_ratchet.sh origin/main` ok
- No `Cargo.toml`/`Cargo.lock` changes

# Additional notes

Behavior is intended to be identical for every existing flow: same bytes on stdout, same stdin reads, same retry limits. The riskiest surface is the fresh-install path (no `client.yml`): the source picker and auth wizard now run through the trait plumbing, so a first-run smoke test (or `--reconfigure-auth`) is the one worth doing before merge.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent onboarding experience for first-run setup, authentication, and credential configuration.
  - Added interactive source selection for terminal users, with a numbered fallback for non-interactive environments.
  - Improved prompts, progress messages, validation, and cancellation handling during setup.

- **Improvements**
  - Status reports can now be rendered in text or JSON while preserving existing formats.
  - Errors and warnings are reported through structured logging for clearer diagnostics.
  - Unexpected setup input continues with safe fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->