### PR TITLE
fix(streaming): queue slot survives track end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5783,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-audio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3abf3a3ed288f7edb7a7561158397f325dc952c505720cbc09974a114f413cd"
+checksum = "4323a85ca33dc31eab5f4d6f4ad539450e693153d4ac156524020d9a6ccc09cc"
 dependencies = [
  "aes",
  "bytes",
@@ -5803,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-connect"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825cd239c1fbe611b59d6eccab009441a263611ea38872d5a2f621e3db4fd04"
+checksum = "69f35486fe6e0877df6125718c81907f1ef93abcfbcece9f4c48ac78b535d0cb"
 dependencies = [
  "futures-util",
  "log",
@@ -5823,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b1b7550de2ba49d7be015afd064f496701d8ef10bc24223f45bf67f5e27f01"
+checksum = "d37d2d4de620069919084341d5c05fed4c58ddd05fb4ea54d5ee6626c2e01890"
 dependencies = [
  "aes",
  "base64",
@@ -5880,9 +5880,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-metadata"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5081b9a14cfda058c3e1650808e5ce4858fd13f251964281168320a96003c9"
+checksum = "505a730134dc62ece09147c832b6d0bd05175c77d4b3e630f0c20c9d459fd6b3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5898,9 +5898,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-oauth"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca334a374e498a8e0e7f49443b9ff8e775f6e97689295781e08298da80f0a0cf"
+checksum = "88426b06aeefe49e343780db5e4247a43079456d806cccc855f1b9994b556263"
 dependencies = [
  "log",
  "oauth2",
@@ -5912,9 +5912,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-playback"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374afcd5df561ef0b0323d006dcabb5e51043bb6db79927160bc1a188071a6be"
+checksum = "26f14436fa70657b9ebfa54729338c310480a57cd48032a190b9469265860a1b"
 dependencies = [
  "alsa 0.10.0",
  "cpal 0.16.0",
@@ -5945,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "spotatui-librespot-protocol"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d05ca4e1305e6f621be834d49e75c84a2837ff8ff94206fe7d7536533de6eb8"
+checksum = "955e5707148d4cf73eb5f829cb2a719b34559f1ad0f99adb58481fca9e8f29ad"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,16 +83,17 @@ rodio = { version = "0.22", optional = true }
 # Streaming dependencies: our maintained librespot fork, published on crates.io
 # as spotatui-librespot-* (upstream 0.8.0 + CDN 530 fallback for silent playback,
 # dealer reconnect/session-loss recovery, OAuth callback listener hardening,
-# previous-on-first-track restarting instead of stopping (#366), and a fork-only
-# session disconnect-reason API the app depends on - upstream 0.8 cannot be
-# substituted). The `package =` rename keeps `librespot_*` imports and
+# previous-on-first-track restarting instead of stopping (#366), Spirc ignoring
+# play-request ids of direct `Player::load`s so a queued track's end cannot stop
+# the next one, and a fork-only session disconnect-reason API the app depends
+# on - upstream 0.8 cannot be substituted). The `package =` rename keeps `librespot_*` imports and
 # `librespot-*/feature` refs unchanged; `=`-pinned so all seven crates upgrade in
 # lockstep. See SPOTATUI_FORK.md in the fork repo for the carried patches.
-librespot-core = { version = "=0.8.2", package = "spotatui-librespot-core", optional = true }
-librespot-connect = { version = "=0.8.2", package = "spotatui-librespot-connect", optional = true }
-librespot-oauth = { version = "=0.8.2", package = "spotatui-librespot-oauth", optional = true }
-librespot-metadata = { version = "=0.8.2", package = "spotatui-librespot-metadata", optional = true }
-librespot-protocol = { version = "=0.8.2", package = "spotatui-librespot-protocol", optional = true, default-features = false }
+librespot-core = { version = "=0.8.3", package = "spotatui-librespot-core", optional = true }
+librespot-connect = { version = "=0.8.3", package = "spotatui-librespot-connect", optional = true }
+librespot-oauth = { version = "=0.8.3", package = "spotatui-librespot-oauth", optional = true }
+librespot-metadata = { version = "=0.8.3", package = "spotatui-librespot-metadata", optional = true }
+librespot-protocol = { version = "=0.8.3", package = "spotatui-librespot-protocol", optional = true, default-features = false }
 protobuf = { version = "3.7", optional = true }
 futures = "0.3.32"
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
@@ -102,18 +103,18 @@ keepawake = "0.6"
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 arboard = { version = "3.4", features = ["wayland-data-control"] }
 pipewire = { version = "0.10", optional = true }
-librespot-playback = { version = "=0.8.2", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["alsa-backend"] }
+librespot-playback = { version = "=0.8.3", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["alsa-backend"] }
 
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 arboard = { version = "3.4", features = ["wayland-data-control"] }
-librespot-playback = { version = "=0.8.2", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
+librespot-playback = { version = "=0.8.3", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 arboard = "3.4"
 # On Windows we default to rodio for audio output.
 # Without this, librespot-playback falls back to the `pipe` sink which writes raw audio bytes
 # to stdout (breaking the TUI and producing no audible output).
-librespot-playback = { version = "=0.8.2", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
+librespot-playback = { version = "=0.8.3", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["rodio-backend"] }
 smtc-tokio = { version = "0.1.0", optional = true }
 
 # MPRIS D-Bus support (Linux only)
@@ -126,7 +127,7 @@ mpris-server = { version = "0.10", optional = true }
 # causing SIGSEGV crashes. See Issue #9 and #20.
 [target.'cfg(target_os = "macos")'.dependencies]
 arboard = "3.4"
-librespot-playback = { version = "=0.8.2", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["portaudio-backend"] }
+librespot-playback = { version = "=0.8.3", package = "spotatui-librespot-playback", optional = true, default-features = false, features = ["portaudio-backend"] }
 objc2-media-player = { version = "0.3", optional = true }
 objc2-foundation = { version = "0.3", optional = true }
 objc2-app-kit = { version = "0.3", optional = true, default-features = false, features = ["NSImage"] }

--- a/src/core/app/native_backend.rs
+++ b/src/core/app/native_backend.rs
@@ -174,7 +174,16 @@ impl App {
     self.native_device_id = Some(device_id.clone());
     self.is_streaming_active = true;
     self.native_activation_pending = false;
-    self.native_is_playing = Some(false);
+    // Only the polled "no active playback" answer reaches this, and that answer
+    // is structurally wrong while a queued Spotify track plays: the queue starts
+    // it with a direct `player.load`, which never enters Spirc's Connect state,
+    // so the Web API reports the device idle over audible playback. Clearing the
+    // play state here drew a paused playbar over that audio, and re-cleared it
+    // on every poll after the user pressed play. The player's own events own
+    // this field while the queue slot holds the sink.
+    if !self.queue_now_is_spotify() {
+      self.native_is_playing = Some(false);
+    }
 
     if self
       .current_playback_context
@@ -300,5 +309,44 @@ mod tests {
     app.last_device_activation = Some(Instant::now() - Duration::from_secs(6));
 
     assert!(!app.has_fresh_native_activity());
+  }
+
+  /// The polled "device is idle" answer is the only caller, and it cannot see a
+  /// queued Spotify track: the queue starts it with a direct `player.load`, so
+  /// the Web API reports the device idle over audible playback. Believing it
+  /// drew a paused playbar over that audio, and re-drew it every poll after the
+  /// user pressed play.
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn marking_the_device_available_keeps_the_queue_slots_play_state() {
+    use crate::core::app::test_support::queue_track;
+    use crate::infra::queue::QueueNowPlaying;
+
+    let mut app = App {
+      native_is_playing: Some(true),
+      queue_now: Some(QueueNowPlaying::Spotify {
+        track: queue_track(Some("spotify:track:queued"), "Queued"),
+      }),
+      ..Default::default()
+    };
+
+    app.mark_native_streaming_device_available("device".to_string(), "spotatui".to_string(), 70);
+
+    assert_eq!(app.native_is_playing, Some(true));
+    assert!(app.is_streaming_active);
+  }
+
+  /// With no queue slot the API's idle answer is trustworthy again.
+  #[cfg(feature = "streaming")]
+  #[test]
+  fn marking_the_device_available_clears_the_play_state_without_a_queue_slot() {
+    let mut app = App {
+      native_is_playing: Some(true),
+      ..Default::default()
+    };
+
+    app.mark_native_streaming_device_available("device".to_string(), "spotatui".to_string(), 70);
+
+    assert_eq!(app.native_is_playing, Some(false));
   }
 }

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1904,11 +1904,16 @@ impl PlaybackNetwork for Network {
     let (player, snapshot) = {
       let mut app = self.app.lock().await;
       if app.pending_start_playback.is_some() {
+        warn!("native restore {generation} skipped: a parked StartPlayback owns the replay");
         return;
       }
       // A stale RestoreNativePlayback (e.g. queued before a handoff cleared
       // the snapshot) must not escalate into a reselecting recovery (#437).
       if app.native_playback_restore_generation() != Some(generation) {
+        warn!(
+          "native restore {generation} skipped: snapshot generation is now {:?}",
+          app.native_playback_restore_generation()
+        );
         return;
       }
       let Some(player) = app
@@ -1917,10 +1922,12 @@ impl PlaybackNetwork for Network {
         .filter(|player| player.is_connected())
         .cloned()
       else {
+        warn!("native restore {generation} skipped: no connected player; forcing recovery");
         app.force_native_streaming_recovery(true);
         return;
       };
       let Some(snapshot) = app.begin_native_playback_restore(generation) else {
+        warn!("native restore {generation} skipped: the snapshot moved on mid-restore");
         return;
       };
       app.native_load_watchdog = Some(Instant::now());
@@ -1929,6 +1936,9 @@ impl PlaybackNetwork for Network {
     };
 
     let Some(request) = native_restore_load_request(&snapshot) else {
+      warn!(
+        "native restore {generation} skipped: the snapshot carries no loadable context or uris"
+      );
       let mut app = self.app.lock().await;
       if app.native_playback_restore_generation() == Some(generation) {
         app.native_restore_pending = None;
@@ -2498,6 +2508,8 @@ impl PlaybackNetwork for Network {
     #[cfg(feature = "streaming")]
     let native_active = is_native_streaming_active_for_playback(self).await;
     #[cfg(feature = "streaming")]
+    info!("continuation for {previous_track_id}: handling, native_active={native_active}");
+    #[cfg(feature = "streaming")]
     if native_active {
       let (transition_advanced, raw_next, raw_list_exhausted) = {
         let app = self.app.lock().await;
@@ -2525,6 +2537,7 @@ impl PlaybackNetwork for Network {
         // the progress watchdog does not read the silence as a stall and
         // rebuild the backend, and so a later recovery cannot replay the
         // final track.
+        info!("continuation for {previous_track_id}: raw uri list exhausted; staying stopped");
         self.app.lock().await.set_native_playback_intent(false);
         return;
       }
@@ -2585,8 +2598,18 @@ impl PlaybackNetwork for Network {
             "continuation for {previous_track_id}: resuming the already-selected next item"
           );
           self.start_playback(None, None, None).await;
+        } else {
+          warn!(
+            "continuation for {previous_track_id}: paused with no current item; nothing to resume"
+          );
         }
+      } else {
+        info!("continuation for {previous_track_id}: the API already reports playback running");
       }
+    } else {
+      warn!(
+        "continuation for {previous_track_id}: no playback context from the API; nothing to resume"
+      );
     }
   }
 

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -9,7 +9,7 @@ use crate::infra::player::{
   get_default_cache_path, PlayerEvent, SessionDisconnectReason, StreamingConfig,
   StreamingConnectionState, StreamingPlayer,
 };
-use log::info;
+use log::{info, warn};
 use std::sync::{
   atomic::{AtomicBool, AtomicU64, Ordering},
   Arc,
@@ -98,6 +98,28 @@ pub fn spawn_streaming_recovery_handler(ctx: StreamingRecoveryContext) {
   });
 }
 
+/// Compact recovery-snapshot summary for the log: enough to tell which restore
+/// branch should have run and with what track/position, without dumping a whole
+/// context's URI list.
+fn recovery_snapshot_summary(app: &App) -> String {
+  match app.native_playback_recovery.as_ref() {
+    None => "snapshot=none".to_string(),
+    Some(s) => format!(
+      "snapshot gen={} current={:?} loading={:?} pos={} dur={:?} playing={} ctx={:?} uris={} offset={:?} attempts={}",
+      s.generation,
+      s.current_track_uri,
+      s.loading_track_uri,
+      s.position_ms,
+      s.track_duration_ms,
+      s.desired_playing,
+      s.context_uri,
+      s.uris.as_ref().map_or(0, |uris| uris.len()),
+      s.offset,
+      s.recovery_attempts,
+    ),
+  }
+}
+
 /// Intent ORs across coalesced transport-drop requests, but a handoff
 /// (`restore_playback == false`) stickily vetoes restore/reselect: restoring
 /// over the user's handoff would steal playback back (#437).
@@ -125,20 +147,36 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
       // pending window is over, so replay anything parked against it.
       let mut app = ctx.app.lock().await;
       app.native_backend_pending = false;
+      info!(
+        "recovery over a live player: reselect={} continue_after={:?} {}",
+        request.reselect_device,
+        request.continue_after_track,
+        recovery_snapshot_summary(&app)
+      );
       if app.pending_start_playback.is_some() {
+        info!("recovery route: replay parked StartPlayback");
         app.replay_pending_start_playback();
       } else if let Some(previous_track_id) = request.continue_after_track {
         if app.native_transition_has_advanced(&previous_track_id) {
           if let Some(generation) = app.native_playback_restore_generation() {
+            info!("recovery route: RestoreNativePlayback({generation}) (transition advanced)");
             app.dispatch(IoEvent::RestoreNativePlayback(generation));
+          } else {
+            warn!("recovery route: none - transition advanced but the snapshot is gone");
           }
         } else {
+          info!("recovery route: EnsurePlaybackContinues({previous_track_id})");
           app.dispatch(IoEvent::EnsurePlaybackContinues(previous_track_id));
         }
       } else if request.reselect_device {
         if let Some(generation) = app.native_playback_restore_generation() {
+          info!("recovery route: RestoreNativePlayback({generation}) (reselect)");
           app.dispatch(IoEvent::RestoreNativePlayback(generation));
+        } else {
+          warn!("recovery route: none - reselect requested but the snapshot is gone");
         }
+      } else {
+        info!("recovery route: none - no restore intent on the request");
       }
       continue;
     }
@@ -200,6 +238,14 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
         // replay event if another device became active during the rebuild.
         let replay_queue_slot = app.pending_start_playback.is_none()
           && should_replay_published_queue_slot(&request, app.queue_now_is_spotify());
+        info!(
+          "recovery rebuilt the backend: restore={} reselect={} continue_after={:?} replay_queue_slot={} {}",
+          request.restore_playback,
+          request.reselect_device,
+          request.continue_after_track,
+          replay_queue_slot,
+          recovery_snapshot_summary(&app)
+        );
         if recovery_needs_native_selection(&request, replay_queue_slot) {
           app.dispatch(IoEvent::AutoSelectStreamingDevice(
             ctx.client_config.streaming_device_name.clone(),
@@ -210,25 +256,33 @@ async fn handle_streaming_recovery(mut ctx: StreamingRecoveryContext) {
         // A new explicit playback request wins over restoring older intent.
         // Both paths are queued after device selection on the serial IoEvent pump.
         if app.pending_start_playback.is_some() {
+          info!("recovery route: replay parked StartPlayback");
           app.replay_pending_start_playback();
         } else if replay_queue_slot {
           // The published queue slot outranks snapshot restore: its direct
           // load was discarded with the replaced player, and for a queue
           // playing over an idle app there is no snapshot whose TrackChanged
           // would trigger the reload guard.
+          info!("recovery route: ReplayPublishedSpotifyQueueSlot");
           app.dispatch(IoEvent::ReplayPublishedSpotifyQueueSlot);
         } else if let Some(previous_track_id) = request.continue_after_track {
           if app.native_transition_has_advanced(&previous_track_id) {
             if let Some(generation) = app.native_playback_restore_generation() {
+              info!("recovery route: RestoreNativePlayback({generation}) (transition advanced)");
               app.dispatch(IoEvent::RestoreNativePlayback(generation));
+            } else {
+              warn!("recovery route: none - transition advanced but the snapshot is gone");
             }
           } else {
+            info!("recovery route: EnsurePlaybackContinues({previous_track_id})");
             app.dispatch(IoEvent::EnsurePlaybackContinues(previous_track_id));
           }
         } else if request.reselect_device {
           if let Some(generation) = app.native_playback_restore_generation() {
+            info!("recovery route: RestoreNativePlayback({generation}) (reselect)");
             app.dispatch(IoEvent::RestoreNativePlayback(generation));
           } else {
+            warn!("recovery route: none - reselect requested but the snapshot is gone");
             app.set_status_message("Native streaming recovered.", 6);
           }
         } else if request.restore_playback {
@@ -1219,6 +1273,11 @@ fn spawn_end_of_track_continuation(
       .await
       .unwrap_or(false)
     {
+      warn!(
+        "end-of-track continuation for {} abandoned: no stable connection within {}s",
+        previous_track_id,
+        END_OF_TRACK_RECONNECT_TIMEOUT.as_secs()
+      );
       return;
     }
 

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -9,4 +9,4 @@ app_field_writes_in_tui_handlers = 785 # target 0
 ioevent_refs_in_tui = 130              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
-test_attribute_total = 1404           # floor: may only rise
+test_attribute_total = 1406           # floor: may only rise


### PR DESCRIPTION
# Summary

A queued Spotify track's end silenced the next queue slot, and the polled "device idle" answer drew a paused playbar over audible queued playback. Two halves:

- **spotatui-librespot 0.8.3** (all seven crates bumped in lockstep). `Player::load` now returns the play request id it assigned, and Spirc records the ids of the loads it issues instead of adopting every `PlayRequestIdChanged` event. Before this, Spirc treated the queue's direct `player.load` as its own context: at that track's end it ran `handle_next`, found no next track in a context it never loaded, and stopped the player under the slot the queue had just started.
- **`mark_native_streaming_device_available` keeps `native_is_playing` while the queue slot plays a Spotify track.** The idle poll cannot see a direct load, so clearing the flag there re-drew a paused playbar on every poll after the user pressed play. Two unit tests cover both sides.
- The recovery handler logs which restore route it takes (live player and rebuilt backend) with a compact snapshot summary, for the next native-playback investigation.

# Testing

- Smoke-tested the full build: queued track ends, the next slot plays with no silence, the playbar stays "playing" across polls.
- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`
- `cargo test --no-default-features --features telemetry,tui` (629 passed)
- `cargo test` (929 passed)
- `cargo check --locked`
- `tools/check_gates_ratchet.sh main` (test floor 1404 -> 1406)

# Additional notes

`Cargo.lock` moves exactly the seven `spotatui-librespot-*` entries (0.8.2 -> 0.8.3). The fork change is fork-only; see `SPOTATUI_FORK.md` in the fork repo for the carried patch list.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback state handling for tracks started through direct playback, preventing active tracks from being incorrectly marked idle.
  * Enhanced recovery and continuation behavior after reconnects, including replaying queued tracks when needed.
  * Updated playback components to better handle paused, missing, or interrupted track states.

* **Diagnostics**
  * Added clearer playback and recovery logging to support troubleshooting of restoration and continuation issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->