### PR TITLE
refactor(core): extract the tick driver from the runner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,7 @@ units under `src/`:
 
 | Unit | Role |
 |------|------|
-| `core/` | Centralized state (`App`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
+| `core/` | Centralized state (`App`), the frontend-neutral tick scheduler (`driver/`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
 | `infra/` | Spotify Web API (`network/`), native librespot streaming (`player/`), alternative sources (`local/`, `subsonic/`, `radio/`, `youtube/`, `queue/`), audio viz (`audio/`), Lua scripting (`scripting/`), AI DJ + MCP (`dj/`, `mcp/`), OS integrations (Discord RPC, MPRIS, macOS/Windows media) |
 | `tui/` | Terminal UI: the event/render loop (`runner.rs`), key plumbing (`event/`), per-block input handlers (`handlers/`), immutable draw fns (`ui/`) |
 | `cli/` | clap subcommands: playback control, listening history, self-update, MCP relay, plugin management |
@@ -100,8 +100,15 @@ crossterm thread (tui/event/) → runner.rs loop (draws the frame, then reads on
 ```
 
 `tui/event/` is only the crossterm→`Key` plumbing; the event loop itself is
-`tui/runner.rs::start_ui`, which also owns Discord/MPRIS presence sync, the window
-title, and cover-art request scheduling. Mouse input enters via `handlers::mouse_handler`.
+`tui/runner.rs::start_ui`. Everything on a timer lives in `core/driver/`
+(`Driver::tick`): the playback tick + debounced flushes, OAuth refresh,
+Discord/MPRIS presence sync, the window title, lyrics + cover-art scheduling,
+native-queue and decoded-source auto-advance, and `last_session.yml`
+persistence. The runner draws frames, reads events, and calls `driver.tick`
+with a `TickEnv` carrying the frontend-geometry inputs (visualizer bar count,
+cover-art pixel support). A frontend that stops ticking is loud, not silent:
+`App::playback_position_ms()` reads stale after 2s and the playbar says so.
+Mouse input enters via `handlers::mouse_handler`.
 
 ### The IoEvent pump: source routing, two lanes, an auth gate
 
@@ -375,7 +382,10 @@ working in those directories.
   read one `PlaybackSnapshot` from `infra/media_metadata.rs`, which checks
   decoded sources first so the paused Spotify track is not published.
 - YouTube is unofficial-fragile by design: when it breaks, the fix is a newer
-  `yt-dlp`, not a spotatui release.
+  `yt-dlp`, not a spotatui release. One in-repo mitigation: a failed download
+  retries once through the embedded player clients (`web_embedded,tv_embedded`),
+  which PO-token enforcement leaves tokenless for embeddable videos - most
+  label uploads. A non-embeddable gated video still fails.
 
 ### Testing conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ units under `src/`:
 
 | Unit | Role |
 |------|------|
-| `core/` | Centralized state (`App`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
+| `core/` | Centralized state (`App`), the frontend-neutral tick scheduler (`driver/`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
 | `infra/` | Spotify Web API (`network/`), native librespot streaming (`player/`), alternative sources (`local/`, `subsonic/`, `radio/`, `youtube/`, `queue/`), audio viz (`audio/`), Lua scripting (`scripting/`), AI DJ + MCP (`dj/`, `mcp/`), OS integrations (Discord RPC, MPRIS, macOS/Windows media) |
 | `tui/` | Terminal UI: the event/render loop (`runner.rs`), key plumbing (`event/`), per-block input handlers (`handlers/`), immutable draw fns (`ui/`) |
 | `cli/` | clap subcommands: playback control, listening history, self-update, MCP relay, plugin management |
@@ -102,8 +102,15 @@ crossterm thread (tui/event/) → runner.rs loop (draws the frame, then reads on
 ```
 
 `tui/event/` is only the crossterm→`Key` plumbing; the event loop itself is
-`tui/runner.rs::start_ui`, which also owns Discord/MPRIS presence sync, the window
-title, and cover-art request scheduling. Mouse input enters via `handlers::mouse_handler`.
+`tui/runner.rs::start_ui`. Everything on a timer lives in `core/driver/`
+(`Driver::tick`): the playback tick + debounced flushes, OAuth refresh,
+Discord/MPRIS presence sync, the window title, lyrics + cover-art scheduling,
+native-queue and decoded-source auto-advance, and `last_session.yml`
+persistence. The runner draws frames, reads events, and calls `driver.tick`
+with a `TickEnv` carrying the frontend-geometry inputs (visualizer bar count,
+cover-art pixel support). A frontend that stops ticking is loud, not silent:
+`App::playback_position_ms()` reads stale after 2s and the playbar says so.
+Mouse input enters via `handlers::mouse_handler`.
 
 ### The IoEvent pump: source routing, two lanes, an auth gate
 
@@ -377,7 +384,10 @@ working in those directories.
   read one `PlaybackSnapshot` from `infra/media_metadata.rs`, which checks
   decoded sources first so the paused Spotify track is not published.
 - YouTube is unofficial-fragile by design: when it breaks, the fix is a newer
-  `yt-dlp`, not a spotatui release.
+  `yt-dlp`, not a spotatui release. One in-repo mitigation: a failed download
+  retries once through the embedded player clients (`web_embedded,tv_embedded`),
+  which PO-token enforcement leaves tokenless for embeddable videos - most
+  label uploads. A non-embeddable gated video still fails.
 
 ### Testing conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ units under `src/`:
 
 | Unit | Role |
 |------|------|
-| `core/` | Centralized state (`App`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
+| `core/` | Centralized state (`App`), the frontend-neutral tick scheduler (`driver/`), config/state persistence, and the rspotify-free domain types (`plugin_api`, `pagination`, `source`) |
 | `infra/` | Spotify Web API (`network/`), native librespot streaming (`player/`), alternative sources (`local/`, `subsonic/`, `radio/`, `youtube/`, `queue/`), audio viz (`audio/`), Lua scripting (`scripting/`), AI DJ + MCP (`dj/`, `mcp/`), OS integrations (Discord RPC, MPRIS, macOS/Windows media) |
 | `tui/` | Terminal UI: the event/render loop (`runner.rs`), key plumbing (`event/`), per-block input handlers (`handlers/`), immutable draw fns (`ui/`) |
 | `cli/` | clap subcommands: playback control, listening history, self-update, MCP relay, plugin management |
@@ -102,8 +102,15 @@ crossterm thread (tui/event/) → runner.rs loop (draws the frame, then reads on
 ```
 
 `tui/event/` is only the crossterm→`Key` plumbing; the event loop itself is
-`tui/runner.rs::start_ui`, which also owns Discord/MPRIS presence sync, the window
-title, and cover-art request scheduling. Mouse input enters via `handlers::mouse_handler`.
+`tui/runner.rs::start_ui`. Everything on a timer lives in `core/driver/`
+(`Driver::tick`): the playback tick + debounced flushes, OAuth refresh,
+Discord/MPRIS presence sync, the window title, lyrics + cover-art scheduling,
+native-queue and decoded-source auto-advance, and `last_session.yml`
+persistence. The runner draws frames, reads events, and calls `driver.tick`
+with a `TickEnv` carrying the frontend-geometry inputs (visualizer bar count,
+cover-art pixel support). A frontend that stops ticking is loud, not silent:
+`App::playback_position_ms()` reads stale after 2s and the playbar says so.
+Mouse input enters via `handlers::mouse_handler`.
 
 ### The IoEvent pump: source routing, two lanes, an auth gate
 
@@ -377,7 +384,10 @@ working in those directories.
   read one `PlaybackSnapshot` from `infra/media_metadata.rs`, which checks
   decoded sources first so the paused Spotify track is not published.
 - YouTube is unofficial-fragile by design: when it breaks, the fix is a newer
-  `yt-dlp`, not a spotatui release.
+  `yt-dlp`, not a spotatui release. One in-repo mitigation: a failed download
+  retries once through the embedded player clients (`web_embedded,tv_embedded`),
+  which PO-token enforcement leaves tokenless for embeddable videos - most
+  label uploads. A non-embeddable gated video still fails.
 
 ### Testing conventions
 

--- a/src/core/app/construction.rs
+++ b/src/core/app/construction.rs
@@ -110,6 +110,7 @@ impl Default for App {
         tracks: None,
       },
       song_progress_ms: 0,
+      last_tick_at: Instant::now(),
       seek_ms: None,
       #[cfg(feature = "streaming")]
       last_native_seek: None,

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -274,6 +274,10 @@ pub struct App {
   #[allow(dead_code)]
   pub small_search_limit: u32,
   pub song_progress_ms: u128,
+  /// When `update_on_tick` last ran. Every frontend must drive the tick (see
+  /// `core::driver`); `playback_position_ms` reports stale past 2s so one
+  /// that stops ticking shows a loud error instead of a frozen playbar.
+  pub last_tick_at: Instant,
   pub seek_ms: Option<u128>,
   /// Last time a native seek was actually sent to the player (for throttling)
   #[cfg(feature = "streaming")]
@@ -344,7 +348,7 @@ pub struct App {
   pub is_fetching_current_playback: bool,
   /// Expiry of the current Spotify access token, or `None` when there is no
   /// Spotify session (launched against a free source). The token-refresh poll
-  /// in the runner skips refreshing while this is `None`.
+  /// in the driver skips refreshing while this is `None`.
   pub spotify_token_expiry: Option<SystemTime>,
   /// Whether a Spotify session is available (token loaded at startup or added
   /// via in-TUI login). Gates the Spotify-only startup dispatches so a

--- a/src/core/app/tick.rs
+++ b/src/core/app/tick.rs
@@ -1,6 +1,18 @@
 use super::*;
 
+/// Grace window after the last tick before playback-position reads go stale.
+const STALE_TICK_AFTER: Duration = Duration::from_secs(2);
+
 impl App {
+  /// Milliseconds into the current track, or `None` when no tick has run for
+  /// over [`STALE_TICK_AFTER`]. A frontend that stops driving
+  /// `core::driver::Driver::tick` (or never starts) would otherwise show a
+  /// silently frozen playbar; `None` is the loud version of that failure,
+  /// rendered as an explicit stall by the playbar.
+  pub fn playback_position_ms(&self) -> Option<u128> {
+    (self.last_tick_at.elapsed() <= STALE_TICK_AFTER).then_some(self.song_progress_ms)
+  }
+
   fn poll_current_playback(&mut self) {
     // No Spotify session (free-source launch): the poll would hit the auth gate
     // and re-flash a "connect Spotify" status message every interval. Free
@@ -36,6 +48,8 @@ impl App {
   }
 
   pub fn update_on_tick(&mut self, elapsed: Duration) {
+    self.last_tick_at = Instant::now();
+
     // Increment global animation tick (wraps after ~9.4 quintillion ticks, effectively never)
     self.animation_tick = self.animation_tick.wrapping_add(1);
 
@@ -269,6 +283,22 @@ mod tests {
     // Nothing dispatched: no per-tick "connect Spotify" auth-spam for free sources.
     assert!(rx.try_recv().is_err());
     assert!(!app.is_fetching_current_playback);
+  }
+
+  #[test]
+  fn playback_position_goes_stale_without_ticks_and_recovers_on_one() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), None);
+    app.song_progress_ms = 1234;
+    assert_eq!(app.playback_position_ms(), Some(1234));
+
+    // A frontend that stops ticking: the position must read as stale rather
+    // than freeze at its last value.
+    app.last_tick_at = Instant::now() - Duration::from_secs(3);
+    assert_eq!(app.playback_position_ms(), None);
+
+    app.update_on_tick(Duration::from_millis(500));
+    assert!(app.playback_position_ms().is_some());
   }
 
   #[test]

--- a/src/core/app/tick.rs
+++ b/src/core/app/tick.rs
@@ -3,6 +3,14 @@ use super::*;
 /// Grace window after the last tick before playback-position reads go stale.
 const STALE_TICK_AFTER: Duration = Duration::from_secs(2);
 
+// The window must cover at least two of the slowest allowed ticks, so one
+// missed frame can never read as stale. The tick rate is bounded on every
+// path (config load rejects out-of-range values, the settings screen clamps),
+// and this assertion keeps the two constants coupled if either ever moves.
+const _: () = assert!(
+  STALE_TICK_AFTER.as_millis() >= 2 * crate::core::user_config::MAX_TICK_RATE_MILLISECONDS as u128
+);
+
 impl App {
   /// Milliseconds into the current track, or `None` when no tick has run for
   /// over [`STALE_TICK_AFTER`]. A frontend that stops driving

--- a/src/core/driver/mod.rs
+++ b/src/core/driver/mod.rs
@@ -1,0 +1,762 @@
+//! The frontend-neutral scheduler ("the driver"): everything the app must do
+//! on a timer, extracted from the terminal event loop so any frontend can run
+//! playback correctly by calling [`Driver::tick`] at its tick rate.
+//!
+//! One tick advances playback state (`App::update_on_tick` plus the debounced
+//! seek/volume/state flushes), refreshes the OAuth token, syncs OS presence
+//! (Discord, MPRIS, window title), detects track changes (lyrics + cover
+//! art), auto-advances the native queue and the decoded sources, persists the
+//! non-Spotify session, and feeds the audio visualizer.
+//!
+//! What stays with the frontend, injected through [`TickEnv`] or kept at the
+//! call site: the visualizer bar count (a function of frontend geometry), the
+//! terminal image-protocol probe behind `TickEnv::cover_art_full_image_support`,
+//! and the macOS `NSRunLoop` pump (the frontend owns the main thread).
+//!
+//! A frontend that stops ticking is a bug this module makes loud:
+//! `App::playback_position_ms` reports stale once no tick has run for two
+//! seconds, instead of leaving a silently frozen playbar.
+
+mod plan;
+mod presence;
+
+use crate::core::app::{App, RouteId};
+use crate::core::auth;
+#[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+use crate::infra::audio;
+#[cfg(feature = "discord-rpc")]
+use crate::infra::discord_rpc;
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+use crate::infra::mpris;
+use crate::infra::network::IoEvent;
+#[cfg(feature = "scripting")]
+use crate::infra::scripting::ScriptEngine;
+#[cfg(feature = "scripting")]
+use log::info;
+use std::sync::{atomic::AtomicU64, Arc};
+use std::time::{Duration, Instant, SystemTime};
+
+#[cfg(feature = "discord-rpc")]
+pub type DiscordRpcHandle = Option<discord_rpc::DiscordRpcManager>;
+#[cfg(not(feature = "discord-rpc"))]
+pub type DiscordRpcHandle = Option<()>;
+
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+pub type MprisHandle = Option<Arc<mpris::MprisManager>>;
+#[cfg(not(all(feature = "mpris", target_os = "linux")))]
+pub type MprisHandle = Option<()>;
+
+/// Identity of the currently-playing track, used by the shared track-change
+/// detector to fire lyrics + cover-art fetches exactly once per track (rather
+/// than every tick). Title + artists + album + duration distinguishes tracks
+/// across every source without depending on a source-specific id.
+type TrackIdentity = (String, Vec<String>, String, u32);
+
+fn track_identity(snapshot: &crate::infra::media_metadata::PlaybackSnapshot) -> TrackIdentity {
+  (
+    snapshot.metadata.title.clone(),
+    snapshot.metadata.artists.clone(),
+    snapshot.metadata.album.clone(),
+    snapshot.metadata.duration_ms,
+  )
+}
+
+/// Resolve what cover art to fetch for the track described by `snapshot`.
+///
+/// Local files carry embedded artwork read straight from the file (no URL), so
+/// they take a dedicated `LocalFile` request. Every other source that can supply
+/// art (Spotify album art, YouTube thumbnail, Subsonic getCoverArt) surfaces it
+/// as `snapshot.metadata.image_url`. `None` means the current track has no art
+/// to show (e.g. internet radio, or a Spotify item without images).
+#[cfg(feature = "art-decode")]
+fn cover_art_request_for(
+  app: &App,
+  snapshot: &crate::infra::media_metadata::PlaybackSnapshot,
+) -> Option<crate::core::art::CoverArtRequest> {
+  use crate::core::art::CoverArtRequest;
+
+  #[cfg(feature = "local-files")]
+  if let Some(local) = app.local_playback.as_ref() {
+    let uri = local.queue.get(local.index)?;
+    let path = crate::infra::local::file_uri_to_path(uri).ok()?;
+    return Some(CoverArtRequest::LocalFile {
+      key: uri.clone(),
+      path,
+    });
+  }
+  #[cfg(not(feature = "local-files"))]
+  let _ = app;
+
+  snapshot
+    .metadata
+    .image_url
+    .clone()
+    .map(CoverArtRequest::Url)
+}
+
+/// Per-tick inputs only the frontend can supply.
+pub struct TickEnv {
+  /// Wall-clock instant of this tick; injected so the driver's throttling
+  /// decisions stay deterministic under test.
+  pub now: Instant,
+  /// Visualizer bar count resolved from the frontend's geometry, or `None`
+  /// while the analysis view is not showing (which releases the capture).
+  #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+  pub viz_bars: Option<usize>,
+  /// Whether the frontend renders real pixels for cover art (the terminal
+  /// image-protocol probe); false in a decode-only build, where art is
+  /// fetched solely for the adaptive theme.
+  #[cfg(feature = "art-decode")]
+  pub cover_art_full_image_support: bool,
+}
+
+/// The scheduler's own state: everything that used to live as locals of the
+/// terminal event loop, one instance per frontend session.
+pub struct Driver {
+  /// Real-time position updates from the native player's event handler,
+  /// read lock-free instead of waiting on the polled Spotify context.
+  shared_position: Option<Arc<AtomicU64>>,
+  #[cfg(all(feature = "mpris", target_os = "linux"))]
+  mpris_manager: MprisHandle,
+  #[cfg(feature = "discord-rpc")]
+  discord_rpc_manager: DiscordRpcHandle,
+  #[cfg(feature = "scripting")]
+  script_engine: Option<ScriptEngine>,
+  #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+  audio_capture: Option<audio::AudioCaptureManager>,
+  /// Previous tick's `is_streaming_active`, so a native session that ends can
+  /// push a final stopped state to MPRIS clients.
+  #[cfg(all(feature = "mpris", target_os = "linux"))]
+  prev_is_streaming_active: bool,
+  #[cfg(feature = "discord-rpc")]
+  discord_presence: presence::DiscordPresenceState,
+  #[cfg(all(feature = "mpris", target_os = "linux"))]
+  mpris_state: presence::MprisState,
+  window_title: presence::WindowTitleState,
+  /// Last track the shared detector fired lyrics for, so the lookup re-fires
+  /// only on an actual track change rather than every tick.
+  last_track_identity: Option<TrackIdentity>,
+  /// Cache key (URL / file URI) of the cover art last requested, so the
+  /// per-tick cover-art evaluation dispatches a fetch only when the resolved
+  /// art changes.
+  #[cfg(feature = "art-decode")]
+  last_cover_art_key: Option<String>,
+  /// Throttle state for `last_session.yml` (see `plan::session_persist_action`):
+  /// `last_session_save` spaces the periodic writes; `session_was_present`
+  /// lets a Some -> None transition (queue ended, switched to Spotify) clear
+  /// the file so a stale session is never resurrected.
+  last_session_save: Option<Instant>,
+  session_was_present: bool,
+  /// Whether the active internet-radio stream has produced audio yet, so the
+  /// tick can tell "stream just started, sink not filled" apart from "stream
+  /// died / drained" — both of which report `is_finished()` (empty sink).
+  #[cfg(feature = "internet-radio")]
+  radio_stream_started: bool,
+}
+
+impl Driver {
+  pub fn new(
+    shared_position: Option<Arc<AtomicU64>>,
+    mpris_manager: MprisHandle,
+    discord_rpc_manager: DiscordRpcHandle,
+  ) -> Self {
+    #[cfg(not(all(feature = "mpris", target_os = "linux")))]
+    let _ = mpris_manager;
+    #[cfg(not(feature = "discord-rpc"))]
+    let _ = discord_rpc_manager;
+
+    // The Lua VM (plus its HTTP client) is only constructed when the user
+    // actually has script files; a zero-plugin install skips the engine — and
+    // its per-tick `on_tick` dispatch — entirely.
+    #[cfg(feature = "scripting")]
+    let script_engine: Option<ScriptEngine> = {
+      let config_dir = crate::core::user_config::default_app_config_dir();
+      match config_dir {
+        Some(config_dir) if ScriptEngine::has_user_scripts(&config_dir) => {
+          match ScriptEngine::new() {
+            Ok(mut engine) => {
+              let loaded = engine.load_user_scripts(&config_dir);
+              info!("loaded {loaded} lua plugin file(s)");
+              Some(engine)
+            }
+            Err(e) => {
+              log::error!("failed to initialize lua scripting engine: {e}");
+              None
+            }
+          }
+        }
+        _ => {
+          info!("no lua plugin files found; scripting engine not started");
+          None
+        }
+      }
+    };
+
+    Driver {
+      shared_position,
+      #[cfg(all(feature = "mpris", target_os = "linux"))]
+      mpris_manager,
+      #[cfg(feature = "discord-rpc")]
+      discord_rpc_manager,
+      #[cfg(feature = "scripting")]
+      script_engine,
+      #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+      audio_capture: None,
+      #[cfg(all(feature = "mpris", target_os = "linux"))]
+      prev_is_streaming_active: false,
+      #[cfg(feature = "discord-rpc")]
+      discord_presence: presence::DiscordPresenceState::default(),
+      #[cfg(all(feature = "mpris", target_os = "linux"))]
+      mpris_state: presence::MprisState::default(),
+      window_title: presence::WindowTitleState::default(),
+      last_track_identity: None,
+      #[cfg(feature = "art-decode")]
+      last_cover_art_key: None,
+      last_session_save: None,
+      session_was_present: false,
+      #[cfg(feature = "internet-radio")]
+      radio_stream_started: false,
+    }
+  }
+
+  /// One tick. The frontend calls this at its tick rate with the `App` lock
+  /// held; everything slow (file I/O, network) is dispatched off-lock.
+  pub fn tick(&mut self, app: &mut App, elapsed: Duration, env: TickEnv) {
+    #[cfg(feature = "streaming")]
+    if let Some(player) = app.streaming_player.clone() {
+      if let Some(error) = player.take_audio_backend_error() {
+        app.pause_native_playback();
+        app.set_status_message(format!("Audio backend failed: {error}"), 15);
+      }
+    }
+
+    #[cfg(all(feature = "mpris", target_os = "linux"))]
+    {
+      let current_is_streaming_active = app.is_streaming_active;
+      if self.prev_is_streaming_active && !current_is_streaming_active {
+        if let Some(ref mpris) = self.mpris_manager {
+          mpris.set_stopped();
+        }
+      }
+      self.prev_is_streaming_active = current_is_streaming_active;
+    }
+
+    // Only refresh when a Spotify session exists; a free-source launch has no
+    // token expiry and must not schedule refreshes. This lives on the tick so
+    // every frontend gets it: one that skipped it would work for exactly one
+    // token lifetime and then 401 forever.
+    if let Some(expiry) = app.spotify_token_expiry {
+      if auth::should_refresh_token_at(expiry, SystemTime::now()) && !app.auth_refresh_in_progress {
+        app.auth_refresh_in_progress = true;
+        app.dispatch(IoEvent::RefreshAuthentication);
+      }
+    }
+
+    app.update_on_tick(elapsed);
+
+    #[cfg(feature = "streaming")]
+    app.flush_pending_native_seek();
+    app.flush_pending_api_seek();
+    app.flush_pending_source_seek();
+    app.flush_pending_volume();
+    app.flush_state_save(false);
+
+    #[cfg(feature = "scripting")]
+    if let Some(engine) = self.script_engine.as_mut() {
+      engine.on_tick(app);
+    }
+
+    #[cfg(feature = "discord-rpc")]
+    if let Some(ref manager) = self.discord_rpc_manager {
+      presence::update_discord_presence(manager, &mut self.discord_presence, app);
+    }
+
+    #[cfg(all(feature = "mpris", target_os = "linux"))]
+    if let Some(ref mpris) = self.mpris_manager {
+      presence::update_mpris_state(mpris, &mut self.mpris_state, app);
+    }
+
+    // Shared track-change detector. One place decides "the playing track
+    // changed" off the source-agnostic snapshot, then drives BOTH lyrics
+    // (every source) and cover art (cover-art feature) — so both light up
+    // for Spotify, local files, Subsonic, radio and YouTube through a single
+    // path.
+    {
+      let snapshot = crate::infra::media_metadata::current_playback_snapshot(app);
+
+      // Lyrics fire once per track (identity latch): their inputs — title,
+      // artist, duration — ARE the identity, so they are correct at the
+      // instant the identity changes.
+      let identity = snapshot.as_ref().map(track_identity);
+      if identity != self.last_track_identity {
+        self.last_track_identity = identity;
+        app.lyrics_view.reset();
+        match snapshot.as_ref() {
+          Some(snapshot) => {
+            use crate::infra::media_metadata::PlaybackItemKind;
+            // LRCLIB lookup by title + artist + duration. Source agnostic;
+            // radio (duration 0) simply resolves to "not found". Podcast
+            // episodes have no lyrics, so skip the lookup and show the
+            // not-found message rather than stale lyrics.
+            if snapshot.item_kind == PlaybackItemKind::Track {
+              let title = snapshot.metadata.title.clone();
+              // The identity latch keys on the joined display credit, but the
+              // LRCLIB lookup needs the structured artist list so it can fall
+              // back to the primary artist alone for collaborations (#410).
+              let artists = snapshot.metadata.artists.clone();
+              app.desired_lyrics_identity = Some((title.clone(), artists.join(", ")));
+              app.dispatch(IoEvent::GetLyrics(
+                title,
+                artists,
+                snapshot.metadata.duration_ms as f64 / 1000.0,
+              ));
+            } else {
+              app.desired_lyrics_identity = None;
+              app.lyrics = None;
+              app.lyrics_status = crate::core::app::LyricsStatus::NotFound;
+              app
+                .plugin_data_generations
+                .bump(crate::core::app::PluginDataKind::Lyrics);
+            }
+          }
+          None => {
+            app.desired_lyrics_identity = None;
+            // Nothing is playing: reset so no stale lyrics linger.
+            app.lyrics = None;
+            app.lyrics_status = crate::core::app::LyricsStatus::NotStarted;
+            app
+              .plugin_data_generations
+              .bump(crate::core::app::PluginDataKind::Lyrics);
+          }
+        }
+      }
+
+      // Cover art is re-evaluated EVERY tick against the desired image key,
+      // NOT latched to the identity change. With native streaming the
+      // snapshot's `image_url` comes from the polled Spotify context, which
+      // catches up seconds *after* `native_track_info` flips the identity —
+      // an identity-latched fetch would fire once with the previous track's
+      // URL (or none at startup) and never see the real one, leaving the art
+      // stuck or missing until restart. Comparing against
+      // `last_cover_art_key` keeps this a no-op on quiet ticks and fires
+      // exactly once whenever the resolved art actually changes.
+      #[cfg(feature = "art-decode")]
+      {
+        use crate::core::art::CoverArtStatus;
+        let enabled = app
+          .user_config
+          .needs_cover_art(env.cover_art_full_image_support);
+        let desired = if enabled {
+          snapshot
+            .as_ref()
+            .and_then(|snapshot| cover_art_request_for(app, snapshot))
+        } else {
+          None
+        };
+        match plan::cover_art_action(
+          desired.as_ref().map(|request| request.key()),
+          self.last_cover_art_key.as_deref(),
+          app.cover_art.available(),
+          enabled,
+          snapshot.is_some(),
+        ) {
+          plan::CoverArtAction::Fetch => {
+            let request = desired.expect("Fetch is only planned with a desired request");
+            app.desired_cover_art_key = Some(request.key().to_string());
+            self.last_cover_art_key = Some(request.key().to_string());
+            // Keep the previous image on screen until the new one
+            // resolves (smooth swap); the fetch runs off-lock.
+            app.cover_art.status = CoverArtStatus::Loading;
+            app.dispatch(IoEvent::FetchCoverArt(request));
+          }
+          plan::CoverArtAction::Keep => {
+            app.desired_cover_art_key = desired.map(|request| request.key().to_string());
+          }
+          plan::CoverArtAction::Drop { clear, status } => {
+            app.desired_cover_art_key = None;
+            self.last_cover_art_key = None;
+            // No art to show (radio, art disabled, nothing playing): drop
+            // any stale image once, so the pane shows the placeholder.
+            if clear {
+              app.clear_cover_art();
+            }
+            app.cover_art.status = status;
+          }
+        }
+      }
+    }
+
+    // Native queue slot: when the queued track finishes, advance the queue
+    // (play the next queued item, or resume the suspended context). Runs
+    // before the per-source blocks so it takes precedence over them.
+    #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+    {
+      use crate::infra::queue::QueueNowPlaying;
+      let advance = match app.queue_now.as_mut() {
+        Some(QueueNowPlaying::Decoded(d))
+          if plan::native_queue_advance_due(d.player.is_finished(), d.advancing) =>
+        {
+          d.advancing = true; // atomic check-and-set: one dispatch only
+          true
+        }
+        _ => false,
+      };
+      if advance {
+        app.dispatch(IoEvent::AdvanceNativeQueue);
+      }
+    }
+
+    // Auto-queue refill. Dispatch only: this path holds `&mut App`, so the
+    // brain call itself must happen on the detached service lane. The
+    // generation goes along for the ride so a refill the user has since
+    // abandoned (DJ off, vibe shift, source change) can be dropped when it
+    // lands instead of queueing tracks for a session that is gone.
+    #[cfg(feature = "ai-dj")]
+    {
+      if crate::infra::network::dj::wants_top_up(
+        app.native_queue.len(),
+        &app.dj,
+        app.spotify_external_device_active(),
+      ) {
+        let turn_seq = app.dj.begin_turn(crate::infra::dj::TurnKind::Refill);
+        let generation = app.dj.generation;
+        // Not `dispatch`: that pins the global `is_loading` spinner until the
+        // service-lane task finishes, which for a brain call is minutes. The
+        // DJ's own `thinking` flag is the progress surface here.
+        app.dispatch_without_spinner(IoEvent::DjTopUp(generation, turn_seq));
+      }
+    }
+
+    // Decoded-source auto-advance, one macro invocation per source (the
+    // blocks are identical except for which `*_playback` session and queue
+    // field they read). Each session reads its progress live from the
+    // player at render time; the only state self-managed here is
+    // end-of-track. When the sink drains and no track change is already in
+    // flight (`!advancing`), `plan::decoded_advance` picks the move: advance /
+    // replay (repeat-one) / suspend to the native queue / tear down.
+    //
+    // Decide under one borrow, then act after the borrow ends. `advancing`
+    // is set *synchronously here* (atomic check-and-set, before
+    // dispatching) because the sink stays empty for the whole decode — or,
+    // for Subsonic/YouTube, multi-second download — window; without it the
+    // next tick would re-dispatch and skip several tracks per advance.
+    #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+    macro_rules! decoded_auto_advance {
+      ($app:ident, $playback:ident, $queue:ident) => {
+        if !$app.queue_owns_playback() {
+          use crate::infra::queue::next_index;
+          let queue_len = $app.native_queue.len();
+          let repeat = $app.decoded_repeat;
+          let advance = $app.$playback.as_ref().map(|s| {
+            plan::decoded_advance(
+              s.player.is_finished(),
+              s.advancing,
+              next_index(s.index, s.$queue.len()).is_some(),
+              queue_len,
+              repeat,
+            )
+          });
+          match advance {
+            Some(plan::DecodedAdvance::Dispatch { replay }) => {
+              if let Some(s) = $app.$playback.as_mut() {
+                s.advancing = true; // atomic check-and-set: one dispatch only
+              }
+              $app.dispatch(if replay {
+                IoEvent::ReplayCurrentTrack
+              } else {
+                IoEvent::NextTrack
+              });
+            }
+            Some(plan::DecodedAdvance::SuspendToQueue) => {
+              // End-of-track handoff: under Repeat One the context resumes
+              // the same track, so a queued song can't consume the repeat.
+              $app.suspend_active_decoded_context_for_skip(
+                crate::infra::queue::SuspendCause::AutoAdvance,
+              );
+              $app.dispatch(IoEvent::AdvanceNativeQueue);
+            }
+            Some(plan::DecodedAdvance::Teardown) => $app.$playback = None,
+            Some(plan::DecodedAdvance::None) | None => {}
+          }
+        }
+      };
+    }
+    #[cfg(feature = "local-files")]
+    decoded_auto_advance!(app, local_playback, queue);
+    #[cfg(feature = "subsonic")]
+    decoded_auto_advance!(app, subsonic_playback, tracks);
+    #[cfg(feature = "youtube")]
+    decoded_auto_advance!(app, youtube_playback, tracks);
+
+    // Apply any shuffle toggle that was deferred while a track change was in
+    // flight, now that the advance may have committed (a cheap no-op when the
+    // queue order already matches the decoded shuffle state).
+    #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+    app.reconcile_decoded_shuffle();
+
+    // Internet radio has no queue to auto-advance; instead the tick watches
+    // for a live stream that dies (server disconnect or the ring buffer
+    // draining to EOF), which leaves `is_finished()` (empty sink) true while
+    // the session was never paused. `is_finished()` is also true during the
+    // brief pre-playback window before the first bytes arrive, so only tear
+    // down once the stream has actually started producing audio.
+    #[cfg(feature = "internet-radio")]
+    match app.radio_playback.as_ref() {
+      Some(radio) => {
+        if !radio.player.is_finished() {
+          self.radio_stream_started = true;
+        } else if self.radio_stream_started {
+          app.radio_playback = None;
+          self.radio_stream_started = false;
+          app.set_status_message("Radio stream ended", 4);
+        }
+      }
+      None => self.radio_stream_started = false,
+    }
+
+    // A decoded non-Spotify source owns the sink while its `*_playback` is
+    // `Some`. Drive `song_progress_ms` from its live player, and do NOT let
+    // the (paused) librespot position below clobber it.
+    #[allow(unused_mut)]
+    let mut source_owns_playback = false;
+    // The native queue slot owns the sink when playing a decoded track; read
+    // progress from its player first (it may share the suspended context's
+    // player, in which case a per-source block below reads the same value).
+    #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+    if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
+      source_owns_playback = true;
+      app.song_progress_ms = d.player.position().as_millis();
+    }
+    #[allow(unused_variables)]
+    let spotify_queue_slot = app.queue_now_is_spotify();
+    #[cfg(feature = "local-files")]
+    if !spotify_queue_slot {
+      if let Some(local) = app.local_playback.as_ref() {
+        source_owns_playback = true;
+        let position_ms = local.player.position().as_millis();
+        app.song_progress_ms = position_ms;
+      }
+    }
+    #[cfg(feature = "subsonic")]
+    if !spotify_queue_slot {
+      if let Some(subsonic) = app.subsonic_playback.as_ref() {
+        source_owns_playback = true;
+        let position_ms = subsonic.player.position().as_millis();
+        app.song_progress_ms = position_ms;
+      }
+    }
+    #[cfg(feature = "internet-radio")]
+    if !spotify_queue_slot {
+      if let Some(radio) = app.radio_playback.as_ref() {
+        source_owns_playback = true;
+        let position_ms = radio.player.position().as_millis();
+        app.song_progress_ms = position_ms;
+      }
+    }
+    #[cfg(feature = "youtube")]
+    if !spotify_queue_slot {
+      if let Some(youtube) = app.youtube_playback.as_ref() {
+        source_owns_playback = true;
+        let position_ms = youtube.player.position().as_millis();
+        app.song_progress_ms = position_ms;
+      }
+    }
+
+    // Persist the active non-Spotify session so it resumes on next launch.
+    // Throttled to avoid churning the file every tick; a Some -> None
+    // transition (queue ended, or switched to Spotify) clears it instead.
+    let has_session = app.has_persistable_session();
+    match plan::session_persist_action(
+      has_session,
+      self.session_was_present,
+      self.last_session_save,
+      env.now,
+    ) {
+      plan::SessionPersist::Save => {
+        self.last_session_save = Some(env.now);
+        // Snapshot (clones the queue) only when a save is actually due,
+        // not on every tick.
+        if let Some(session) = app.current_persisted_session() {
+          // Fire-and-forget on the blocking pool: file I/O never blocks the
+          // UI tick, and a dropped handle still runs to completion.
+          tokio::task::spawn_blocking(move || {
+            if let Ok(path) = crate::core::persisted_playback::default_session_path() {
+              if let Err(e) = crate::core::persisted_playback::save(&path, &session) {
+                log::warn!("[session] failed to persist playback session: {e}");
+              }
+            }
+          });
+        }
+      }
+      plan::SessionPersist::Clear => {
+        self.last_session_save = None;
+        tokio::task::spawn_blocking(|| {
+          if let Ok(path) = crate::core::persisted_playback::default_session_path() {
+            if let Err(e) = crate::core::persisted_playback::clear(&path) {
+              log::warn!("[session] failed to clear playback session: {e}");
+            }
+          }
+        });
+      }
+      plan::SessionPersist::None => {}
+    }
+    self.session_was_present = has_session;
+
+    #[cfg(feature = "streaming")]
+    if !source_owns_playback {
+      if let Some(ref pos) = self.shared_position {
+        if app.is_streaming_active {
+          let recently_seeked = app
+            .last_native_seek
+            .is_some_and(|t| t.elapsed().as_millis() < crate::core::app::SEEK_POSITION_IGNORE_MS);
+
+          if !recently_seeked {
+            let position_ms = pos.load(std::sync::atomic::Ordering::Relaxed);
+            if position_ms > 0 {
+              app.song_progress_ms = position_ms as u128;
+            }
+          }
+        }
+      }
+    }
+    #[cfg(not(feature = "streaming"))]
+    if !source_owns_playback {
+      if let Some(ref pos) = self.shared_position {
+        if app.is_streaming_active {
+          let position_ms = pos.load(std::sync::atomic::Ordering::Relaxed);
+          if position_ms > 0 {
+            app.song_progress_ms = position_ms as u128;
+          }
+        }
+      }
+    }
+
+    #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+    match env.viz_bars {
+      Some(desired_bars) => {
+        if self.audio_capture.is_none() {
+          // Built at the count we are about to ask for, so the first frame
+          // does not immediately throw the fresh cavacore plan away.
+          self.audio_capture = audio::AudioCaptureManager::new(desired_bars);
+          app.audio_capture_active = self.audio_capture.is_some();
+        }
+
+        if let Some(ref capture) = self.audio_capture {
+          if let Some(spectrum) = capture.get_spectrum(desired_bars) {
+            app.spectrum_data = Some(spectrum);
+          }
+          // Kept outside the spectrum arm: a dead stream must drop the
+          // "Capturing audio" status instead of freezing it on.
+          app.audio_capture_active = capture.is_active();
+        }
+      }
+      None => {
+        if self.audio_capture.is_some() {
+          self.audio_capture = None;
+          app.audio_capture_active = false;
+          app.spectrum_data = None;
+        }
+      }
+    }
+  }
+
+  /// The one-shot startup dispatch, fired by the frontend right after its
+  /// first frame: initial Spotify fetches, the startup route's data, the
+  /// persisted active source's sidebar data, and `--play-file`.
+  pub fn dispatch_startup(&mut self, app: &mut App) {
+    // Spotify-only startup fetches: skip them entirely when launched against a
+    // free source with no Spotify session, so the network layer doesn't reject
+    // three events with "connect Spotify" status flashes on every launch.
+    if app.spotify_connected {
+      app.dispatch(IoEvent::GetCurrentPlayback);
+      app.dispatch(IoEvent::GetPlaylists);
+      app.dispatch(IoEvent::GetUser);
+    }
+    // startup_route seeds the nav stack directly (App::new), bypassing the
+    // handlers that normally fetch a screen's data on navigation — kick
+    // off that fetch here or the screen renders empty until re-entered.
+    // (Home needs nothing extra; Discover fetches from within its menu.)
+    // Spotify-backed screens are gated on a connected session; Stats reads
+    // local history so it always fetches.
+    match app.get_current_route().id {
+      RouteId::RecentlyPlayed if app.spotify_connected => app.dispatch(IoEvent::GetRecentlyPlayed),
+      RouteId::AlbumList if app.spotify_connected => {
+        app.dispatch(IoEvent::GetCurrentUserSavedAlbums(None))
+      }
+      RouteId::Artists if app.spotify_connected => app.dispatch(IoEvent::GetFollowedArtists(None)),
+      RouteId::Podcasts if app.spotify_connected => {
+        app.dispatch(IoEvent::GetCurrentUserSavedShows(None))
+      }
+      RouteId::Stats => {
+        app.stats_loading = true;
+        let period = app.stats_period;
+        app.dispatch(IoEvent::LoadListeningStats(period));
+      }
+      _ => {}
+    }
+    // A persisted non-Spotify active source needs its sidebar data loaded
+    // too (all of these are inert no-ops when the feature is off).
+    match app.active_source {
+      crate::core::source::Source::Local => app.dispatch(IoEvent::GetLocalPlaylists),
+      crate::core::source::Source::Subsonic => app.dispatch(IoEvent::GetSubsonicPlaylists),
+      crate::core::source::Source::Radio => app.dispatch(IoEvent::GetRadioStations),
+      crate::core::source::Source::YouTube => app.dispatch(IoEvent::GetYouTubePlaylists),
+      crate::core::source::Source::Spotify => {}
+    }
+    if app.user_config.behavior.enable_global_song_count {
+      app.dispatch(IoEvent::FetchGlobalSongCount);
+    }
+    app.dispatch(IoEvent::FetchAnnouncements);
+
+    // `--play-file`: kick off local playback now that dispatch is wired.
+    if let Some(uri) = app.pending_play_file.take() {
+      app.dispatch(IoEvent::StartPlayback(Some(uri), None, None));
+    }
+
+    #[cfg(feature = "scripting")]
+    if let Some(engine) = self.script_engine.as_mut() {
+      engine.on_start(app);
+    }
+  }
+
+  /// Run any plugin commands a keypress queued; the frontend calls this after
+  /// each key event. No-op without the `scripting` feature.
+  pub fn run_pending_script_commands(&mut self, app: &mut App) {
+    #[cfg(feature = "scripting")]
+    if let Some(engine) = self.script_engine.as_mut() {
+      engine.run_pending_commands(app);
+    }
+    #[cfg(not(feature = "scripting"))]
+    let _ = app;
+  }
+
+  /// The window title the frontend should apply now, or `None` when it is
+  /// unchanged. Called once per frame (cheaper than a tick, and a title
+  /// change should not wait for one).
+  pub fn next_window_title(&mut self, app: &App) -> Option<String> {
+    presence::next_window_title(&mut self.window_title, app)
+  }
+
+  /// On teardown: the default title to restore if this session changed it.
+  pub fn window_title_reset(&mut self) -> Option<&'static str> {
+    presence::window_title_reset(&mut self.window_title)
+  }
+
+  /// The scripting quit hook. No-op without the `scripting` feature.
+  pub fn on_quit(&mut self, app: &mut App) {
+    #[cfg(feature = "scripting")]
+    if let Some(engine) = self.script_engine.as_mut() {
+      engine.on_quit(app);
+    }
+    #[cfg(not(feature = "scripting"))]
+    let _ = app;
+  }
+
+  /// Clear any published rich presence on the way out.
+  pub fn clear_presence(&self) {
+    #[cfg(feature = "discord-rpc")]
+    if let Some(ref manager) = self.discord_rpc_manager {
+      manager.clear();
+    }
+  }
+}

--- a/src/core/driver/mod.rs
+++ b/src/core/driver/mod.rs
@@ -220,7 +220,9 @@ impl Driver {
   }
 
   /// One tick. The frontend calls this at its tick rate with the `App` lock
-  /// held; everything slow (file I/O, network) is dispatched off-lock.
+  /// held; everything slow (file I/O, network) is dispatched off-lock. Must
+  /// run inside a Tokio runtime: session persistence goes through
+  /// `tokio::task::spawn_blocking`, which panics without one.
   pub fn tick(&mut self, app: &mut App, elapsed: Duration, env: TickEnv) {
     #[cfg(feature = "streaming")]
     if let Some(player) = app.streaming_player.clone() {

--- a/src/core/driver/plan.rs
+++ b/src/core/driver/plan.rs
@@ -1,0 +1,323 @@
+//! Pure per-tick decisions, split out of [`super::Driver::tick`] in the house
+//! style: scalars in, plain data out. Each one used to live inline in the
+//! terminal event loop, where it was untestable without an audio sink, a
+//! Spotify session, or a real clock; here every decision runs against fake
+//! inputs. The driver probes live state (`player.is_finished()`, `Instant`),
+//! asks these functions what to do, then applies the answer.
+
+#[cfg(feature = "art-decode")]
+use crate::core::art::CoverArtStatus;
+#[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+use crate::infra::queue::{advance_decision, Decision, RepeatMode};
+use std::time::{Duration, Instant};
+
+/// How often the active non-Spotify playback session is persisted to
+/// `last_session.yml` while it keeps playing.
+const SESSION_SAVE_INTERVAL: Duration = Duration::from_secs(3);
+
+/// What the session persister should do this tick.
+#[derive(Debug, PartialEq)]
+pub(super) enum SessionPersist {
+  /// A save is due: snapshot the session and write it.
+  Save,
+  /// The session just ended (Some -> None transition): clear the file so a
+  /// stale session is never resurrected on the next launch.
+  Clear,
+  None,
+}
+
+/// Throttled `last_session.yml` persistence: save at most every
+/// [`SESSION_SAVE_INTERVAL`] while a session is active (immediately on the
+/// first tick that has one), and clear the file exactly once when it goes
+/// away.
+pub(super) fn session_persist_action(
+  has_session: bool,
+  was_present: bool,
+  last_save: Option<Instant>,
+  now: Instant,
+) -> SessionPersist {
+  if has_session {
+    let due = last_save
+      .map(|t| now.duration_since(t) >= SESSION_SAVE_INTERVAL)
+      .unwrap_or(true);
+    if due {
+      SessionPersist::Save
+    } else {
+      SessionPersist::None
+    }
+  } else if was_present {
+    SessionPersist::Clear
+  } else {
+    SessionPersist::None
+  }
+}
+
+/// Whether the native queue slot's finished track should advance the queue.
+/// `advancing` is the atomic check-and-set flag that guarantees one dispatch
+/// per finished track: the sink stays empty for the whole decode/download of
+/// the next item, so without it every tick in that window would re-dispatch.
+#[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+pub(super) fn native_queue_advance_due(finished: bool, advancing: bool) -> bool {
+  finished && !advancing
+}
+
+/// What the tick does about a decoded-source session, as plain data so the
+/// glue between [`advance_decision`] and the dispatch/suspend/teardown calls
+/// is testable without a sink.
+#[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+#[derive(Debug, PartialEq)]
+pub(super) enum DecodedAdvance {
+  /// Mark the session advancing and dispatch the track change: replay the
+  /// current track (repeat-one) or advance within the context.
+  Dispatch {
+    replay: bool,
+  },
+  /// Hand the sink to the native queue.
+  SuspendToQueue,
+  /// Context exhausted and the queue is empty: drop the session.
+  Teardown,
+  None,
+}
+
+/// Decoded-source auto-advance for one tick, composing [`advance_decision`]
+/// (the shared end-of-track policy) with the action the driver takes on it.
+#[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+pub(super) fn decoded_advance(
+  finished: bool,
+  advancing: bool,
+  has_next: bool,
+  queue_len: usize,
+  repeat: RepeatMode,
+) -> DecodedAdvance {
+  match advance_decision(finished, advancing, has_next, queue_len, repeat) {
+    Decision::AdvanceContext => DecodedAdvance::Dispatch { replay: false },
+    Decision::RepeatTrack => DecodedAdvance::Dispatch { replay: true },
+    Decision::SuspendToQueue => DecodedAdvance::SuspendToQueue,
+    Decision::Teardown => DecodedAdvance::Teardown,
+    Decision::None => DecodedAdvance::None,
+  }
+}
+
+/// What the per-tick cover-art evaluation should do. See the call site for why
+/// this re-evaluates every tick against the desired key instead of latching to
+/// the track identity.
+#[cfg(feature = "art-decode")]
+#[derive(Debug, PartialEq)]
+pub(super) enum CoverArtAction {
+  /// New art resolved: latch its key, mark it loading, dispatch the fetch.
+  Fetch,
+  /// Same art as already requested: leave everything alone.
+  Keep,
+  /// No art to show (radio, art disabled, nothing playing): drop any stale
+  /// image once, then show `status` in the pane.
+  Drop { clear: bool, status: CoverArtStatus },
+}
+
+#[cfg(feature = "art-decode")]
+pub(super) fn cover_art_action(
+  desired_key: Option<&str>,
+  last_requested_key: Option<&str>,
+  art_loaded: bool,
+  enabled: bool,
+  snapshot_present: bool,
+) -> CoverArtAction {
+  match desired_key {
+    Some(key) => {
+      if last_requested_key == Some(key) {
+        CoverArtAction::Keep
+      } else {
+        CoverArtAction::Fetch
+      }
+    }
+    None => CoverArtAction::Drop {
+      clear: last_requested_key.is_some() || art_loaded,
+      status: if enabled && snapshot_present {
+        CoverArtStatus::Unavailable
+      } else {
+        CoverArtStatus::NotStarted
+      },
+    },
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn first_tick_with_a_session_saves_immediately() {
+    let now = Instant::now();
+    assert_eq!(
+      session_persist_action(true, false, None, now),
+      SessionPersist::Save
+    );
+  }
+
+  #[test]
+  fn session_saves_are_throttled_to_the_interval() {
+    let t0 = Instant::now();
+    let just_after = t0 + Duration::from_secs(1);
+    let past_interval = t0 + SESSION_SAVE_INTERVAL;
+
+    assert_eq!(
+      session_persist_action(true, true, Some(t0), just_after),
+      SessionPersist::None
+    );
+    assert_eq!(
+      session_persist_action(true, true, Some(t0), past_interval),
+      SessionPersist::Save
+    );
+  }
+
+  #[test]
+  fn ending_a_session_clears_the_file_exactly_once() {
+    let now = Instant::now();
+    // Some -> None transition: clear.
+    assert_eq!(
+      session_persist_action(false, true, Some(now), now),
+      SessionPersist::Clear
+    );
+    // Already cleared (was_present false): nothing left to do.
+    assert_eq!(
+      session_persist_action(false, false, None, now),
+      SessionPersist::None
+    );
+  }
+
+  #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
+  mod decoded {
+    use super::*;
+
+    #[test]
+    fn a_finished_queue_track_advances_the_queue_once() {
+      assert!(native_queue_advance_due(true, false));
+      // The advancing latch holds the whole decode/download window.
+      assert!(!native_queue_advance_due(true, true));
+      assert!(!native_queue_advance_due(false, false));
+    }
+
+    #[test]
+    fn a_finished_track_with_a_next_advances_the_context() {
+      assert_eq!(
+        decoded_advance(true, false, true, 0, RepeatMode::Off),
+        DecodedAdvance::Dispatch { replay: false }
+      );
+    }
+
+    #[test]
+    fn repeat_one_replays_instead_of_advancing() {
+      assert_eq!(
+        decoded_advance(true, false, true, 0, RepeatMode::Track),
+        DecodedAdvance::Dispatch { replay: true }
+      );
+    }
+
+    #[test]
+    fn a_waiting_queue_preempts_the_context_advance() {
+      // Even under repeat-one: a queued song must not consume the repeat.
+      assert_eq!(
+        decoded_advance(true, false, true, 1, RepeatMode::Track),
+        DecodedAdvance::SuspendToQueue
+      );
+    }
+
+    #[test]
+    fn an_exhausted_context_with_an_empty_queue_tears_down() {
+      assert_eq!(
+        decoded_advance(true, false, false, 0, RepeatMode::Off),
+        DecodedAdvance::Teardown
+      );
+    }
+
+    #[test]
+    fn an_advance_already_in_flight_dispatches_nothing() {
+      // The sink is empty for the whole decode; without the latch every tick
+      // in that window would dispatch another skip.
+      assert_eq!(
+        decoded_advance(true, true, true, 0, RepeatMode::Off),
+        DecodedAdvance::None
+      );
+      assert_eq!(
+        decoded_advance(false, false, true, 0, RepeatMode::Off),
+        DecodedAdvance::None
+      );
+    }
+  }
+
+  #[cfg(feature = "art-decode")]
+  mod cover_art {
+    use super::*;
+
+    #[test]
+    fn newly_resolved_art_fetches_and_unchanged_art_keeps() {
+      assert_eq!(
+        cover_art_action(Some("url-a"), None, false, true, true),
+        CoverArtAction::Fetch
+      );
+      assert_eq!(
+        cover_art_action(Some("url-a"), Some("url-a"), true, true, true),
+        CoverArtAction::Keep
+      );
+    }
+
+    #[test]
+    fn art_resolving_late_still_fetches() {
+      // Native streaming: the snapshot's image_url catches up seconds after
+      // the track identity flips, so the desired key appears (or changes)
+      // ticks later. The key comparison, not an identity latch, must fire.
+      assert_eq!(
+        cover_art_action(None, None, false, true, true),
+        CoverArtAction::Drop {
+          clear: false,
+          status: CoverArtStatus::Unavailable
+        }
+      );
+      assert_eq!(
+        cover_art_action(Some("real-url"), None, false, true, true),
+        CoverArtAction::Fetch
+      );
+      assert_eq!(
+        cover_art_action(Some("next-url"), Some("real-url"), true, true, true),
+        CoverArtAction::Fetch
+      );
+    }
+
+    #[test]
+    fn losing_the_art_drops_the_stale_image_once() {
+      // A track with art was playing; now radio (no art) is: clear once...
+      assert_eq!(
+        cover_art_action(None, Some("url-a"), true, true, true),
+        CoverArtAction::Drop {
+          clear: true,
+          status: CoverArtStatus::Unavailable
+        }
+      );
+      // ...and quiet ticks afterwards have nothing left to clear.
+      assert_eq!(
+        cover_art_action(None, None, false, true, true),
+        CoverArtAction::Drop {
+          clear: false,
+          status: CoverArtStatus::Unavailable
+        }
+      );
+    }
+
+    #[test]
+    fn disabled_art_and_silence_read_as_not_started() {
+      assert_eq!(
+        cover_art_action(None, Some("url-a"), true, false, true),
+        CoverArtAction::Drop {
+          clear: true,
+          status: CoverArtStatus::NotStarted
+        }
+      );
+      assert_eq!(
+        cover_art_action(None, None, false, true, false),
+        CoverArtAction::Drop {
+          clear: false,
+          status: CoverArtStatus::NotStarted
+        }
+      );
+    }
+  }
+}

--- a/src/core/driver/presence.rs
+++ b/src/core/driver/presence.rs
@@ -1,0 +1,394 @@
+//! Presence sync: Discord Rich Presence, MPRIS, and the window title. Each
+//! keeps a last-published copy so quiet ticks publish nothing. Moved verbatim
+//! out of the terminal runner; nothing here touches a terminal — the frontend
+//! only applies the returned window title.
+
+use crate::core::app::App;
+#[cfg(feature = "discord-rpc")]
+use crate::infra::discord_rpc;
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+use crate::infra::mpris;
+
+pub(super) const DEFAULT_WINDOW_TITLE: &str = "spt - spotatui";
+
+#[derive(Default)]
+pub(super) struct WindowTitleState {
+  last_title: Option<String>,
+}
+
+#[cfg(feature = "discord-rpc")]
+#[derive(Clone, Debug, PartialEq)]
+struct DiscordTrackInfo {
+  title: String,
+  artist: String,
+  album: String,
+  image_url: Option<String>,
+  duration_ms: u32,
+}
+
+#[cfg(feature = "discord-rpc")]
+#[derive(Default)]
+pub(super) struct DiscordPresenceState {
+  last_track: Option<DiscordTrackInfo>,
+  last_is_playing: Option<bool>,
+  last_progress_ms: u128,
+}
+
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+#[derive(Default, PartialEq)]
+struct MprisMetadata {
+  title: String,
+  artists: Vec<String>,
+  album: String,
+  duration_ms: u32,
+  art_url: Option<String>,
+}
+
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+#[derive(Default)]
+pub(super) struct MprisState {
+  last_metadata: Option<MprisMetadata>,
+  last_is_playing: Option<bool>,
+  last_shuffle: Option<bool>,
+  last_loop: Option<mpris::LoopStatusEvent>,
+}
+
+#[cfg(feature = "discord-rpc")]
+fn build_discord_playback(app: &App) -> Option<discord_rpc::DiscordPlayback> {
+  let snapshot = crate::infra::media_metadata::current_playback_snapshot(app)?;
+  let artist = snapshot.primary_artist();
+  let track_info = DiscordTrackInfo {
+    title: snapshot.metadata.title,
+    artist,
+    album: snapshot.metadata.album,
+    image_url: snapshot.metadata.image_url,
+    duration_ms: snapshot.metadata.duration_ms,
+  };
+
+  let base_state = if track_info.album.is_empty() {
+    track_info.artist.clone()
+  } else {
+    format!("{} - {}", track_info.artist, track_info.album)
+  };
+  let state = if snapshot.is_playing {
+    base_state
+  } else if base_state.is_empty() {
+    "Paused".to_string()
+  } else {
+    format!("Paused: {}", base_state)
+  };
+
+  Some(discord_rpc::DiscordPlayback {
+    title: track_info.title,
+    artist: track_info.artist,
+    album: track_info.album,
+    state,
+    image_url: track_info.image_url,
+    duration_ms: track_info.duration_ms,
+    progress_ms: snapshot.progress_ms,
+    is_playing: snapshot.is_playing,
+  })
+}
+
+#[cfg(feature = "discord-rpc")]
+pub(super) fn update_discord_presence(
+  manager: &discord_rpc::DiscordRpcManager,
+  state: &mut DiscordPresenceState,
+  app: &App,
+) {
+  let playback = build_discord_playback(app);
+
+  match playback {
+    Some(playback) => {
+      let track_info = DiscordTrackInfo {
+        title: playback.title.clone(),
+        artist: playback.artist.clone(),
+        album: playback.album.clone(),
+        image_url: playback.image_url.clone(),
+        duration_ms: playback.duration_ms,
+      };
+
+      let track_changed = state.last_track.as_ref() != Some(&track_info);
+      let playing_changed = state.last_is_playing != Some(playback.is_playing);
+      let progress_delta = playback.progress_ms.abs_diff(state.last_progress_ms);
+      let progress_changed = progress_delta > 5000;
+
+      if track_changed || playing_changed || progress_changed {
+        manager.set_activity(&playback);
+        state.last_track = Some(track_info);
+        state.last_is_playing = Some(playback.is_playing);
+        state.last_progress_ms = playback.progress_ms;
+      }
+    }
+    None => {
+      if state.last_track.is_some() {
+        manager.clear();
+        state.last_track = None;
+        state.last_is_playing = None;
+        state.last_progress_ms = 0;
+      }
+    }
+  }
+}
+
+#[cfg(all(feature = "mpris", target_os = "linux"))]
+pub(super) fn update_mpris_state(manager: &mpris::MprisManager, state: &mut MprisState, app: &App) {
+  use rspotify::model::enums::RepeatState;
+
+  // Local-file playback owns its own state and never populates the Spotify
+  // playback context, so it takes a dedicated path that reads metadata, play
+  // state, and position straight from the live local player. Skipped while the
+  // native queue owns the sink: `local_playback` is then a *suspended* context,
+  // so fall through to the snapshot path, which renders the queue slot and
+  // clears its shuffle/repeat instead of publishing this context's stale modes.
+  #[cfg(feature = "local-files")]
+  if let Some(local) = app
+    .local_playback
+    .as_ref()
+    .filter(|_| !app.queue_owns_playback())
+  {
+    use crate::infra::media_metadata::{select_media_metadata, LocalMediaMetadata};
+
+    let is_playing = !local.player.is_paused();
+    let position_ms = local.player.position().as_millis() as u64;
+
+    // `select_media_metadata` is the single, unit-tested decision for which
+    // source the OS integration follows; local always wins while it is active.
+    let metadata = select_media_metadata(
+      Some(LocalMediaMetadata {
+        title: local.name.clone(),
+        artists: vec![local.artists.clone()],
+        album: local.album.clone(),
+        duration_ms: local.duration_ms as u32,
+      }),
+      None,
+    )
+    .expect("local metadata is present");
+
+    let new_metadata = MprisMetadata {
+      title: metadata.title.clone(),
+      artists: metadata.artists.clone(),
+      album: metadata.album.clone(),
+      duration_ms: metadata.duration_ms,
+      art_url: metadata.image_url.clone(),
+    };
+    if state.last_metadata.as_ref() != Some(&new_metadata) {
+      manager.set_metadata(
+        &metadata.title,
+        &metadata.artists,
+        &metadata.album,
+        metadata.duration_ms,
+        metadata.image_url,
+      );
+      state.last_metadata = Some(new_metadata);
+    }
+
+    if state.last_is_playing != Some(is_playing) {
+      manager.set_playback_status(is_playing);
+      state.last_is_playing = Some(is_playing);
+    }
+
+    manager.set_position(position_ms);
+
+    // Local playback carries the decoded shuffle/repeat modes; push them like
+    // the snapshot branch below so keyboard and MPRIS toggles reach clients
+    // (this dedicated branch returns before the snapshot path runs).
+    if state.last_shuffle != Some(app.decoded_shuffle) {
+      manager.set_shuffle(app.decoded_shuffle);
+      state.last_shuffle = Some(app.decoded_shuffle);
+    }
+    let loop_status = match app.decoded_repeat {
+      crate::infra::queue::RepeatMode::Off => mpris::LoopStatusEvent::None,
+      crate::infra::queue::RepeatMode::Track => mpris::LoopStatusEvent::Track,
+      crate::infra::queue::RepeatMode::Context => mpris::LoopStatusEvent::Playlist,
+    };
+    if state.last_loop != Some(loop_status) {
+      manager.set_loop_status(loop_status);
+      state.last_loop = Some(loop_status);
+    }
+    return;
+  }
+
+  if let Some(snapshot) = crate::infra::media_metadata::current_playback_snapshot(app) {
+    let new_metadata = MprisMetadata {
+      title: snapshot.metadata.title.clone(),
+      artists: snapshot.metadata.artists.clone(),
+      album: snapshot.metadata.album.clone(),
+      duration_ms: snapshot.metadata.duration_ms,
+      art_url: snapshot.metadata.image_url.clone(),
+    };
+    if state.last_metadata.as_ref() != Some(&new_metadata) {
+      manager.set_metadata(
+        &snapshot.metadata.title,
+        &snapshot.metadata.artists,
+        &snapshot.metadata.album,
+        snapshot.metadata.duration_ms,
+        snapshot.metadata.image_url.clone(),
+      );
+      state.last_metadata = Some(new_metadata);
+    }
+
+    if state.last_is_playing != Some(snapshot.is_playing) {
+      manager.set_playback_status(snapshot.is_playing);
+      state.last_is_playing = Some(snapshot.is_playing);
+    }
+
+    manager.set_position(snapshot.progress_ms as u64);
+
+    if state.last_shuffle != Some(snapshot.shuffle) {
+      manager.set_shuffle(snapshot.shuffle);
+      state.last_shuffle = Some(snapshot.shuffle);
+    }
+
+    // A `None` repeat means the source has no repeat control (native queue,
+    // radio); reset to `None` rather than leaving a stale Track/Playlist that a
+    // prior decoded context pushed.
+    let loop_status = match snapshot.repeat {
+      Some(RepeatState::Track) => mpris::LoopStatusEvent::Track,
+      Some(RepeatState::Context) => mpris::LoopStatusEvent::Playlist,
+      Some(RepeatState::Off) | None => mpris::LoopStatusEvent::None,
+    };
+    if state.last_loop != Some(loop_status) {
+      manager.set_loop_status(loop_status);
+      state.last_loop = Some(loop_status);
+    }
+  } else if state.last_metadata.is_some() {
+    manager.set_stopped();
+    state.last_metadata = None;
+    state.last_is_playing = None;
+  }
+}
+
+fn playback_window_title(app: &App) -> String {
+  let Some(snapshot) = crate::infra::media_metadata::current_playback_snapshot(app) else {
+    return DEFAULT_WINDOW_TITLE.to_string();
+  };
+
+  let title = sanitize_window_title_component(&snapshot.metadata.title);
+  let artist_raw = sanitize_window_title_component(&snapshot.primary_artist());
+  // Compose the artist segment with the em-dash separator, matching today's
+  // `"{title} — {artist}"` output; omitted when there's no artist.
+  let artist = if artist_raw.trim().is_empty() {
+    String::new()
+  } else {
+    format!(" — {}", artist_raw)
+  };
+  app
+    .user_config
+    .format
+    .window_title
+    .render(&[&title, &artist])
+}
+
+fn sanitize_window_title_component(value: &str) -> String {
+  value.chars().filter(|c| !c.is_control()).collect()
+}
+
+pub(super) fn next_window_title(state: &mut WindowTitleState, app: &App) -> Option<String> {
+  if !app.user_config.behavior.set_window_title {
+    return state
+      .last_title
+      .take()
+      .map(|_| DEFAULT_WINDOW_TITLE.to_string());
+  }
+
+  let title = playback_window_title(app);
+  if state.last_title.as_ref() == Some(&title) {
+    None
+  } else {
+    state.last_title = Some(title.clone());
+    Some(title)
+  }
+}
+
+/// The teardown half: the default title to restore on exit, or `None` when
+/// the title was never changed away from it. Clears the latch either way.
+pub(super) fn window_title_reset(state: &mut WindowTitleState) -> Option<&'static str> {
+  state
+    .last_title
+    .take()
+    .filter(|title| title != DEFAULT_WINDOW_TITLE)
+    .map(|_| DEFAULT_WINDOW_TITLE)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::app::NativeTrackInfo;
+  use std::{sync::mpsc::channel, time::SystemTime};
+
+  fn app() -> App {
+    let (tx, _rx) = channel();
+    App::new(
+      tx,
+      crate::core::user_config::UserConfig::new(),
+      Some(SystemTime::now()),
+    )
+  }
+
+  #[test]
+  fn playback_window_title_uses_current_native_track() {
+    let mut app = app();
+    app.is_streaming_active = true;
+    app.native_track_info = Some(NativeTrackInfo {
+      name: "The Track".to_string(),
+      artists: vec!["The Artist".to_string()],
+      album: "The Album".to_string(),
+      duration_ms: 180_000,
+      kind: crate::core::app::NativeTrackKind::Track,
+      image_url: None,
+    });
+
+    assert_eq!(playback_window_title(&app), "The Track — The Artist");
+  }
+
+  #[test]
+  fn playback_window_title_strips_control_characters() {
+    let mut app = app();
+    app.is_streaming_active = true;
+    app.native_track_info = Some(NativeTrackInfo {
+      name: "The\x1b]2;Bad\x07 Track".to_string(),
+      artists: vec!["The\nArtist".to_string()],
+      album: "The Album".to_string(),
+      duration_ms: 180_000,
+      kind: crate::core::app::NativeTrackKind::Track,
+      image_url: None,
+    });
+
+    assert_eq!(playback_window_title(&app), "The]2;Bad Track — TheArtist");
+  }
+
+  #[test]
+  fn playback_window_title_falls_back_without_playback() {
+    let app = app();
+
+    assert_eq!(playback_window_title(&app), DEFAULT_WINDOW_TITLE);
+  }
+
+  #[test]
+  fn disabling_window_title_restores_default_once() {
+    let mut app = app();
+    let mut state = WindowTitleState {
+      last_title: Some("The Track — The Artist".to_string()),
+    };
+    app.user_config.behavior.set_window_title = false;
+
+    assert_eq!(
+      next_window_title(&mut state, &app).as_deref(),
+      Some(DEFAULT_WINDOW_TITLE)
+    );
+    assert_eq!(next_window_title(&mut state, &app), None);
+  }
+
+  #[test]
+  fn window_title_reset_fires_only_after_a_custom_title() {
+    let mut untouched = WindowTitleState::default();
+    assert_eq!(window_title_reset(&mut untouched), None);
+
+    let mut changed = WindowTitleState {
+      last_title: Some("The Track — The Artist".to_string()),
+    };
+    assert_eq!(window_title_reset(&mut changed), Some(DEFAULT_WINDOW_TITLE));
+    assert_eq!(window_title_reset(&mut changed), None);
+  }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -13,6 +13,8 @@ pub mod banner;
 pub mod config;
 #[cfg(feature = "art-decode")]
 pub mod cover_theme;
+#[cfg_attr(not(feature = "tui"), allow(dead_code))]
+pub mod driver;
 pub mod first_run;
 #[cfg_attr(not(feature = "tui"), allow(dead_code))]
 pub mod format;

--- a/src/core/plugin_api.rs
+++ b/src/core/plugin_api.rs
@@ -765,7 +765,7 @@ pub fn search_results_snapshot(app: &App) -> SearchResults {
 
 /// Whether `app.lyrics`/`app.lyrics_status` describe the item playing *right now*.
 ///
-/// The runner's shared track-change detector runs **after** the script engine's
+/// The driver's shared track-change detector runs **after** the script engine's
 /// tick, so on the tick a track changes the lyrics state still belongs to the
 /// previous track. Without this check, `spotatui.get_lyrics` called from a
 /// `track_change` handler - the obvious place to call it - sees a terminal

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -967,9 +967,9 @@ impl PlaybackNetwork for Network {
     let mut app = self.app.lock().await;
 
     // Cover-art download (network + synchronous image decode) must NOT happen
-    // Cover art is fetched by the shared track-change detector (see `core/driver/`),
-    // which dispatches `IoEvent::FetchCoverArt` off the `App` lock for every
-    // source. This handler no longer fetches art inline.
+    // in this handler: art is fetched by the shared track-change detector
+    // (see `core/driver/`), which dispatches `IoEvent::FetchCoverArt` off the
+    // `App` lock for every source.
     match context {
       #[allow(unused_mut)]
       Ok(Some(mut c)) => {

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -967,7 +967,7 @@ impl PlaybackNetwork for Network {
     let mut app = self.app.lock().await;
 
     // Cover-art download (network + synchronous image decode) must NOT happen
-    // Cover art is fetched by the shared track-change detector (see `runner.rs`),
+    // Cover art is fetched by the shared track-change detector (see `core/driver/`),
     // which dispatches `IoEvent::FetchCoverArt` off the `App` lock for every
     // source. This handler no longer fetches art inline.
     match context {
@@ -1053,7 +1053,7 @@ impl PlaybackNetwork for Network {
 
                     // Lyrics (and cover art) are now driven by the shared
                     // track-change detector in the UI tick, which works for every
-                    // source — see `runner.rs`. No per-source dispatch here.
+                    // source — see `core/driver/`. No per-source dispatch here.
 
                     app.dispatch(IoEvent::CurrentUserSavedTracksContains(vec![
                       track_id_str.clone()
@@ -1115,7 +1115,7 @@ impl PlaybackNetwork for Network {
 
         if !stale_api_item_for_native {
           // Cover art (Spotify album/episode image) is fetched by the shared
-          // track-change detector in `runner.rs`, from the snapshot's image URL.
+          // track-change detector in `core/driver/`, from the snapshot's image URL.
           app.current_playback_context = Some(c);
         }
 

--- a/src/infra/scripting/effects.rs
+++ b/src/infra/scripting/effects.rs
@@ -2,7 +2,7 @@ use crate::core::app::App;
 use crate::core::plugin_api::{self, PluginPopup};
 use crate::infra::network::IoEvent;
 
-/// An action queued by a plugin, drained by the runner while holding `&mut App`.
+/// An action queued by a plugin, drained by the driver while holding `&mut App`.
 ///
 /// Each variant routes through the same `App` methods as the equivalent keybinding,
 /// so native-streaming fast paths and throttling/coalescing are automatically honoured.

--- a/src/infra/scripting/engine.rs
+++ b/src/infra/scripting/engine.rs
@@ -24,7 +24,7 @@ use super::shared::{
 const DATA_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Minimum interval between throttled plugin-storage flushes (mirrors the
-/// runner's session-save cadence).
+/// driver's session-save cadence).
 const STORAGE_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// An in-flight plugin data request: dispatched, waiting for the domain's
@@ -131,7 +131,7 @@ impl ScriptEngine {
   /// never aborts the others. Returns the number of plugins loaded successfully.
   /// Cheap discovery-only mirror of [`Self::load_user_scripts`]: reports
   /// whether any loadable script exists (`init.lua`, `plugins/*.lua`, or
-  /// `plugins/<name>/{main,init}.lua`) so the runner can skip constructing
+  /// `plugins/<name>/{main,init}.lua`) so the driver can skip constructing
   /// the Lua VM (and its HTTP client) entirely when there is nothing to
   /// load. Keep the discovery rules in sync with `load_user_scripts`.
   pub fn has_user_scripts(config_dir: &Path) -> bool {
@@ -589,7 +589,7 @@ impl ScriptEngine {
     // App call, and so requests queued by callbacks below land in the next pass.
     let requests: Vec<DataRequest> = self.shared.data_requests.borrow_mut().drain(..).collect();
     for req in requests {
-      // Lyrics fetches are driven by the runner's track-change detector, not by
+      // Lyrics fetches are driven by the driver's track-change detector, not by
       // dispatch: deliver immediately when the current status is terminal AND
       // describes the item playing now, otherwise wait for the in-flight fetch
       // to bump the generation. The currency check matters because the detector

--- a/src/infra/scripting/mod.rs
+++ b/src/infra/scripting/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Embeds `mlua` and exposes a curated `spotatui.*` API to user plugins. Lua never sees
 //! `&mut App` or rspotify types: reads come from a cached snapshot of the [`plugin_api`]
-//! facade, and actions are queued as [`ScriptEffect`]s that the runner drains while holding
+//! facade, and actions are queued as [`ScriptEffect`]s that the driver drains while holding
 //! `&mut App`. Every Rust->Lua callback is wrapped in `catch_unwind`; a misbehaving plugin
 //! logs an error, surfaces a status message, and is disabled (one strike) rather than
 //! crashing the TUI.

--- a/src/infra/scripting/tests.rs
+++ b/src/infra/scripting/tests.rs
@@ -1874,7 +1874,7 @@ mod data_read_tests {
     }
   }
 
-  /// The runner ticks the script engine *before* its track-change detector, so
+  /// The driver ticks the script engine *before* its track-change detector, so
   /// on the tick a track changes `lyrics_status` is still `Found` for the
   /// previous track. `get_lyrics` from a `track_change` handler must wait for
   /// the new lyrics rather than resolving with the old ones.

--- a/src/infra/youtube/mod.rs
+++ b/src/infra/youtube/mod.rs
@@ -57,6 +57,14 @@ const SEARCH_LIMIT: usize = 20;
 /// error beats no audio at all when 140 disappears someday).
 const FORMAT_SELECTOR: &str = "140/bestaudio[ext=m4a]/bestaudio";
 
+/// Extractor override for the download retry: YouTube's GVS PO-token
+/// enforcement 403s music-label content on the default player clients, while
+/// the embedded players still serve tokenless media URLs for any embeddable
+/// video — which label uploads are. Tried only after a default download
+/// fails, so healthy videos never pay for it; a non-embeddable gated video
+/// stays undownloadable without a real PO-token provider.
+const EMBEDDED_PLAYER_CLIENTS: &str = "youtube:player_client=web_embedded,tv_embedded";
+
 /// Cap on a search invocation. yt-dlp searches normally return in a few
 /// seconds; a hung process must not wedge the IoEvent pump forever.
 const SEARCH_TIMEOUT: Duration = Duration::from_secs(45);
@@ -211,28 +219,31 @@ impl YouTubeSource {
     let dest = dest
       .to_str()
       .ok_or_else(|| anyhow!("Non-UTF-8 tempfile path"))?;
+    let url = format!("https://www.youtube.com/watch?v={video_id}");
 
-    self
-      .run(
-        &[
-          "-f",
-          FORMAT_SELECTOR,
-          "--no-playlist",
-          // The NamedTempFile already exists (0 bytes); overwrite it.
-          "--force-overwrites",
-          // Write straight to dest instead of a .part file next to it.
-          "--no-part",
-          "--no-warnings",
-          "--no-progress",
-          "--quiet",
-          "-o",
-          dest,
-          &format!("https://www.youtube.com/watch?v={video_id}"),
-        ],
-        DOWNLOAD_TIMEOUT,
-      )
-      .await?;
-    Ok(())
+    match self
+      .run(&download_args(dest, &url, false), DOWNLOAD_TIMEOUT)
+      .await
+    {
+      Ok(_) => Ok(()),
+      Err(primary) => {
+        // Retry once through the embedded players (see
+        // [`EMBEDDED_PLAYER_CLIENTS`]). On a double failure surface the
+        // default path's error: it names the canonical problem (403, missing
+        // binary, dead network), where the fallback's is usually a less
+        // useful "format not available".
+        match self
+          .run(&download_args(dest, &url, true), DOWNLOAD_TIMEOUT)
+          .await
+        {
+          Ok(_) => Ok(()),
+          Err(fallback) => {
+            log::info!("youtube: embedded-client download fallback also failed: {fallback:#}");
+            Err(primary)
+          }
+        }
+      }
+    }
   }
 
   /// Run `yt-dlp` with `args`, returning stdout. Fails with the tail of
@@ -299,6 +310,31 @@ impl YouTubeSource {
     }
     Ok(stdout)
   }
+}
+
+/// Arguments for one download attempt; the retry differs from the first try
+/// only by the embedded-client extractor override.
+fn download_args<'a>(dest: &'a str, url: &'a str, embedded_fallback: bool) -> Vec<&'a str> {
+  let mut args: Vec<&str> = Vec::new();
+  if embedded_fallback {
+    args.extend_from_slice(&["--extractor-args", EMBEDDED_PLAYER_CLIENTS]);
+  }
+  args.extend_from_slice(&[
+    "-f",
+    FORMAT_SELECTOR,
+    "--no-playlist",
+    // The NamedTempFile already exists (0 bytes); overwrite it.
+    "--force-overwrites",
+    // Write straight to dest instead of a .part file next to it.
+    "--no-part",
+    "--no-warnings",
+    "--no-progress",
+    "--quiet",
+    "-o",
+    dest,
+    url,
+  ]);
+  args
 }
 
 impl Searcher for YouTubeSource {
@@ -467,6 +503,17 @@ mod tests {
       video_summary(Some(1_200_000_000)),
       "YouTube \u{2022} 1.2B views"
     );
+  }
+
+  #[test]
+  fn download_retry_only_prepends_the_embedded_client_override() {
+    let url = "https://www.youtube.com/watch?v=5NV6Rdv1a3I";
+    let first_try = download_args("dest.m4a", url, false);
+    let retry = download_args("dest.m4a", url, true);
+
+    assert!(!first_try.contains(&"--extractor-args"));
+    assert_eq!(retry[..2], ["--extractor-args", EMBEDDED_PLAYER_CLIENTS]);
+    assert_eq!(retry[2..], first_try[..], "everything else stays identical");
   }
 
   #[test]

--- a/src/infra/youtube/mod.rs
+++ b/src/infra/youtube/mod.rs
@@ -221,29 +221,11 @@ impl YouTubeSource {
       .ok_or_else(|| anyhow!("Non-UTF-8 tempfile path"))?;
     let url = format!("https://www.youtube.com/watch?v={video_id}");
 
-    match self
-      .run(&download_args(dest, &url, false), DOWNLOAD_TIMEOUT)
-      .await
-    {
-      Ok(_) => Ok(()),
-      Err(primary) => {
-        // Retry once through the embedded players (see
-        // [`EMBEDDED_PLAYER_CLIENTS`]). On a double failure surface the
-        // default path's error: it names the canonical problem (403, missing
-        // binary, dead network), where the fallback's is usually a less
-        // useful "format not available".
-        match self
-          .run(&download_args(dest, &url, true), DOWNLOAD_TIMEOUT)
-          .await
-        {
-          Ok(_) => Ok(()),
-          Err(fallback) => {
-            log::info!("youtube: embedded-client download fallback also failed: {fallback:#}");
-            Err(primary)
-          }
-        }
-      }
-    }
+    run_with_embedded_fallback(|embedded| {
+      let args = download_args(dest, &url, embedded);
+      async move { self.run(&args, DOWNLOAD_TIMEOUT).await.map(|_| ()) }
+    })
+    .await
   }
 
   /// Run `yt-dlp` with `args`, returning stdout. Fails with the tail of
@@ -309,6 +291,28 @@ impl YouTubeSource {
       );
     }
     Ok(stdout)
+  }
+}
+
+/// The download's attempt sequence: the default clients first, then one
+/// retry through the embedded players (see [`EMBEDDED_PLAYER_CLIENTS`]). On
+/// a double failure the *primary* error surfaces: it names the canonical
+/// problem (403, missing binary, dead network), where the fallback's usually
+/// degenerates to a less useful "format not available".
+async fn run_with_embedded_fallback<F, Fut>(mut attempt: F) -> Result<()>
+where
+  F: FnMut(bool) -> Fut,
+  Fut: std::future::Future<Output = Result<()>>,
+{
+  match attempt(false).await {
+    Ok(()) => Ok(()),
+    Err(primary) => match attempt(true).await {
+      Ok(()) => Ok(()),
+      Err(fallback) => {
+        log::info!("youtube: embedded-client download fallback also failed: {fallback:#}");
+        Err(primary)
+      }
+    },
   }
 }
 
@@ -514,6 +518,50 @@ mod tests {
     assert!(!first_try.contains(&"--extractor-args"));
     assert_eq!(retry[..2], ["--extractor-args", EMBEDDED_PLAYER_CLIENTS]);
     assert_eq!(retry[2..], first_try[..], "everything else stays identical");
+  }
+
+  #[tokio::test]
+  async fn download_fallback_never_runs_after_a_primary_success() {
+    let mut attempts = Vec::new();
+    run_with_embedded_fallback(|embedded| {
+      attempts.push(embedded);
+      async { Ok(()) }
+    })
+    .await
+    .unwrap();
+    assert_eq!(attempts, [false]);
+  }
+
+  #[tokio::test]
+  async fn download_retries_exactly_once_through_the_embedded_clients() {
+    let mut attempts = Vec::new();
+    run_with_embedded_fallback(|embedded| {
+      attempts.push(embedded);
+      async move {
+        if embedded {
+          Ok(())
+        } else {
+          Err(anyhow!("HTTP Error 403"))
+        }
+      }
+    })
+    .await
+    .unwrap();
+    assert_eq!(attempts, [false, true]);
+  }
+
+  #[tokio::test]
+  async fn double_download_failure_surfaces_the_primary_error() {
+    let err = run_with_embedded_fallback(|embedded| async move {
+      Err(anyhow!(if embedded {
+        "format not available"
+      } else {
+        "HTTP Error 403"
+      }))
+    })
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("403"), "got: {err}");
   }
 
   #[test]

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -92,7 +92,7 @@ fn update_macos_metadata(
   // while the native queue owns the sink: `local_playback` is then a *suspended*
   // context, so fall through to the snapshot path, which describes the queued
   // track actually playing. Mirrors the same filter on the MPRIS twin in
-  // `update_mpris_state` in the TUI runner.
+  // `update_mpris_state` in `core/driver/presence.rs`.
   #[cfg(feature = "local-files")]
   if let Some(local) = app
     .local_playback
@@ -1162,7 +1162,7 @@ async fn restore_playback_session(
       // Trust the persisted intent (`shuffle_on`) for the flag and restore the
       // backup as-is (the start path above did not re-shuffle because
       // `decoded_shuffle` is still off). When the two disagree — a toggle deferred
-      // at exit — the runner's `reconcile_decoded_shuffle` re-syncs the queue
+      // at exit — the driver's `reconcile_decoded_shuffle` re-syncs the queue
       // order to the flag on the next tick.
       if guard.local_playback.is_some() {
         guard.decoded_repeat = repeat;

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -1,15 +1,7 @@
 use crate::core::app::{self, ActiveBlock, App, RouteId};
-use crate::core::auth;
+use crate::core::driver::{DiscordRpcHandle, Driver, MprisHandle, TickEnv};
 use crate::core::user_config::UserConfig;
-#[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
-use crate::infra::audio;
-#[cfg(feature = "discord-rpc")]
-use crate::infra::discord_rpc;
-#[cfg(all(feature = "mpris", target_os = "linux"))]
-use crate::infra::mpris;
 use crate::infra::network::IoEvent;
-#[cfg(feature = "scripting")]
-use crate::infra::scripting::ScriptEngine;
 use crate::tui::event::{self, Key};
 use crate::tui::handlers;
 use crate::tui::ui;
@@ -30,189 +22,9 @@ use std::{
   cmp::{max, min},
   io::stdout,
   sync::{atomic::AtomicU64, Arc},
-  time::{Duration, Instant, SystemTime},
+  time::Instant,
 };
 use tokio::sync::Mutex;
-
-const DEFAULT_WINDOW_TITLE: &str = "spt - spotatui";
-
-#[derive(Default)]
-struct WindowTitleState {
-  last_title: Option<String>,
-}
-
-#[cfg(feature = "discord-rpc")]
-pub type DiscordRpcHandle = Option<discord_rpc::DiscordRpcManager>;
-#[cfg(not(feature = "discord-rpc"))]
-pub type DiscordRpcHandle = Option<()>;
-
-#[cfg(all(feature = "mpris", target_os = "linux"))]
-pub type MprisHandle = Option<Arc<mpris::MprisManager>>;
-#[cfg(not(all(feature = "mpris", target_os = "linux")))]
-pub type MprisHandle = Option<()>;
-
-#[cfg(feature = "discord-rpc")]
-#[derive(Clone, Debug, PartialEq)]
-struct DiscordTrackInfo {
-  title: String,
-  artist: String,
-  album: String,
-  image_url: Option<String>,
-  duration_ms: u32,
-}
-
-#[cfg(feature = "discord-rpc")]
-#[derive(Default)]
-struct DiscordPresenceState {
-  last_track: Option<DiscordTrackInfo>,
-  last_is_playing: Option<bool>,
-  last_progress_ms: u128,
-}
-
-#[cfg(all(feature = "mpris", target_os = "linux"))]
-#[derive(Default, PartialEq)]
-struct MprisMetadata {
-  title: String,
-  artists: Vec<String>,
-  album: String,
-  duration_ms: u32,
-  art_url: Option<String>,
-}
-
-#[cfg(all(feature = "mpris", target_os = "linux"))]
-#[derive(Default)]
-struct MprisState {
-  last_metadata: Option<MprisMetadata>,
-  last_is_playing: Option<bool>,
-  last_shuffle: Option<bool>,
-  last_loop: Option<mpris::LoopStatusEvent>,
-}
-
-#[cfg(feature = "discord-rpc")]
-fn build_discord_playback(app: &App) -> Option<discord_rpc::DiscordPlayback> {
-  let snapshot = crate::infra::media_metadata::current_playback_snapshot(app)?;
-  let artist = snapshot.primary_artist();
-  let track_info = DiscordTrackInfo {
-    title: snapshot.metadata.title,
-    artist,
-    album: snapshot.metadata.album,
-    image_url: snapshot.metadata.image_url,
-    duration_ms: snapshot.metadata.duration_ms,
-  };
-
-  let base_state = if track_info.album.is_empty() {
-    track_info.artist.clone()
-  } else {
-    format!("{} - {}", track_info.artist, track_info.album)
-  };
-  let state = if snapshot.is_playing {
-    base_state
-  } else if base_state.is_empty() {
-    "Paused".to_string()
-  } else {
-    format!("Paused: {}", base_state)
-  };
-
-  Some(discord_rpc::DiscordPlayback {
-    title: track_info.title,
-    artist: track_info.artist,
-    album: track_info.album,
-    state,
-    image_url: track_info.image_url,
-    duration_ms: track_info.duration_ms,
-    progress_ms: snapshot.progress_ms,
-    is_playing: snapshot.is_playing,
-  })
-}
-
-#[cfg(feature = "discord-rpc")]
-fn update_discord_presence(
-  manager: &discord_rpc::DiscordRpcManager,
-  state: &mut DiscordPresenceState,
-  app: &App,
-) {
-  let playback = build_discord_playback(app);
-
-  match playback {
-    Some(playback) => {
-      let track_info = DiscordTrackInfo {
-        title: playback.title.clone(),
-        artist: playback.artist.clone(),
-        album: playback.album.clone(),
-        image_url: playback.image_url.clone(),
-        duration_ms: playback.duration_ms,
-      };
-
-      let track_changed = state.last_track.as_ref() != Some(&track_info);
-      let playing_changed = state.last_is_playing != Some(playback.is_playing);
-      let progress_delta = playback.progress_ms.abs_diff(state.last_progress_ms);
-      let progress_changed = progress_delta > 5000;
-
-      if track_changed || playing_changed || progress_changed {
-        manager.set_activity(&playback);
-        state.last_track = Some(track_info);
-        state.last_is_playing = Some(playback.is_playing);
-        state.last_progress_ms = playback.progress_ms;
-      }
-    }
-    None => {
-      if state.last_track.is_some() {
-        manager.clear();
-        state.last_track = None;
-        state.last_is_playing = None;
-        state.last_progress_ms = 0;
-      }
-    }
-  }
-}
-
-/// Identity of the currently-playing track, used by the shared track-change
-/// detector to fire lyrics + cover-art fetches exactly once per track (rather
-/// than every tick). Title + artists + album + duration distinguishes tracks
-/// across every source without depending on a source-specific id.
-type TrackIdentity = (String, Vec<String>, String, u32);
-
-fn track_identity(snapshot: &crate::infra::media_metadata::PlaybackSnapshot) -> TrackIdentity {
-  (
-    snapshot.metadata.title.clone(),
-    snapshot.metadata.artists.clone(),
-    snapshot.metadata.album.clone(),
-    snapshot.metadata.duration_ms,
-  )
-}
-
-/// Resolve what cover art to fetch for the track described by `snapshot`.
-///
-/// Local files carry embedded artwork read straight from the file (no URL), so
-/// they take a dedicated `LocalFile` request. Every other source that can supply
-/// art (Spotify album art, YouTube thumbnail, Subsonic getCoverArt) surfaces it
-/// as `snapshot.metadata.image_url`. `None` means the current track has no art
-/// to show (e.g. internet radio, or a Spotify item without images).
-#[cfg(feature = "art-decode")]
-fn cover_art_request_for(
-  app: &App,
-  snapshot: &crate::infra::media_metadata::PlaybackSnapshot,
-) -> Option<crate::core::art::CoverArtRequest> {
-  use crate::core::art::CoverArtRequest;
-
-  #[cfg(feature = "local-files")]
-  if let Some(local) = app.local_playback.as_ref() {
-    let uri = local.queue.get(local.index)?;
-    let path = crate::infra::local::file_uri_to_path(uri).ok()?;
-    return Some(CoverArtRequest::LocalFile {
-      key: uri.clone(),
-      path,
-    });
-  }
-  #[cfg(not(feature = "local-files"))]
-  let _ = app;
-
-  snapshot
-    .metadata
-    .image_url
-    .clone()
-    .map(CoverArtRequest::Url)
-}
 
 /// Whether the terminal renders real pixels. False until the renderer is
 /// initialized, and always false in a decode-only build (`art-decode` without
@@ -227,60 +39,6 @@ fn cover_art_full_image_support() -> bool {
   {
     false
   }
-}
-
-fn playback_window_title(app: &App) -> String {
-  let Some(snapshot) = crate::infra::media_metadata::current_playback_snapshot(app) else {
-    return DEFAULT_WINDOW_TITLE.to_string();
-  };
-
-  let title = sanitize_window_title_component(&snapshot.metadata.title);
-  let artist_raw = sanitize_window_title_component(&snapshot.primary_artist());
-  // Compose the artist segment with the em-dash separator, matching today's
-  // `"{title} — {artist}"` output; omitted when there's no artist.
-  let artist = if artist_raw.trim().is_empty() {
-    String::new()
-  } else {
-    format!(" — {}", artist_raw)
-  };
-  app
-    .user_config
-    .format
-    .window_title
-    .render(&[&title, &artist])
-}
-
-fn sanitize_window_title_component(value: &str) -> String {
-  value.chars().filter(|c| !c.is_control()).collect()
-}
-
-fn next_window_title(state: &mut WindowTitleState, app: &App) -> Option<String> {
-  if !app.user_config.behavior.set_window_title {
-    return state
-      .last_title
-      .take()
-      .map(|_| DEFAULT_WINDOW_TITLE.to_string());
-  }
-
-  let title = playback_window_title(app);
-  if state.last_title.as_ref() == Some(&title) {
-    None
-  } else {
-    state.last_title = Some(title.clone());
-    Some(title)
-  }
-}
-
-fn reset_window_title(state: &mut WindowTitleState) -> Result<()> {
-  if state
-    .last_title
-    .as_deref()
-    .is_some_and(|title| title != DEFAULT_WINDOW_TITLE)
-  {
-    execute!(stdout(), SetTitle(DEFAULT_WINDOW_TITLE))?;
-    state.last_title = None;
-  }
-  Ok(())
 }
 
 fn back_key_clears_playlist_filter(app: &mut App, active_block: ActiveBlock) -> bool {
@@ -400,7 +158,7 @@ fn dispatch_key(key: Key, app: &mut App) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::core::app::{NativeTrackInfo, TrackTableContext};
+  use crate::core::app::TrackTableContext;
   use rspotify::model::idtypes::PlaylistId;
   use std::{sync::mpsc::channel, time::SystemTime};
 
@@ -411,60 +169,6 @@ mod tests {
       crate::core::user_config::UserConfig::new(),
       Some(SystemTime::now()),
     )
-  }
-
-  #[test]
-  fn playback_window_title_uses_current_native_track() {
-    let mut app = app();
-    app.is_streaming_active = true;
-    app.native_track_info = Some(NativeTrackInfo {
-      name: "The Track".to_string(),
-      artists: vec!["The Artist".to_string()],
-      album: "The Album".to_string(),
-      duration_ms: 180_000,
-      kind: crate::core::app::NativeTrackKind::Track,
-      image_url: None,
-    });
-
-    assert_eq!(playback_window_title(&app), "The Track — The Artist");
-  }
-
-  #[test]
-  fn playback_window_title_strips_control_characters() {
-    let mut app = app();
-    app.is_streaming_active = true;
-    app.native_track_info = Some(NativeTrackInfo {
-      name: "The\x1b]2;Bad\x07 Track".to_string(),
-      artists: vec!["The\nArtist".to_string()],
-      album: "The Album".to_string(),
-      duration_ms: 180_000,
-      kind: crate::core::app::NativeTrackKind::Track,
-      image_url: None,
-    });
-
-    assert_eq!(playback_window_title(&app), "The]2;Bad Track — TheArtist");
-  }
-
-  #[test]
-  fn playback_window_title_falls_back_without_playback() {
-    let app = app();
-
-    assert_eq!(playback_window_title(&app), DEFAULT_WINDOW_TITLE);
-  }
-
-  #[test]
-  fn disabling_window_title_restores_default_once() {
-    let mut app = app();
-    let mut state = WindowTitleState {
-      last_title: Some("The Track — The Artist".to_string()),
-    };
-    app.user_config.behavior.set_window_title = false;
-
-    assert_eq!(
-      next_window_title(&mut state, &app).as_deref(),
-      Some(DEFAULT_WINDOW_TITLE)
-    );
-    assert_eq!(next_window_title(&mut state, &app), None);
   }
 
   #[test]
@@ -572,134 +276,6 @@ mod tests {
   }
 }
 
-#[cfg(all(feature = "mpris", target_os = "linux"))]
-fn update_mpris_state(manager: &mpris::MprisManager, state: &mut MprisState, app: &App) {
-  use rspotify::model::enums::RepeatState;
-
-  // Local-file playback owns its own state and never populates the Spotify
-  // playback context, so it takes a dedicated path that reads metadata, play
-  // state, and position straight from the live local player. Skipped while the
-  // native queue owns the sink: `local_playback` is then a *suspended* context,
-  // so fall through to the snapshot path, which renders the queue slot and
-  // clears its shuffle/repeat instead of publishing this context's stale modes.
-  #[cfg(feature = "local-files")]
-  if let Some(local) = app
-    .local_playback
-    .as_ref()
-    .filter(|_| !app.queue_owns_playback())
-  {
-    use crate::infra::media_metadata::{select_media_metadata, LocalMediaMetadata};
-
-    let is_playing = !local.player.is_paused();
-    let position_ms = local.player.position().as_millis() as u64;
-
-    // `select_media_metadata` is the single, unit-tested decision for which
-    // source the OS integration follows; local always wins while it is active.
-    let metadata = select_media_metadata(
-      Some(LocalMediaMetadata {
-        title: local.name.clone(),
-        artists: vec![local.artists.clone()],
-        album: local.album.clone(),
-        duration_ms: local.duration_ms as u32,
-      }),
-      None,
-    )
-    .expect("local metadata is present");
-
-    let new_metadata = MprisMetadata {
-      title: metadata.title.clone(),
-      artists: metadata.artists.clone(),
-      album: metadata.album.clone(),
-      duration_ms: metadata.duration_ms,
-      art_url: metadata.image_url.clone(),
-    };
-    if state.last_metadata.as_ref() != Some(&new_metadata) {
-      manager.set_metadata(
-        &metadata.title,
-        &metadata.artists,
-        &metadata.album,
-        metadata.duration_ms,
-        metadata.image_url,
-      );
-      state.last_metadata = Some(new_metadata);
-    }
-
-    if state.last_is_playing != Some(is_playing) {
-      manager.set_playback_status(is_playing);
-      state.last_is_playing = Some(is_playing);
-    }
-
-    manager.set_position(position_ms);
-
-    // Local playback carries the decoded shuffle/repeat modes; push them like
-    // the snapshot branch below so keyboard and MPRIS toggles reach clients
-    // (this dedicated branch returns before the snapshot path runs).
-    if state.last_shuffle != Some(app.decoded_shuffle) {
-      manager.set_shuffle(app.decoded_shuffle);
-      state.last_shuffle = Some(app.decoded_shuffle);
-    }
-    let loop_status = match app.decoded_repeat {
-      crate::infra::queue::RepeatMode::Off => mpris::LoopStatusEvent::None,
-      crate::infra::queue::RepeatMode::Track => mpris::LoopStatusEvent::Track,
-      crate::infra::queue::RepeatMode::Context => mpris::LoopStatusEvent::Playlist,
-    };
-    if state.last_loop != Some(loop_status) {
-      manager.set_loop_status(loop_status);
-      state.last_loop = Some(loop_status);
-    }
-    return;
-  }
-
-  if let Some(snapshot) = crate::infra::media_metadata::current_playback_snapshot(app) {
-    let new_metadata = MprisMetadata {
-      title: snapshot.metadata.title.clone(),
-      artists: snapshot.metadata.artists.clone(),
-      album: snapshot.metadata.album.clone(),
-      duration_ms: snapshot.metadata.duration_ms,
-      art_url: snapshot.metadata.image_url.clone(),
-    };
-    if state.last_metadata.as_ref() != Some(&new_metadata) {
-      manager.set_metadata(
-        &snapshot.metadata.title,
-        &snapshot.metadata.artists,
-        &snapshot.metadata.album,
-        snapshot.metadata.duration_ms,
-        snapshot.metadata.image_url.clone(),
-      );
-      state.last_metadata = Some(new_metadata);
-    }
-
-    if state.last_is_playing != Some(snapshot.is_playing) {
-      manager.set_playback_status(snapshot.is_playing);
-      state.last_is_playing = Some(snapshot.is_playing);
-    }
-
-    manager.set_position(snapshot.progress_ms as u64);
-
-    if state.last_shuffle != Some(snapshot.shuffle) {
-      manager.set_shuffle(snapshot.shuffle);
-      state.last_shuffle = Some(snapshot.shuffle);
-    }
-
-    // A `None` repeat means the source has no repeat control (native queue,
-    // radio); reset to `None` rather than leaving a stale Track/Playlist that a
-    // prior decoded context pushed.
-    let loop_status = match snapshot.repeat {
-      Some(RepeatState::Track) => mpris::LoopStatusEvent::Track,
-      Some(RepeatState::Context) => mpris::LoopStatusEvent::Playlist,
-      Some(RepeatState::Off) | None => mpris::LoopStatusEvent::None,
-    };
-    if state.last_loop != Some(loop_status) {
-      manager.set_loop_status(loop_status);
-      state.last_loop = Some(loop_status);
-    }
-  } else if state.last_metadata.is_some() {
-    manager.set_stopped();
-    state.last_metadata = None;
-    state.last_is_playing = None;
-  }
-}
-
 #[cfg(feature = "streaming")]
 async fn pause_native_playback_before_exit(app: &Arc<Mutex<App>>) {
   let player = {
@@ -745,12 +321,10 @@ pub async fn start_ui(
   history_collector: crate::infra::history::HistoryCollectorHandle,
 ) -> Result<()> {
   info!("ui thread initialized");
-  #[cfg(not(feature = "discord-rpc"))]
-  let _ = discord_rpc_manager;
-  #[cfg(not(feature = "streaming"))]
-  let _ = &shared_position;
-  #[cfg(not(all(feature = "mpris", target_os = "linux")))]
-  let _ = &mpris_manager;
+  // The driver owns everything the app must do on a timer (see
+  // `core::driver`); this loop's job shrinks to drawing frames, reading
+  // events, and calling `driver.tick` at the configured tick rate.
+  let mut driver = Driver::new(shared_position, mpris_manager, discord_rpc_manager);
 
   let mut terminal = ratatui::init();
   // Probe the terminal's image protocol only now that the terminal is set up;
@@ -781,69 +355,7 @@ pub async fn start_ui(
 
   let events = event::Events::new(user_config.behavior.tick_rate_milliseconds);
 
-  #[cfg(all(feature = "mpris", target_os = "linux"))]
-  let mut prev_is_streaming_active = false;
-
-  #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
-  let mut audio_capture: Option<audio::AudioCaptureManager> = None;
-
-  #[cfg(feature = "discord-rpc")]
-  let mut discord_presence_state = DiscordPresenceState::default();
-
-  #[cfg(all(feature = "mpris", target_os = "linux"))]
-  let mut mpris_state = MprisState::default();
-
-  let mut window_title_state = WindowTitleState::default();
-  // Last track the shared detector fired lyrics for, so the lookup re-fires
-  // only on an actual track change rather than every tick.
-  let mut last_track_identity: Option<TrackIdentity> = None;
-  // Cache key (URL / file URI) of the cover art last requested, so the per-tick
-  // cover-art evaluation dispatches a fetch only when the resolved art changes.
-  #[cfg(feature = "art-decode")]
-  let mut last_cover_art_key: Option<String> = None;
   let mut is_first_render = true;
-
-  // Throttled persistence of the active non-Spotify playback session, so it can
-  // resume the exact song/position on the next launch (see
-  // `core::persisted_playback`). `last_session_save` throttles the periodic
-  // writes; `session_was_present` lets a Some -> None transition (queue ended,
-  // switched to Spotify) clear the file so a stale session is never resurrected.
-  let mut last_session_save: Option<Instant> = None;
-  let mut session_was_present = false;
-  const SESSION_SAVE_INTERVAL: Duration = Duration::from_secs(3);
-
-  // Tracks whether the active internet-radio stream has produced audio yet, so
-  // the tick can tell "stream just started, sink not filled" apart from "stream
-  // died / drained" — both of which report `is_finished()` (empty sink).
-  #[cfg(feature = "internet-radio")]
-  let mut radio_stream_started = false;
-
-  // The Lua VM (plus its HTTP client) is only constructed when the user
-  // actually has script files; a zero-plugin install skips the engine — and
-  // its per-tick `on_tick` dispatch — entirely.
-  #[cfg(feature = "scripting")]
-  let mut script_engine: Option<ScriptEngine> = {
-    let config_dir = crate::core::user_config::default_app_config_dir();
-    match config_dir {
-      Some(config_dir) if ScriptEngine::has_user_scripts(&config_dir) => {
-        match ScriptEngine::new() {
-          Ok(mut engine) => {
-            let loaded = engine.load_user_scripts(&config_dir);
-            info!("loaded {loaded} lua plugin file(s)");
-            Some(engine)
-          }
-          Err(e) => {
-            log::error!("failed to initialize lua scripting engine: {e}");
-            None
-          }
-        }
-      }
-      _ => {
-        info!("no lua plugin files found; scripting engine not started");
-        None
-      }
-    }
-  };
 
   loop {
     let terminal_size =
@@ -857,25 +369,6 @@ pub async fn start_ui(
         });
     let title_update = {
       let mut app = app.lock().await;
-
-      #[cfg(feature = "streaming")]
-      if let Some(player) = app.streaming_player.clone() {
-        if let Some(error) = player.take_audio_backend_error() {
-          app.pause_native_playback();
-          app.set_status_message(format!("Audio backend failed: {error}"), 15);
-        }
-      }
-
-      #[cfg(all(feature = "mpris", target_os = "linux"))]
-      {
-        let current_is_streaming_active = app.is_streaming_active;
-        if prev_is_streaming_active && !current_is_streaming_active {
-          if let Some(ref mpris) = mpris_manager {
-            mpris.set_stopped();
-          }
-        }
-        prev_is_streaming_active = current_is_streaming_active;
-      }
 
       if let Some(size) = terminal_size {
         if is_first_render || app.size != size {
@@ -994,16 +487,7 @@ pub async fn start_ui(
         cursor_offset,
       ))?;
 
-      // Only refresh when a Spotify session exists; a free-source launch has no
-      // token expiry and must not schedule refreshes.
-      if let Some(expiry) = app.spotify_token_expiry {
-        if auth::should_refresh_token_at(expiry, SystemTime::now()) && !app.auth_refresh_in_progress
-        {
-          app.auth_refresh_in_progress = true;
-          app.dispatch(IoEvent::RefreshAuthentication);
-        }
-      }
-      next_window_title(&mut window_title_state, &app)
+      driver.next_window_title(&app)
     };
     if let Some(title) = title_update {
       execute!(stdout(), SetTitle(title.as_str()))?;
@@ -1022,10 +506,7 @@ pub async fn start_ui(
         if dispatch_key(key, &mut app) {
           break;
         }
-        #[cfg(feature = "scripting")]
-        if let Some(engine) = script_engine.as_mut() {
-          engine.run_pending_commands(&mut app);
-        }
+        driver.run_pending_script_commands(&mut app);
       }
       event::Event::Mouse(mouse) => {
         let mut app = app.lock().await;
@@ -1034,6 +515,8 @@ pub async fn start_ui(
         }
       }
       event::Event::Tick(elapsed) => {
+        // The frontend owns the macOS main thread, so its run loop is pumped
+        // here rather than by the driver.
         #[cfg(all(feature = "macos-media", target_os = "macos"))]
         {
           use objc2_foundation::{NSDate, NSRunLoop};
@@ -1041,472 +524,35 @@ pub async fn start_ui(
         }
 
         let mut app = app.lock().await;
-        app.update_on_tick(elapsed);
-
-        #[cfg(feature = "streaming")]
-        app.flush_pending_native_seek();
-        app.flush_pending_api_seek();
-        app.flush_pending_source_seek();
-        app.flush_pending_volume();
-        app.flush_state_save(false);
-
-        #[cfg(feature = "scripting")]
-        if let Some(engine) = script_engine.as_mut() {
-          engine.on_tick(&mut app);
-        }
-
-        #[cfg(feature = "discord-rpc")]
-        if let Some(ref manager) = discord_rpc_manager {
-          update_discord_presence(manager, &mut discord_presence_state, &app);
-        }
-
-        #[cfg(all(feature = "mpris", target_os = "linux"))]
-        if let Some(ref mpris) = mpris_manager {
-          update_mpris_state(mpris, &mut mpris_state, &app);
-        }
-
-        // Shared track-change detector. One place decides "the playing track
-        // changed" off the source-agnostic snapshot, then drives BOTH lyrics
-        // (every source) and cover art (cover-art feature) — so both light up
-        // for Spotify, local files, Subsonic, radio and YouTube through a single
-        // path.
-        {
-          let snapshot = crate::infra::media_metadata::current_playback_snapshot(&app);
-
-          // Lyrics fire once per track (identity latch): their inputs — title,
-          // artist, duration — ARE the identity, so they are correct at the
-          // instant the identity changes.
-          let identity = snapshot.as_ref().map(track_identity);
-          if identity != last_track_identity {
-            last_track_identity = identity;
-            app.lyrics_view.reset();
-            match snapshot.as_ref() {
-              Some(snapshot) => {
-                use crate::infra::media_metadata::PlaybackItemKind;
-                // LRCLIB lookup by title + artist + duration. Source agnostic;
-                // radio (duration 0) simply resolves to "not found". Podcast
-                // episodes have no lyrics, so skip the lookup and show the
-                // not-found message rather than stale lyrics.
-                if snapshot.item_kind == PlaybackItemKind::Track {
-                  let title = snapshot.metadata.title.clone();
-                  // The identity latch keys on the joined display credit, but the
-                  // LRCLIB lookup needs the structured artist list so it can fall
-                  // back to the primary artist alone for collaborations (#410).
-                  let artists = snapshot.metadata.artists.clone();
-                  app.desired_lyrics_identity = Some((title.clone(), artists.join(", ")));
-                  app.dispatch(IoEvent::GetLyrics(
-                    title,
-                    artists,
-                    snapshot.metadata.duration_ms as f64 / 1000.0,
-                  ));
-                } else {
-                  app.desired_lyrics_identity = None;
-                  app.lyrics = None;
-                  app.lyrics_status = crate::core::app::LyricsStatus::NotFound;
-                  app
-                    .plugin_data_generations
-                    .bump(crate::core::app::PluginDataKind::Lyrics);
-                }
-              }
-              None => {
-                app.desired_lyrics_identity = None;
-                // Nothing is playing: reset so no stale lyrics linger.
-                app.lyrics = None;
-                app.lyrics_status = crate::core::app::LyricsStatus::NotStarted;
-                app
-                  .plugin_data_generations
-                  .bump(crate::core::app::PluginDataKind::Lyrics);
-              }
-            }
-          }
-
-          // Cover art is re-evaluated EVERY tick against the desired image key,
-          // NOT latched to the identity change. With native streaming the
-          // snapshot's `image_url` comes from the polled Spotify context, which
-          // catches up seconds *after* `native_track_info` flips the identity —
-          // an identity-latched fetch would fire once with the previous track's
-          // URL (or none at startup) and never see the real one, leaving the art
-          // stuck or missing until restart. Comparing against
-          // `last_cover_art_key` keeps this a no-op on quiet ticks and fires
-          // exactly once whenever the resolved art actually changes.
-          #[cfg(feature = "art-decode")]
-          {
-            use crate::core::art::CoverArtStatus;
-            let enabled = app
-              .user_config
-              .needs_cover_art(cover_art_full_image_support());
-            let desired = if enabled {
-              snapshot
-                .as_ref()
-                .and_then(|snapshot| cover_art_request_for(&app, snapshot))
-            } else {
-              None
-            };
-            match desired {
-              Some(request) => {
-                app.desired_cover_art_key = Some(request.key().to_string());
-                if last_cover_art_key.as_deref() != Some(request.key()) {
-                  last_cover_art_key = Some(request.key().to_string());
-                  // Keep the previous image on screen until the new one
-                  // resolves (smooth swap); the fetch runs off-lock.
-                  app.cover_art.status = CoverArtStatus::Loading;
-                  app.dispatch(IoEvent::FetchCoverArt(request));
-                }
-              }
-              None => {
-                app.desired_cover_art_key = None;
-                // No art to show (radio, art disabled, nothing playing): drop
-                // any stale image once, so the pane shows the placeholder.
-                if last_cover_art_key.take().is_some() || app.cover_art.available() {
-                  app.clear_cover_art();
-                }
-                app.cover_art.status = if enabled && snapshot.is_some() {
-                  CoverArtStatus::Unavailable
-                } else {
-                  CoverArtStatus::NotStarted
-                };
-              }
-            }
-          }
-        }
-
-        // Native queue slot: when the queued track finishes, advance the queue
-        // (play the next queued item, or resume the suspended context). Runs
-        // before the per-source blocks so it takes precedence over them.
-        #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
-        {
-          use crate::infra::queue::QueueNowPlaying;
-          let advance = match app.queue_now.as_mut() {
-            Some(QueueNowPlaying::Decoded(d)) if d.player.is_finished() && !d.advancing => {
-              d.advancing = true; // atomic check-and-set: one dispatch only
-              true
-            }
-            _ => false,
-          };
-          if advance {
-            app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
-          }
-        }
-
-        // Auto-queue refill. Dispatch only: this path holds `&mut App`, so the
-        // brain call itself must happen on the detached service lane. The
-        // generation goes along for the ride so a refill the user has since
-        // abandoned (DJ off, vibe shift, source change) can be dropped when it
-        // lands instead of queueing tracks for a session that is gone.
-        #[cfg(feature = "ai-dj")]
-        {
-          if crate::infra::network::dj::wants_top_up(
-            app.native_queue.len(),
-            &app.dj,
-            app.spotify_external_device_active(),
-          ) {
-            let turn_seq = app.dj.begin_turn(crate::infra::dj::TurnKind::Refill);
-            let generation = app.dj.generation;
-            // Not `dispatch`: that pins the global `is_loading` spinner until the
-            // service-lane task finishes, which for a brain call is minutes. The
-            // DJ's own `thinking` flag is the progress surface here.
-            app.dispatch_without_spinner(crate::infra::network::IoEvent::DjTopUp(
-              generation, turn_seq,
-            ));
-          }
-        }
-
-        // Decoded-source auto-advance, one macro invocation per source (the
-        // blocks are identical except for which `*_playback` session and queue
-        // field they read). Each session reads its progress live from the
-        // player at render time; the only state self-managed here is
-        // end-of-track. When the sink drains and no track change is already in
-        // flight (`!advancing`), `advance_decision` picks the move: advance /
-        // replay (repeat-one) / suspend to the native queue / tear down.
-        //
-        // Decide under one borrow, then act after the borrow ends. `advancing`
-        // is set *synchronously here* (atomic check-and-set, before
-        // dispatching) because the sink stays empty for the whole decode — or,
-        // for Subsonic/YouTube, multi-second download — window; without it the
-        // next tick would re-dispatch and skip several tracks per advance.
-        #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
-        macro_rules! decoded_auto_advance {
-          ($app:ident, $playback:ident, $queue:ident) => {
-            if !$app.queue_owns_playback() {
-              use crate::infra::queue::{advance_decision, next_index, Decision};
-              let queue_len = $app.native_queue.len();
-              let repeat = $app.decoded_repeat;
-              let decision = $app.$playback.as_ref().map(|s| {
-                advance_decision(
-                  s.player.is_finished(),
-                  s.advancing,
-                  next_index(s.index, s.$queue.len()).is_some(),
-                  queue_len,
-                  repeat,
-                )
-              });
-              match decision {
-                Some(d @ (Decision::AdvanceContext | Decision::RepeatTrack)) => {
-                  if let Some(s) = $app.$playback.as_mut() {
-                    s.advancing = true; // atomic check-and-set: one dispatch only
-                  }
-                  $app.dispatch(if d == Decision::RepeatTrack {
-                    crate::infra::network::IoEvent::ReplayCurrentTrack
-                  } else {
-                    crate::infra::network::IoEvent::NextTrack
-                  });
-                }
-                Some(Decision::SuspendToQueue) => {
-                  // End-of-track handoff: under Repeat One the context resumes
-                  // the same track, so a queued song can't consume the repeat.
-                  $app.suspend_active_decoded_context_for_skip(
-                    crate::infra::queue::SuspendCause::AutoAdvance,
-                  );
-                  $app.dispatch(crate::infra::network::IoEvent::AdvanceNativeQueue);
-                }
-                Some(Decision::Teardown) => $app.$playback = None,
-                Some(Decision::None) | None => {}
-              }
-            }
-          };
-        }
-        #[cfg(feature = "local-files")]
-        decoded_auto_advance!(app, local_playback, queue);
-        #[cfg(feature = "subsonic")]
-        decoded_auto_advance!(app, subsonic_playback, tracks);
-        #[cfg(feature = "youtube")]
-        decoded_auto_advance!(app, youtube_playback, tracks);
-
-        // Apply any shuffle toggle that was deferred while a track change was in
-        // flight, now that the advance may have committed (a cheap no-op when the
-        // queue order already matches the decoded shuffle state).
-        #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
-        app.reconcile_decoded_shuffle();
-
-        // Internet radio has no queue to auto-advance; instead the tick watches
-        // for a live stream that dies (server disconnect or the ring buffer
-        // draining to EOF), which leaves `is_finished()` (empty sink) true while
-        // the session was never paused. `is_finished()` is also true during the
-        // brief pre-playback window before the first bytes arrive, so only tear
-        // down once the stream has actually started producing audio.
-        #[cfg(feature = "internet-radio")]
-        match app.radio_playback.as_ref() {
-          Some(radio) => {
-            if !radio.player.is_finished() {
-              radio_stream_started = true;
-            } else if radio_stream_started {
-              app.radio_playback = None;
-              radio_stream_started = false;
-              app.set_status_message("Radio stream ended", 4);
-            }
-          }
-          None => radio_stream_started = false,
-        }
-
-        // A decoded non-Spotify source owns the sink while its `*_playback` is
-        // `Some`. Drive `song_progress_ms` from its live player, and do NOT let
-        // the (paused) librespot position below clobber it.
-        #[allow(unused_mut)]
-        let mut source_owns_playback = false;
-        // The native queue slot owns the sink when playing a decoded track; read
-        // progress from its player first (it may share the suspended context's
-        // player, in which case a per-source block below reads the same value).
-        #[cfg(any(feature = "local-files", feature = "subsonic", feature = "youtube"))]
-        if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
-          source_owns_playback = true;
-          app.song_progress_ms = d.player.position().as_millis();
-        }
-        #[allow(unused_variables)]
-        let spotify_queue_slot = app.queue_now_is_spotify();
-        #[cfg(feature = "local-files")]
-        if !spotify_queue_slot {
-          if let Some(local) = app.local_playback.as_ref() {
-            source_owns_playback = true;
-            let position_ms = local.player.position().as_millis();
-            app.song_progress_ms = position_ms;
-          }
-        }
-        #[cfg(feature = "subsonic")]
-        if !spotify_queue_slot {
-          if let Some(subsonic) = app.subsonic_playback.as_ref() {
-            source_owns_playback = true;
-            let position_ms = subsonic.player.position().as_millis();
-            app.song_progress_ms = position_ms;
-          }
-        }
-        #[cfg(feature = "internet-radio")]
-        if !spotify_queue_slot {
-          if let Some(radio) = app.radio_playback.as_ref() {
-            source_owns_playback = true;
-            let position_ms = radio.player.position().as_millis();
-            app.song_progress_ms = position_ms;
-          }
-        }
-        #[cfg(feature = "youtube")]
-        if !spotify_queue_slot {
-          if let Some(youtube) = app.youtube_playback.as_ref() {
-            source_owns_playback = true;
-            let position_ms = youtube.player.position().as_millis();
-            app.song_progress_ms = position_ms;
-          }
-        }
-
-        // Persist the active non-Spotify session so it resumes on next launch.
-        // Throttled to avoid churning the file every tick; a Some -> None
-        // transition (queue ended, or switched to Spotify) clears it instead.
-        if app.has_persistable_session() {
-          let due = last_session_save
-            .map(|t| t.elapsed() >= SESSION_SAVE_INTERVAL)
-            .unwrap_or(true);
-          if due {
-            last_session_save = Some(Instant::now());
-            // Snapshot (clones the queue) only when a save is actually due,
-            // not on every tick.
-            if let Some(session) = app.current_persisted_session() {
-              // Fire-and-forget on the blocking pool: file I/O never blocks the
-              // UI tick, and a dropped handle still runs to completion.
-              tokio::task::spawn_blocking(move || {
-                if let Ok(path) = crate::core::persisted_playback::default_session_path() {
-                  if let Err(e) = crate::core::persisted_playback::save(&path, &session) {
-                    log::warn!("[session] failed to persist playback session: {e}");
-                  }
-                }
-              });
-            }
-          }
-          session_was_present = true;
-        } else {
-          if session_was_present {
-            last_session_save = None;
-            tokio::task::spawn_blocking(|| {
-              if let Ok(path) = crate::core::persisted_playback::default_session_path() {
-                if let Err(e) = crate::core::persisted_playback::clear(&path) {
-                  log::warn!("[session] failed to clear playback session: {e}");
-                }
-              }
-            });
-          }
-          session_was_present = false;
-        }
-
-        #[cfg(feature = "streaming")]
-        if !source_owns_playback {
-          if let Some(ref pos) = shared_position {
-            if app.is_streaming_active {
-              let recently_seeked = app
-                .last_native_seek
-                .is_some_and(|t| t.elapsed().as_millis() < app::SEEK_POSITION_IGNORE_MS);
-
-              if !recently_seeked {
-                let position_ms = pos.load(std::sync::atomic::Ordering::Relaxed);
-                if position_ms > 0 {
-                  app.song_progress_ms = position_ms as u128;
-                }
-              }
-            }
-          }
-        }
-        #[cfg(not(feature = "streaming"))]
-        if !source_owns_playback {
-          if let Some(ref pos) = shared_position {
-            if app.is_streaming_active {
-              let position_ms = pos.load(std::sync::atomic::Ordering::Relaxed);
-              if position_ms > 0 {
-                app.song_progress_ms = position_ms as u128;
-              }
-            }
-          }
-        }
-
+        // The visualizer bar count is frontend geometry (terminal width and
+        // layout margin), so it is resolved here and injected.
         #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
-        {
-          let in_analysis_view = app.get_current_route().active_block == ActiveBlock::Analysis;
-
-          if in_analysis_view {
-            let desired_bars = ui::audio_analysis::visualizer_bar_count(
-              app.user_config.behavior.visualizer_style,
-              ui::audio_analysis::visualizer_inner_width(&app),
-            );
-
-            if audio_capture.is_none() {
-              // Built at the count we are about to ask for, so the first frame
-              // does not immediately throw the fresh cavacore plan away.
-              audio_capture = audio::AudioCaptureManager::new(desired_bars);
-              app.audio_capture_active = audio_capture.is_some();
-            }
-
-            if let Some(ref capture) = audio_capture {
-              if let Some(spectrum) = capture.get_spectrum(desired_bars) {
-                app.spectrum_data = Some(spectrum);
-              }
-              // Kept outside the spectrum arm: a dead stream must drop the
-              // "Capturing audio" status instead of freezing it on.
-              app.audio_capture_active = capture.is_active();
-            }
-          } else if audio_capture.is_some() {
-            audio_capture = None;
-            app.audio_capture_active = false;
-            app.spectrum_data = None;
-          }
-        }
+        let viz_bars = (app.get_current_route().active_block == ActiveBlock::Analysis).then(|| {
+          ui::audio_analysis::visualizer_bar_count(
+            app.user_config.behavior.visualizer_style,
+            ui::audio_analysis::visualizer_inner_width(&app),
+          )
+        });
+        driver.tick(
+          &mut app,
+          elapsed,
+          TickEnv {
+            now: Instant::now(),
+            #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]
+            viz_bars,
+            #[cfg(feature = "art-decode")]
+            cover_art_full_image_support: cover_art_full_image_support(),
+          },
+        );
       }
     }
 
     if is_first_render {
       let mut app = app.lock().await;
-      // Spotify-only startup fetches: skip them entirely when launched against a
-      // free source with no Spotify session, so the network layer doesn't reject
-      // three events with "connect Spotify" status flashes on every launch.
-      if app.spotify_connected {
-        app.dispatch(IoEvent::GetCurrentPlayback);
-        app.dispatch(IoEvent::GetPlaylists);
-        app.dispatch(IoEvent::GetUser);
-      }
-      // startup_route seeds the nav stack directly (App::new), bypassing the
-      // handlers that normally fetch a screen's data on navigation — kick
-      // off that fetch here or the screen renders empty until re-entered.
-      // (Home needs nothing extra; Discover fetches from within its menu.)
-      // Spotify-backed screens are gated on a connected session; Stats reads
-      // local history so it always fetches.
-      match app.get_current_route().id {
-        RouteId::RecentlyPlayed if app.spotify_connected => {
-          app.dispatch(IoEvent::GetRecentlyPlayed)
-        }
-        RouteId::AlbumList if app.spotify_connected => {
-          app.dispatch(IoEvent::GetCurrentUserSavedAlbums(None))
-        }
-        RouteId::Artists if app.spotify_connected => {
-          app.dispatch(IoEvent::GetFollowedArtists(None))
-        }
-        RouteId::Podcasts if app.spotify_connected => {
-          app.dispatch(IoEvent::GetCurrentUserSavedShows(None))
-        }
-        RouteId::Stats => {
-          app.stats_loading = true;
-          let period = app.stats_period;
-          app.dispatch(IoEvent::LoadListeningStats(period));
-        }
-        _ => {}
-      }
-      // A persisted non-Spotify active source needs its sidebar data loaded
-      // too (all of these are inert no-ops when the feature is off).
-      match app.active_source {
-        crate::core::source::Source::Local => app.dispatch(IoEvent::GetLocalPlaylists),
-        crate::core::source::Source::Subsonic => app.dispatch(IoEvent::GetSubsonicPlaylists),
-        crate::core::source::Source::Radio => app.dispatch(IoEvent::GetRadioStations),
-        crate::core::source::Source::YouTube => app.dispatch(IoEvent::GetYouTubePlaylists),
-        crate::core::source::Source::Spotify => {}
-      }
-      if app.user_config.behavior.enable_global_song_count {
-        app.dispatch(IoEvent::FetchGlobalSongCount);
-      }
-      app.dispatch(IoEvent::FetchAnnouncements);
+      driver.dispatch_startup(&mut app);
+      // The formatted Help row count is frontend presentation, so it stays
+      // out of the driver's startup dispatch.
       app.help_docs_size = ui::help::get_help_docs(&app).len() as u32;
-
-      // `--play-file`: kick off local playback now that dispatch is wired.
-      if let Some(uri) = app.pending_play_file.take() {
-        app.dispatch(IoEvent::StartPlayback(Some(uri), None, None));
-      }
-
-      #[cfg(feature = "scripting")]
-      if let Some(engine) = script_engine.as_mut() {
-        engine.on_start(&mut app);
-      }
 
       is_first_render = false;
     }
@@ -1526,10 +572,9 @@ pub async fn start_ui(
     }
   }
 
-  #[cfg(feature = "scripting")]
-  if let Some(engine) = script_engine.as_mut() {
+  {
     let mut app = app.lock().await;
-    engine.on_quit(&mut app);
+    driver.on_quit(&mut app);
   }
 
   // A volume/resize/shuffle change may still be inside its debounce window;
@@ -1549,7 +594,9 @@ pub async fn start_ui(
 
   // Restore the terminal before the exit network calls: there is no reason to
   // hold the alternate screen and raw mode while waiting on HTTP.
-  let _ = reset_window_title(&mut window_title_state);
+  if let Some(title) = driver.window_title_reset() {
+    let _ = execute!(stdout(), SetTitle(title));
+  }
   let _ = execute!(stdout(), DisableMouseCapture);
   if keyboard_enhancement_enabled {
     let _ = execute!(stdout(), PopKeyboardEnhancementFlags);
@@ -1587,10 +634,7 @@ pub async fn start_ui(
     }
   }
 
-  #[cfg(feature = "discord-rpc")]
-  if let Some(ref manager) = discord_rpc_manager {
-    manager.clear();
-  }
+  driver.clear_presence();
 
   Ok(())
 }

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -656,6 +656,11 @@ pub(crate) fn playbar_progress_line(app: &App, playbar_area: Rect) -> Option<Pla
     }
   };
 
+  // While the playback position is stale (tick loop stopped), draw_playbar
+  // swaps the gauge label for a warning, so the geometry below would not
+  // match the rendered bar; no seeking then.
+  app.playback_position_ms()?;
+
   // Recreate the gauge label exactly as draw_playbar does so the computed line
   // `start` matches the rendered bar. The label reflects a pending seek if one is
   // in flight (see player.rs ~805), otherwise the current progress.
@@ -1381,7 +1386,13 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       let duration_std = std::time::Duration::from_millis(display_duration_ms);
       let perc = get_track_progress_percentage(progress_ms, duration_std);
 
-      let song_progress_label = display_track_progress(progress_ms, duration_std);
+      // The loud-failure guard: a frontend that stops driving the tick would
+      // otherwise freeze this label at its last value indefinitely.
+      let song_progress_label = if app.playback_position_ms().is_none() {
+        "position stale (tick loop stopped)".to_string()
+      } else {
+        display_track_progress(progress_ms, duration_std)
+      };
       let modifier = if app.user_config.behavior.enable_text_emphasis {
         Modifier::ITALIC | Modifier::BOLD
       } else {

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 130              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1368            # floor: may only rise
+test_attribute_total = 1371            # floor: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -6,7 +6,7 @@
 
 crate_tui_refs_outside_tui = 2         # target 0
 app_field_writes_in_tui_handlers = 786 # target 0
-ioevent_refs_in_tui = 153              # target 0
+ioevent_refs_in_tui = 130              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1352            # floor: may only rise
+test_attribute_total = 1368            # floor: may only rise


### PR DESCRIPTION
# Summary

Everything the app must do on a timer moves out of `tui/runner.rs` into a new frontend-neutral `core/driver/`, so any future frontend runs playback correctly by calling `Driver::tick` at its tick rate:

- **`core/driver/mod.rs`**: `Driver` owns the whole per-tick pass (playback tick + debounced seek/volume/state flushes, native queue and decoded-source auto-advance, DJ top-up, the radio watchdog, the progress ownership chain, `last_session.yml` persistence, visualizer capture) plus the Lua script engine and the Discord/MPRIS handles. Three things that ran per-frame in the draw block move onto the tick where every frontend gets them: the OAuth token refresh, librespot audio-backend-error surfacing, and the MPRIS stopped-on-streaming-end edge.
- **`core/driver/presence.rs`**: Discord Rich Presence, MPRIS, and window-title state machines, moved verbatim (the frontend only applies the returned title string).
- **`core/driver/plan.rs`**: the pure per-tick decisions in the house style (scalars in, plain data out), now unit-testable without an audio sink or real clock: session-save throttling, decoded auto-advance (including repeat-one vs. queue precedence), native queue advance, and cover-art scheduling (the key-comparison-not-identity-latch logic).
- **`TickEnv`** injects the two frontend-geometry inputs (visualizer bar count, cover-art pixel support); the macOS `NSRunLoop` pump stays with the frontend.
- **Loud-failure guard**: `App` records `last_tick_at`; `App::playback_position_ms()` reads stale after 2s without a tick, and the playbar then renders an explicit stall instead of silently freezing (mouse-seek geometry is disabled while stale).
- `tui/runner.rs` goes from 1,597 to 640 lines; its Tick arm is the run-loop pump, the bar-count resolve, and one `driver.tick` call.

Also riding along, one file (`src/infra/youtube/mod.rs`): YouTube downloads retry once through the embedded player clients (`web_embedded,tv_embedded`) when the default clients fail. YouTube's GVS PO-token enforcement currently 403s most label uploads on the default clients; the embedded players still serve tokenless URLs for embeddable videos. Healthy videos never pay for the retry, search is untouched, and a double failure surfaces the primary error.

# Testing

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings` (also headless, default, and the full sources set): clean
- `cargo test --no-default-features --features telemetry,tui`: 596 passed
- `cargo test --no-default-features --features telemetry`: 315 passed
- `cargo test` (default): 894 passed
- `cargo test --no-default-features --features telemetry,tui,mcp-server`: 715 passed
- `cargo test --no-default-features --features telemetry,tui,ai-dj`: 855 passed
- all-sources CI string with `audio-viz` swapped for `audio-viz-cpal` (the leg itself is Linux-only): 1326 passed, plus the known pre-existing Windows-only `infra::local::tests::uri_round_trip` failure
- `git grep update_on_tick src/tui/` is empty; `tools/check_gates_ratchet.sh` vs main ok
- `cargo test --features youtube -- --ignored live_download`: the pre-existing live test downloads a PO-token-gated video and was broken upstream; it passes again through the new fallback (download, decode, and sink playback verified live)
- Manual smoke on Windows: decoded auto-advance (natural end, repeat-one, repeat-all wrap, end-of-context teardown, manual skip under repeat-one), YouTube thumbnails + per-track lyrics, window title, Discord presence, SMTC, visualizer enter/resize/leave, label-upload download via the fallback, plus an hour-long session with a working token refresh

# Additional notes

- Gates: `ioevent_refs_in_tui` baseline lowered 153 -> 130, test floor raised 1352 -> 1368, `crate_tui_refs_outside_tui` held at 2.
- Behavior delta: the three pieces moved out of the draw block now run at tick cadence, so backend-failure toasts and the MPRIS stopped edge can lag by at most one tick (default 500ms).
- A PO-token-gated video that also disables embedding still fails to download; that class needs a real PO-token provider, which stays out of scope (the YouTube doctrine in the docs is updated accordingly).
- Docs updated together: CLAUDE.md, AGENTS.md, copilot-instructions.md.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved playback scheduling and synchronization for playback, persistence, integrations, scripting, and queue advancement.
  * Playback progress now warns when updates become stale rather than showing frozen timing.
  * YouTube downloads retry once with embedded-player clients after an initial failure.
* **Bug Fixes**
  * Seeking is disabled when playback position data is stale.
* **Documentation**
  * Updated architecture and troubleshooting guidance covering scheduling and YouTube download retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->