### PR TITLE
fix(cli): retry player commands on the saved device

### DIFF
--- a/src/bin/spotatui.rs
+++ b/src/bin/spotatui.rs
@@ -1,6 +1,22 @@
 use anyhow::Result;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-  spotatui::run_cli().await
+fn main() -> Result<()> {
+  // Debug builds overflow the 1 MiB Windows main-thread stack: CLI mode
+  // awaits the whole network future chain inline under `block_on`, and the
+  // unoptimized state machine plus its poll frames does not fit. Run the
+  // runtime on a thread with an explicit stack size instead of
+  // `#[tokio::main]`.
+  let handle = std::thread::Builder::new()
+    .stack_size(16 * 1024 * 1024)
+    .spawn(|| {
+      tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build the tokio runtime")
+        .block_on(spotatui::run_cli())
+    })?;
+  match handle.join() {
+    Ok(result) => result,
+    Err(panic) => std::panic::resume_unwind(panic),
+  }
 }

--- a/src/cli/handle.rs
+++ b/src/cli/handle.rs
@@ -46,7 +46,9 @@ pub async fn handle_matches(
     }
   }
 
-  if let Some(d) = matches.get_one::<String>("device") {
+  // Only `playback` and `play` define `device`; a plain `get_one` panics
+  // under clap's debug assertions when `list`/`search` reach this shared path.
+  if let Some(d) = matches.try_get_one::<String>("device").ok().flatten() {
     cli.set_device(d.to_string()).await?;
   }
 

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -8,7 +8,6 @@ use crate::core::{
 use crate::infra::player::{select_native, PlaybackBackend};
 use anyhow::anyhow;
 use chrono::TimeDelta;
-#[cfg(feature = "streaming")]
 use log::{info, warn};
 use reqwest::Method;
 #[cfg(feature = "streaming")]
@@ -416,10 +415,89 @@ fn spotify_payload_confirms_native_device(payload: &DevicePayload, native_device
     .any(|device| device.id.as_deref() == Some(native_device_id))
 }
 
-#[cfg(feature = "streaming")]
 fn is_no_active_device_error(e: &anyhow::Error) -> bool {
   let text = e.to_string().to_ascii_lowercase();
   text.contains("no_active_device") || text.contains("no active device")
+}
+
+/// Whether a native backend is positioned to claim a failed player command:
+/// an available player (`start_playback` activates it on `NO_ACTIVE_DEVICE`),
+/// or a backend/activation still materializing (the `suppressed_*` handlers
+/// classify on the original error).
+async fn native_can_claim_player_command(network: &Network) -> bool {
+  #[cfg(feature = "streaming")]
+  {
+    let app = network.app.lock().await;
+    app
+      .streaming_player
+      .as_ref()
+      .is_some_and(|p| p.is_available())
+      || app.native_backend_pending
+      || app.native_activation_pending
+  }
+  #[cfg(not(feature = "streaming"))]
+  {
+    let _ = network;
+    false
+  }
+}
+
+/// The saved device to retry a player command on, or `None` to surface the
+/// original error. Sending `device_id` with `me/player/*` both targets and
+/// activates the device, which a bare command cannot do — without it every
+/// command 404s once all devices are idle, the steady state of CLI mode
+/// (#464). Never retries while a native backend could claim the command.
+fn saved_device_retry(
+  error_is_no_active_device: bool,
+  saved_device_id: Option<&str>,
+  native_can_claim: bool,
+) -> Option<String> {
+  if !error_is_no_active_device || native_can_claim {
+    return None;
+  }
+  saved_device_id.map(str::to_string)
+}
+
+/// Run a player command against the Web API, retrying once on the saved
+/// device (`client_config.device_id`) when Spotify rejects the bare command
+/// with `NO_ACTIVE_DEVICE`. A failed retry surfaces the *original* error so
+/// downstream classification (native fallback, transient suppression) is
+/// unchanged.
+async fn player_command_with_saved_device_retry(
+  network: &Network,
+  method: Method,
+  path: &str,
+  query: &[(&str, String)],
+  body: Option<Value>,
+) -> anyhow::Result<Value> {
+  let result = network
+    .spotify_api_request_json(method.clone(), path, query, body.clone())
+    .await;
+  let Err(e) = result else {
+    return result;
+  };
+
+  let Some(device_id) = saved_device_retry(
+    is_no_active_device_error(&e),
+    network.client_config.device_id.as_deref(),
+    native_can_claim_player_command(network).await,
+  ) else {
+    return Err(e);
+  };
+
+  info!("{path}: no active device; retrying on the saved device {device_id}");
+  let mut query = query.to_vec();
+  query.push(("device_id", device_id));
+  match network
+    .spotify_api_request_json(method, path, &query, body)
+    .await
+  {
+    Ok(value) => Ok(value),
+    Err(retry_err) => {
+      warn!("saved-device retry failed: {retry_err}");
+      Err(e)
+    }
+  }
 }
 
 /// While a native backend is expected to materialize (recovery in flight, or
@@ -1635,9 +1713,8 @@ impl PlaybackNetwork for Network {
     }
 
     let body = api_playback_body(context_id.as_ref(), uris.as_deref(), offset);
-    let result = self
-      .spotify_api_request_json(Method::PUT, "me/player/play", &[], body)
-      .await;
+    let result =
+      player_command_with_saved_device_retry(self, Method::PUT, "me/player/play", &[], body).await;
 
     match result {
       Ok(_) => {
@@ -1921,8 +1998,7 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    match self
-      .spotify_api_request_json(Method::PUT, "me/player/pause", &[], None)
+    match player_command_with_saved_device_retry(self, Method::PUT, "me/player/pause", &[], None)
       .await
     {
       Ok(_) => {
@@ -1955,9 +2031,8 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    if let Err(e) = self
-      .spotify_api_request_json(Method::POST, "me/player/next", &[], None)
-      .await
+    if let Err(e) =
+      player_command_with_saved_device_retry(self, Method::POST, "me/player/next", &[], None).await
     {
       #[cfg(feature = "streaming")]
       if suppressed_transient_native_command_error(self, &e).await {
@@ -1981,9 +2056,9 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    if let Err(e) = self
-      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
-      .await
+    if let Err(e) =
+      player_command_with_saved_device_retry(self, Method::POST, "me/player/previous", &[], None)
+        .await
     {
       #[cfg(feature = "streaming")]
       if suppressed_transient_native_command_error(self, &e).await {
@@ -2011,9 +2086,9 @@ impl PlaybackNetwork for Network {
     // First previous_track restarts the current track (if past Spotify's ~3s
     // threshold). After a short delay the second call actually skips to the
     // previous track, since the position is now back at 0.
-    if let Err(e) = self
-      .spotify_api_request_json(Method::POST, "me/player/previous", &[], None)
-      .await
+    if let Err(e) =
+      player_command_with_saved_device_retry(self, Method::POST, "me/player/previous", &[], None)
+        .await
     {
       #[cfg(feature = "streaming")]
       if suppressed_transient_native_command_error(self, &e).await {
@@ -2049,14 +2124,14 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    if let Err(e) = self
-      .spotify_api_request_json(
-        Method::PUT,
-        "me/player/seek",
-        &[("position_ms", position_ms.to_string())],
-        None,
-      )
-      .await
+    if let Err(e) = player_command_with_saved_device_retry(
+      self,
+      Method::PUT,
+      "me/player/seek",
+      &[("position_ms", position_ms.to_string())],
+      None,
+    )
+    .await
     {
       #[cfg(feature = "streaming")]
       if suppressed_transient_native_command_error(self, &e).await {
@@ -2083,14 +2158,14 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    match self
-      .spotify_api_request_json(
-        Method::PUT,
-        "me/player/shuffle",
-        &[("state", shuffle_state.to_string())],
-        None,
-      )
-      .await
+    match player_command_with_saved_device_retry(
+      self,
+      Method::PUT,
+      "me/player/shuffle",
+      &[("state", shuffle_state.to_string())],
+      None,
+    )
+    .await
     {
       Ok(_) => {
         let mut app = self.app.lock().await;
@@ -2126,14 +2201,14 @@ impl PlaybackNetwork for Network {
     }
 
     let repeat_state_param: &'static str = repeat_state.into();
-    match self
-      .spotify_api_request_json(
-        Method::PUT,
-        "me/player/repeat",
-        &[("state", repeat_state_param.to_string())],
-        None,
-      )
-      .await
+    match player_command_with_saved_device_retry(
+      self,
+      Method::PUT,
+      "me/player/repeat",
+      &[("state", repeat_state_param.to_string())],
+      None,
+    )
+    .await
     {
       Ok(_) => {
         let mut app = self.app.lock().await;
@@ -2179,14 +2254,14 @@ impl PlaybackNetwork for Network {
       return;
     }
 
-    match self
-      .spotify_api_request_json(
-        Method::PUT,
-        "me/player/volume",
-        &[("volume_percent", volume.to_string())],
-        None,
-      )
-      .await
+    match player_command_with_saved_device_retry(
+      self,
+      Method::PUT,
+      "me/player/volume",
+      &[("volume_percent", volume.to_string())],
+      None,
+    )
+    .await
     {
       Ok(_) => {
         let mut app = self.app.lock().await;
@@ -2625,6 +2700,35 @@ mod tests {
 
   fn playable_track(id: &str) -> PlayableId<'static> {
     PlayableId::Track(TrackId::from_id(id).unwrap().into_static())
+  }
+
+  #[test]
+  fn no_active_device_error_matches_spotify_404_payload() {
+    let e = anyhow!(
+      "{}",
+      r#"Spotify API 404 Not Found failed: {
+  "error" : {
+    "status" : 404,
+    "message" : "Player command failed: No active device found",
+    "reason" : "NO_ACTIVE_DEVICE"
+  }
+}"#
+    );
+    assert!(is_no_active_device_error(&e));
+    assert!(!is_no_active_device_error(&anyhow!(
+      "Spotify API 404 Not Found failed: Device not found"
+    )));
+  }
+
+  #[test]
+  fn saved_device_retry_needs_the_error_and_a_device_and_no_native_claim() {
+    assert_eq!(
+      saved_device_retry(true, Some("dev1"), false),
+      Some("dev1".to_string())
+    );
+    assert_eq!(saved_device_retry(true, Some("dev1"), true), None);
+    assert_eq!(saved_device_retry(true, None, false), None);
+    assert_eq!(saved_device_retry(false, Some("dev1"), false), None);
   }
 
   #[allow(deprecated)]

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 130              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1371            # floor: may only rise
+test_attribute_total = 1373            # floor: may only rise


### PR DESCRIPTION
# Summary

Fixes #464. CLI player commands failed with `404 NO_ACTIVE_DEVICE` whenever no Spotify device was active, which is the CLI's steady state once the TUI has exited. The CLI resolved `--device` into `client_config.device_id` but the Web API route never sent it: a bare `me/player/*` call only works against an already-active device, while the same call with `device_id` both targets and activates it.

- **`infra/network/playback.rs`**: all nine external-route player commands (play, pause, next, previous x2, seek, shuffle, repeat, volume) now go through `player_command_with_saved_device_retry`. When the bare command fails with `NO_ACTIVE_DEVICE` and a saved device exists, it retries once with `device_id=<saved>`. The retry stands down whenever a native backend could claim the command (available player, or a pending backend/activation the `suppressed_*` handlers classify on), so TUI native-streaming behavior is byte-for-byte unchanged. A failed retry surfaces the original error, keeping downstream classification intact. The decision is a pure function with tests.
- Two debug-build-only CLI crashes on Windows that masked the bug locally ride along:
  - **`bin/spotatui.rs`**: the inline CLI future chain overflows the 1 MiB Windows main-thread stack in unoptimized builds; the shim now runs the runtime on a 16 MiB thread instead of `#[tokio::main]`.
  - **`cli/handle.rs`**: `get_one("device")` panics under clap's debug assertions for subcommands that do not define the arg (`list`, `search`); switched to `try_get_one`.

Not covered: `play --queue` (`me/player/queue`), which cannot activate a device server-side.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`: clean
- `cargo test --no-default-features --features telemetry,tui`: 598 passed
- `cargo test` (default): 896 passed
- `cargo check` on the headless (`telemetry`), `mcp-only`, and `ai-dj-only` feature sets: clean
- Live on Windows: reproduced the issue's exact 404 before the fix; after it, the log shows the bare 404, the retry firing on the saved device, and (with zero devices online, so the saved id is stale) the original error surfaced unchanged. The positive path (an idle listed device getting activated) still needs a manual smoke test with a Spotify client open.

# Additional notes

- Gates: test floor raised 1371 -> 1373.
- `spotatui playback --transfer <name>` was already the one working command (it sends the device id); this PR brings the rest of the playback surface in line with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback reliability when no active device is available by retrying commands on the configured device.
  - Applies to play, pause, skip, seek, shuffle, repeat, and volume controls.
  - Preserved the original error when retrying cannot resolve the issue.
  - Prevented commands without a device selection from causing unexpected failures.
  - Improved application startup and runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->