### PR TITLE
fix(core): clear api_error instead of latching it

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -276,6 +276,37 @@ until they expire, so use the right one. TTLs are seconds, scaled by the user's
 `self.show_status_message(msg, ttl_secs).await`; be aware it bypasses the
 error-priority guard. Never write `app.status_message` directly.
 
+
+### Errors
+
+`App::handle_error(e)` records the message in `api_error`, stamps a 60s
+lifetime on it, and pushes `RouteId::Error`. That route is a *presentation
+hint*: the terminal frontend draws it full-screen, another frontend may render
+`api_error` as a toast and ignore the frame entirely. Four rules:
+
+- Dismiss with `app.clear_api_error()`, never by clearing the string or popping
+  the route by hand. It drops the message, its lifetime, and every frame still
+  showing it together - a cleared string under a surviving frame renders as an
+  error page with nothing on it. `pop_navigation_stack` already calls it when
+  the frame it pops is `Error`.
+- Nothing else clears `api_error`. `update_on_tick` retires it once the
+  lifetime passes, handing the text to the status bar only when the error frame
+  is the current screen, so a frontend with no dismissal gesture does not latch
+  the first failure forever. The CLI never ticks, so its latch is intact.
+- A non-empty `api_error` is the CLI's only failure signal for every subcommand
+  that reaches the bottom of `handle_matches` (`src/cli/handle.rs`; the two
+  `share-*` flags return early and bypass it). Moving a call site off
+  `handle_error` turns a failing CLI command into exit 0 unless that site is
+  provably unreachable from the CLI.
+- Demote a site to `set_error_status_message` only when all three hold: it
+  fires from the tick or a self-refreshing retry loop (so every retry restamps
+  the lifetime and the backstop can never win), it is provably unreachable as a
+  CLI exit signal, and the failed operation is bookkeeping rather than the thing
+  the user asked for. `flush_state_save` is the only site that qualifies today,
+  and it latches its report to once per failure run - repeating it at the retry
+  rate would hold `status_message_is_error` and silently drop every ordinary
+  status message for the rest of the session.
+
 ### Dialog state cleanup
 
 Close dialogs with the single call `app.clear_dialog_state()` (clears `dialog`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,37 @@ until they expire, so use the right one. TTLs are seconds, scaled by the user's
 `self.show_status_message(msg, ttl_secs).await`; be aware it bypasses the
 error-priority guard. Never write `app.status_message` directly.
 
+
+### Errors
+
+`App::handle_error(e)` records the message in `api_error`, stamps a 60s
+lifetime on it, and pushes `RouteId::Error`. That route is a *presentation
+hint*: the terminal frontend draws it full-screen, another frontend may render
+`api_error` as a toast and ignore the frame entirely. Four rules:
+
+- Dismiss with `app.clear_api_error()`, never by clearing the string or popping
+  the route by hand. It drops the message, its lifetime, and every frame still
+  showing it together - a cleared string under a surviving frame renders as an
+  error page with nothing on it. `pop_navigation_stack` already calls it when
+  the frame it pops is `Error`.
+- Nothing else clears `api_error`. `update_on_tick` retires it once the
+  lifetime passes, handing the text to the status bar only when the error frame
+  is the current screen, so a frontend with no dismissal gesture does not latch
+  the first failure forever. The CLI never ticks, so its latch is intact.
+- A non-empty `api_error` is the CLI's only failure signal for every subcommand
+  that reaches the bottom of `handle_matches` (`src/cli/handle.rs`; the two
+  `share-*` flags return early and bypass it). Moving a call site off
+  `handle_error` turns a failing CLI command into exit 0 unless that site is
+  provably unreachable from the CLI.
+- Demote a site to `set_error_status_message` only when all three hold: it
+  fires from the tick or a self-refreshing retry loop (so every retry restamps
+  the lifetime and the backstop can never win), it is provably unreachable as a
+  CLI exit signal, and the failed operation is bookkeeping rather than the thing
+  the user asked for. `flush_state_save` is the only site that qualifies today,
+  and it latches its report to once per failure run - repeating it at the retry
+  rate would hold `status_message_is_error` and silently drop every ordinary
+  status message for the rest of the session.
+
 ### Dialog state cleanup
 
 Close dialogs with the single call `app.clear_dialog_state()` (clears `dialog`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,37 @@ until they expire, so use the right one. TTLs are seconds, scaled by the user's
 `self.show_status_message(msg, ttl_secs).await`; be aware it bypasses the
 error-priority guard. Never write `app.status_message` directly.
 
+
+### Errors
+
+`App::handle_error(e)` records the message in `api_error`, stamps a 60s
+lifetime on it, and pushes `RouteId::Error`. That route is a *presentation
+hint*: the terminal frontend draws it full-screen, another frontend may render
+`api_error` as a toast and ignore the frame entirely. Four rules:
+
+- Dismiss with `app.clear_api_error()`, never by clearing the string or popping
+  the route by hand. It drops the message, its lifetime, and every frame still
+  showing it together - a cleared string under a surviving frame renders as an
+  error page with nothing on it. `pop_navigation_stack` already calls it when
+  the frame it pops is `Error`.
+- Nothing else clears `api_error`. `update_on_tick` retires it once the
+  lifetime passes, handing the text to the status bar only when the error frame
+  is the current screen, so a frontend with no dismissal gesture does not latch
+  the first failure forever. The CLI never ticks, so its latch is intact.
+- A non-empty `api_error` is the CLI's only failure signal for every subcommand
+  that reaches the bottom of `handle_matches` (`src/cli/handle.rs`; the two
+  `share-*` flags return early and bypass it). Moving a call site off
+  `handle_error` turns a failing CLI command into exit 0 unless that site is
+  provably unreachable from the CLI.
+- Demote a site to `set_error_status_message` only when all three hold: it
+  fires from the tick or a self-refreshing retry loop (so every retry restamps
+  the lifetime and the backstop can never win), it is provably unreachable as a
+  CLI exit signal, and the failed operation is bookkeeping rather than the thing
+  the user asked for. `flush_state_save` is the only site that qualifies today,
+  and it latches its report to once per failure run - repeating it at the retry
+  rate would hold `status_message_is_error` and silently drop every ordinary
+  status message for the rest of the session.
+
 ### Dialog state cleanup
 
 Close dialogs with the single call `app.clear_dialog_state()` (clears `dialog`,

--- a/src/core/app/construction.rs
+++ b/src/core/app/construction.rs
@@ -62,6 +62,7 @@ impl Default for App {
       navigation_stack: vec![DEFAULT_ROUTE],
       small_search_limit: 4,
       api_error: String::new(),
+      api_error_expires_at: None,
       current_playback_context: None,
       last_track_id: None,
       pending_stop_after_track: false,
@@ -219,6 +220,7 @@ impl Default for App {
       is_volume_change_in_flight: false,
       state_save_due: None,
       pending_state_save_patch: PersistedRuntimeState::default(),
+      state_save_error_reported: false,
       pending_volume: None,
       last_dispatched_volume: None,
       #[cfg(feature = "streaming")]

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -154,7 +154,14 @@ pub struct App {
   pub artist: Option<Artist>,
   pub album_table_context: AlbumTableContext,
   pub saved_album_tracks_index: usize,
+  /// The live error recorded by [`App::handle_error`], or empty when there is
+  /// none. The `RouteId::Error` frame raised alongside it is a presentation
+  /// *hint*, not the state: a frontend may draw it full-screen, render this
+  /// string as a toast, or ignore it. Dismiss via [`App::clear_api_error`].
   pub api_error: String,
+  /// When the live `api_error` stops being current. Stamped by `handle_error`,
+  /// consumed by `App::expire_api_error` on the tick. `None` means none is live.
+  pub api_error_expires_at: Option<Instant>,
   pub current_playback_context: Option<CurrentPlaybackContext>,
   pub last_track_id: Option<String>,
   /// Set to true when a track ends naturally and stop_after_current_track is enabled.
@@ -521,6 +528,12 @@ pub struct App {
   pub state_save_due: Option<Instant>,
   /// Runtime-state patch waiting for the next debounced save.
   pub pending_state_save_patch: PersistedRuntimeState,
+  /// Whether the current run of state-save failures has already been reported.
+  /// A failed flush re-arms its own deadline, so the tick retries twice a
+  /// second; without this latch the report would re-fire at that rate and pin
+  /// the status bar into error mode, where `set_status_message` refuses to
+  /// overwrite it and every ordinary message is dropped for the rest of the run.
+  pub state_save_error_reported: bool,
   /// Reference to the native streaming player for direct control (bypasses event channel)
   #[cfg(feature = "streaming")]
   pub streaming_player: Option<Arc<crate::infra::player::StreamingPlayer>>,

--- a/src/core/app/persistence.rs
+++ b/src/core/app/persistence.rs
@@ -321,14 +321,111 @@ impl App {
     if force || Instant::now() >= due {
       let patch = std::mem::take(&mut self.pending_state_save_patch);
       self.state_save_due = None;
-      if let Err(e) = self.save_runtime_state(&patch) {
-        self.pending_state_save_patch.merge_patch(&patch);
-        // Keep the save scheduled: with the deadline cleared the retained patch
-        // would never be retried (this fn returns early on a `None` deadline),
-        // and the forced shutdown flush would silently drop it.
-        self.state_save_due = Some(Instant::now() + Duration::from_millis(STATE_SAVE_DEBOUNCE_MS));
-        self.handle_error(anyhow!("Failed to save state: {}", e));
+      match self.save_runtime_state(&patch) {
+        Ok(()) => self.state_save_error_reported = false,
+        Err(e) => {
+          self.pending_state_save_patch.merge_patch(&patch);
+          // Keep the save scheduled: with the deadline cleared the retained patch
+          // would never be retried (this fn returns early on a `None` deadline),
+          // and the forced shutdown flush would silently drop it.
+          self.state_save_due =
+            Some(Instant::now() + Duration::from_millis(STATE_SAVE_DEBOUNCE_MS));
+          // Reported to the status bar, not as an error page: the tick calls
+          // this every frame and the retry above re-arms twice a second, so as
+          // a modal an unwritable state dir is an unusable app, and as an
+          // `api_error` it is one no frontend can clear because every retry
+          // restamps the lifetime. Latched to one report per failure run, or
+          // the same rate would pin the status bar into error mode and drop
+          // every ordinary message for the rest of the session.
+          if !self.state_save_error_reported {
+            self.state_save_error_reported = true;
+            self.set_error_status_message(format!("Failed to save state: {}", e), 8);
+          }
+        }
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::app::test_support::*;
+
+  /// An `App` whose state saves always fail: the save path's parent is a
+  /// regular file, so creating the directory for it cannot succeed on any
+  /// platform.
+  fn app_with_unwritable_state_path() -> (App, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+
+    let mut app = make_app_simple();
+    app.state_path = Some(blocker.join("state.yml"));
+    (app, dir)
+  }
+
+  fn schedule_a_save(app: &mut App) {
+    app.pending_state_save_patch = PersistedRuntimeState {
+      volume_percent: Some(42),
+      ..PersistedRuntimeState::default()
+    };
+    app.state_save_due = Some(Instant::now());
+  }
+
+  #[test]
+  fn a_failed_state_save_reports_to_the_status_bar_instead_of_the_error_page() {
+    let (mut app, _dir) = app_with_unwritable_state_path();
+    schedule_a_save(&mut app);
+
+    app.flush_state_save(false);
+
+    assert!(app
+      .status_message
+      .as_deref()
+      .is_some_and(|message| message.starts_with("Failed to save state")));
+    assert!(app.status_message_is_error);
+    // Not the modal: the tick retries twice a second, so an error page here
+    // is an app the user cannot escape.
+    assert!(app.api_error.is_empty());
+    assert_ne!(app.get_current_route().id, RouteId::Error);
+  }
+
+  // The regression the latch exists to prevent: an unlatched report re-fires
+  // at the tick's retry rate, and a live error message holds
+  // `status_message_is_error`, which makes `set_status_message` drop every
+  // ordinary message for the rest of the session.
+  //
+  // Asserted through a sentinel rather than by expiring the message and
+  // watching the bar recover: backdating `status_message_expires_at` opens the
+  // priority guard whether or not the latch is there, so that version of this
+  // test passes with the latch deleted. A second report would replace the
+  // sentinel, because an error always overwrites a live error.
+  #[test]
+  fn repeated_state_save_failures_report_only_once() {
+    let (mut app, _dir) = app_with_unwritable_state_path();
+    schedule_a_save(&mut app);
+    app.flush_state_save(false);
+    app.set_error_status_message("sentinel", 8);
+
+    // The retry the failed flush re-armed, as the tick would drive it.
+    app.state_save_due = Some(Instant::now());
+    app.flush_state_save(false);
+
+    assert_eq!(app.status_message.as_deref(), Some("sentinel"));
+  }
+
+  #[test]
+  fn a_successful_state_save_re_arms_the_failure_report() {
+    let (mut app, dir) = app_with_unwritable_state_path();
+    schedule_a_save(&mut app);
+    app.flush_state_save(false);
+    assert!(app.state_save_error_reported);
+
+    app.state_path = Some(dir.path().join("state.yml"));
+    app.state_save_due = Some(Instant::now());
+    app.flush_state_save(false);
+
+    assert!(!app.state_save_error_reported);
   }
 }

--- a/src/core/app/route.rs
+++ b/src/core/app/route.rs
@@ -221,8 +221,43 @@ impl App {
     if self.navigation_stack.len() == 1 {
       None
     } else {
-      self.navigation_stack.pop()
+      let popped = self.navigation_stack.pop();
+      // Leaving the error screen dismisses the error. Done here rather than in
+      // a key handler so every back path clears it (the escape key, the
+      // configurable back key, a script's `Back`), and so a frontend with no
+      // back key at all is not the odd one out. Keyed on the frame that was
+      // POPPED, not on the new top: pressing `d` from the error page stacks the
+      // device picker over it, and coming back must still show the message.
+      if popped
+        .as_ref()
+        .is_some_and(|route| route.id == RouteId::Error)
+      {
+        self.clear_api_error();
+      }
+      popped
     }
+  }
+
+  /// Remove every frame still serving as the error screen.
+  ///
+  /// Matched on the id AND the block, not on the id alone. The search key
+  /// rewrites the error frame in place to `{ id: Error, active_block: Input }`
+  /// (it does not push), so an id-only match would delete a frame that is
+  /// holding live text-input focus and drop the user's next keystrokes into
+  /// the global bindings. Such a frame no longer draws the error screen, so
+  /// leaving it is harmless.
+  ///
+  /// Both `push_navigation_stack` and the frames below the top are covered:
+  /// pushes dedupe only against the top frame, so navigating away and failing
+  /// again buries a second error frame that would otherwise resurface later
+  /// rendering an unrelated message, or an empty one.
+  ///
+  /// Cannot empty the stack: the bottom frame is `DEFAULT_ROUTE` (Home) or a
+  /// `RouteId::STARTUP_OPTIONS` route, and `Error` is in neither.
+  pub(super) fn drop_error_routes(&mut self) {
+    self
+      .navigation_stack
+      .retain(|route| !(route.id == RouteId::Error && route.active_block == ActiveBlock::Error));
   }
 
   pub fn get_current_route(&self) -> &Route {

--- a/src/core/app/status.rs
+++ b/src/core/app/status.rs
@@ -17,6 +17,16 @@ pub struct Announcement {
   pub received_at: Instant,
 }
 
+/// How long a recorded error stays current before the tick retires it. Long
+/// enough not to snatch the page away from someone reading it; short enough
+/// that a frontend with no dismissal gesture does not latch the first failure
+/// for the life of the process.
+const API_ERROR_TTL: Duration = Duration::from_secs(60);
+
+/// How long the retired message lingers in the status bar afterwards, before
+/// `status_message_ttl_percent` scaling.
+const API_ERROR_HANDOFF_TTL_SECS: u64 = 8;
+
 impl App {
   #[allow(dead_code)]
   pub fn enqueue_announcements(&mut self, announcements: Vec<Announcement>) {
@@ -97,10 +107,46 @@ impl App {
     ((ttl_secs * pct + 50) / 100).max(1)
   }
 
+  /// Record an error and raise the `RouteId::Error` frame the terminal
+  /// frontend draws full-screen. That frame is a presentation hint, not the
+  /// state: another frontend may render [`Self::api_error`] however it likes.
+  /// Every frontend dismisses through [`Self::clear_api_error`], and one that
+  /// never dismisses gets the [`API_ERROR_TTL`] backstop on the tick.
   pub fn handle_error(&mut self, e: anyhow::Error) {
     info!("error occurred: {}", e);
     self.push_navigation_stack(RouteId::Error, ActiveBlock::Error);
     self.api_error = e.to_string();
+    self.api_error_expires_at = Some(Instant::now() + API_ERROR_TTL);
+  }
+
+  /// Dismiss the live error: the message, its lifetime, and every navigation
+  /// frame still showing it. The single dismissal primitive, so a frontend
+  /// with no route stack has one call to make. Dropping the frames is what
+  /// stops a cleared message from leaving an error page with nothing on it.
+  pub fn clear_api_error(&mut self) {
+    self.api_error.clear();
+    self.api_error_expires_at = None;
+    self.drop_error_routes();
+  }
+
+  /// Retire an error whose lifetime has passed. When the error frame is the
+  /// screen the user is on, the text moves to the status bar on the way out so
+  /// the page does not vanish leaving nothing behind. A frame that expired
+  /// buried under something else goes quietly: a toast about a minute-old
+  /// failure the user already navigated away from is noise.
+  pub(super) fn expire_api_error(&mut self) {
+    let Some(expires_at) = self.api_error_expires_at else {
+      return;
+    };
+    if Instant::now() < expires_at {
+      return;
+    }
+    let showing = self.get_current_route().active_block == ActiveBlock::Error;
+    let message = std::mem::take(&mut self.api_error);
+    self.clear_api_error();
+    if showing && !message.is_empty() {
+      self.set_error_status_message(message, API_ERROR_HANDOFF_TTL_SECS);
+    }
   }
 }
 
@@ -143,6 +189,86 @@ mod tests {
 
     assert_eq!(app.status_message.as_deref(), Some("second error"));
     assert!(app.status_message_is_error);
+  }
+
+  // --- error lifecycle tests ---
+
+  #[test]
+  fn raising_an_error_stamps_a_lifetime_on_it() {
+    let mut app = make_app_simple();
+
+    app.handle_error(anyhow!("boom"));
+
+    assert_eq!(app.api_error, "boom");
+    assert!(app.api_error_expires_at.is_some());
+    assert_eq!(app.get_current_route().id, RouteId::Error);
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::Error);
+  }
+
+  #[test]
+  fn dismissing_the_error_route_clears_the_message() {
+    let mut app = make_app_simple();
+    app.handle_error(anyhow!("boom"));
+
+    app.pop_navigation_stack();
+
+    assert!(app.api_error.is_empty());
+    assert!(app.api_error_expires_at.is_none());
+    assert_ne!(app.get_current_route().id, RouteId::Error);
+  }
+
+  // The error page's own hint tells the user to press `d`. Coming back from
+  // the device picker must still show the message, which is why the clear is
+  // keyed on the frame that was popped rather than on the new top.
+  #[test]
+  fn popping_a_screen_opened_from_the_error_route_keeps_the_message() {
+    let mut app = make_app_simple();
+    app.handle_error(anyhow!("boom"));
+    app.push_navigation_stack(RouteId::SelectedDevice, ActiveBlock::SelectDevice);
+
+    app.pop_navigation_stack();
+
+    assert_eq!(app.api_error, "boom");
+    assert_eq!(app.get_current_route().id, RouteId::Error);
+  }
+
+  #[test]
+  fn dismissing_an_error_drops_a_duplicate_error_frame_left_lower_in_the_stack() {
+    let mut app = make_app_simple();
+    app.handle_error(anyhow!("first"));
+    app.push_navigation_stack(RouteId::SelectedDevice, ActiveBlock::SelectDevice);
+    // Pushes a SECOND error frame: pushes dedupe only against the top frame.
+    app.handle_error(anyhow!("second"));
+
+    app.pop_navigation_stack();
+
+    assert!(app.api_error.is_empty());
+    assert_eq!(app.get_current_route().id, RouteId::SelectedDevice);
+  }
+
+  #[test]
+  fn dismissing_an_error_never_empties_the_navigation_stack() {
+    let mut app = make_app_simple();
+    app.handle_error(anyhow!("boom"));
+
+    app.pop_navigation_stack();
+
+    assert_eq!(app.get_current_route().id, RouteId::Home);
+  }
+
+  // The search key rewrites the error frame in place instead of pushing, so
+  // the frame can be holding text-input focus. Deleting it there would drop
+  // the user's next keystrokes into the global bindings.
+  #[test]
+  fn clearing_an_error_leaves_a_frame_repurposed_as_a_search_input_alone() {
+    let mut app = make_app_simple();
+    app.handle_error(anyhow!("boom"));
+    app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
+
+    app.clear_api_error();
+
+    assert!(app.api_error.is_empty());
+    assert_eq!(app.get_current_route().active_block, ActiveBlock::Input);
   }
 
   #[test]

--- a/src/core/app/tick.rs
+++ b/src/core/app/tick.rs
@@ -104,6 +104,10 @@ impl App {
       }
     }
 
+    // Must stay above the early returns further down this fn, or the backstop
+    // would silently stop running during playback.
+    self.expire_api_error();
+
     if let Some(frame) = self.liked_song_animation_frame {
       if frame > 0 {
         self.liked_song_animation_frame = Some(frame - 1);
@@ -307,6 +311,56 @@ mod tests {
 
     app.update_on_tick(Duration::from_millis(500));
     assert!(app.playback_position_ms().is_some());
+  }
+
+  #[test]
+  fn a_live_error_survives_a_tick() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), None);
+    app.handle_error(anyhow!("boom"));
+
+    app.update_on_tick(Duration::from_millis(500));
+
+    assert_eq!(app.api_error, "boom");
+    assert_eq!(app.get_current_route().id, RouteId::Error);
+  }
+
+  #[test]
+  fn an_expired_error_is_retired_by_the_tick_and_handed_to_the_status_bar() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), None);
+    app.handle_error(anyhow!("boom"));
+    app.api_error_expires_at = Some(Instant::now() - Duration::from_secs(1));
+
+    app.update_on_tick(Duration::from_millis(500));
+
+    assert!(app.api_error.is_empty());
+    assert!(app.api_error_expires_at.is_none());
+    assert_ne!(app.get_current_route().id, RouteId::Error);
+    assert_eq!(app.status_message.as_deref(), Some("boom"));
+    assert!(app.status_message_is_error);
+  }
+
+  // The load-bearing case for a frontend that never dismisses: a buried error
+  // frame must not survive the expiry, or it resurfaces later rendering an
+  // error page with nothing on it. It expires silently, because a toast about
+  // a minute-old failure on a screen the user already left is noise.
+  #[test]
+  fn expiring_an_error_removes_an_error_route_left_under_another_screen() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), None);
+    app.handle_error(anyhow!("boom"));
+    app.push_navigation_stack(RouteId::SelectedDevice, ActiveBlock::SelectDevice);
+    app.api_error_expires_at = Some(Instant::now() - Duration::from_secs(1));
+
+    app.update_on_tick(Duration::from_millis(500));
+
+    assert!(app.api_error.is_empty());
+    assert_eq!(app.get_current_route().id, RouteId::SelectedDevice);
+    assert!(app.status_message.is_none());
+
+    app.pop_navigation_stack();
+    assert_eq!(app.get_current_route().id, RouteId::Home);
   }
 
   #[test]

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 786 # target 0
 ioevent_refs_in_tui = 130              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1373            # floor: may only rise
+test_attribute_total = 1385            # floor: may only rise


### PR DESCRIPTION
# Summary

`App::handle_error` is the only writer of `api_error`, and no site in the repo
cleared it. The TUI hides this because the user dismisses the error route, but
the field itself stays set forever — so anything that renders app state rather
than reacting to a keypress latches the first failure for the life of the
process. This gives the field a lifetime and a dismissal path, both owned by
`core/app` so they work without a route stack or an Esc key.

- **`handle_error`** stamps a 60s lifetime alongside the message. One edit
  covers all ~88 call sites and changes none of them.
- **`clear_api_error()`** is the single dismissal primitive: it drops the
  message, its lifetime, and every navigation frame still showing it. Clearing
  the string on its own would leave an error page with nothing rendered on it.
- **`pop_navigation_stack`** calls it when the frame it popped was `Error`, so
  the escape key, the configurable back key and a script's `Back` all dismiss
  identically with no changes under `src/tui/`. Keyed on the frame that was
  *popped* rather than the new top, so pressing `d` from the error page (the
  recovery the page itself advertises) and coming back still shows the message.
- **`update_on_tick`** retires an expired error next to the existing
  status-message expiry, guarded on the clock alone. Guarding on the route
  would never fire for a consumer that never pops, which is exactly the case
  this exists for. The text moves to the status bar only when the error frame
  is the screen the user is on; one that expired buried under another screen
  goes quietly.
- **`drop_error_routes`** matches on the id *and* the block. The search key
  rewrites the error frame in place into an input field rather than pushing,
  so an id-only match would delete a frame holding live text-input focus and
  drop the user's next keystrokes into the global bindings.
- **`flush_state_save`** reports to the status bar instead of the error page.
  The tick calls it every frame and a failed save re-arms its own deadline, so
  as a modal an unwritable state dir is an app you cannot escape. The report is
  latched to once per failure run: repeating it at the retry rate would hold
  `status_message_is_error`, and `set_status_message` refuses to overwrite a
  live error, so every ordinary status message would be dropped for the rest of
  the session.

CLI behavior is unchanged. It builds no driver and pops no routes, so a
non-empty `api_error` remains its failure signal.

# Testing

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`
  (also default and headless): clean
- `cargo test --no-default-features --features telemetry,tui`: 610 passed
- `cargo test --no-default-features --features telemetry` (headless): 329
  passed, zero warnings
- `cargo test` (default): 908 passed
- `cargo test --no-default-features --features telemetry,tui,mcp-server`: 729
  passed
- `cargo test --no-default-features --features telemetry,tui,ai-dj`: 869 passed
- all-sources CI string with `audio-viz` swapped for `audio-viz-cpal` (the leg
  itself is Linux-only): 1344 passed, plus the known pre-existing Windows-only
  `infra::local::tests::uri_round_trip` failure
- `tools/check_gates_ratchet.sh` vs main ok; `Cargo.lock` untouched
- The latch regression test was mutation-checked: with the latch removed it
  fails, as it should
- Manual smoke on Windows: the error page still raises and dismisses; opening
  the device picker from it and coming back preserves the message; the 60s
  backstop retires the page and hands the text to the status bar; a buried
  error frame is cleaned up rather than resurfacing; CLI exit codes unchanged

# Additional notes

- Gates: test floor raised 1373 -> 1385. No coupling counter moves — every
  edit lands in `src/core/app/**`, outside all of their measurement scopes.
- The new `### Errors` section in the three docs writes down the rule for
  moving a call site off `handle_error`, since a non-empty `api_error` is the
  CLI's only failure signal and demoting a CLI-reachable site silently turns a
  failing command into exit 0.
- Deliberately not included: clearing `api_error` between the shared CLI
  preamble and the subcommand. It looks like a free fix for a preamble failure
  discarding a subcommand that succeeded, but `list --devices` performs no
  fetch of its own and reads only the preamble's `GetDevices`, so clearing
  turns a failed device fetch into "No devices available" and exit 0;
  `playback --toggle` likewise consumes preamble state and returns `()`. That
  needs its own change and its own verification.
- The remaining ~87 `handle_error` call sites are unconverted on purpose. The
  latched-error defect is closed by the lifetime on the single writer, and a
  broad conversion is a behavioral change per site with a real exit-code trap.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for API errors, including automatic expiration after 60 seconds.
  * Expired errors can transition to status messages for limited visibility.
  * Added dismissal behavior that removes related error screens while preserving other navigation.
  * State-save failures now appear in the status bar and are reported once until saving succeeds.
* **Documentation**
  * Documented error display, dismissal, expiration, and state-save failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->