### PR TITLE
refactor(tui): route global keys through App::apply

### DIFF
--- a/src/core/action/apply.rs
+++ b/src/core/action/apply.rs
@@ -26,10 +26,16 @@ impl App {
           self.toggle_playback();
         }
       }
+      Action::TogglePlayback => self.toggle_playback(),
       Action::NextTrack => self.next_track(),
       Action::PreviousTrack => self.previous_track(),
+      Action::ForcePreviousTrack => self.force_previous_track(),
       Action::SeekTo(ms) => self.seek_to(ms),
+      Action::SeekForward => self.seek_forwards(),
+      Action::SeekBackward => self.seek_backwards(),
       Action::SetVolume(v) => self.set_volume_percent(v),
+      Action::VolumeUp => self.increase_volume(),
+      Action::VolumeDown => self.decrease_volume(),
       Action::SetShuffle(desired) => {
         let current = plugin_api::playback_state(self)
           .map(|p| p.shuffle)
@@ -38,6 +44,7 @@ impl App {
           self.shuffle();
         }
       }
+      Action::ToggleShuffle => self.shuffle(),
       Action::CycleRepeat => self.repeat(),
       Action::SetRepeat(setting) => {
         use rspotify::model::RepeatState;
@@ -106,6 +113,10 @@ impl App {
       Action::Back => {
         self.pop_navigation_stack();
       }
+      Action::JumpToAlbum => self.jump_to_album(),
+      Action::JumpToArtist => self.jump_to_artist_album(),
+      Action::JumpToContext => self.jump_to_context(),
+      Action::GenerateRecap => self.generate_recap(),
       Action::SetPlaybarSegment { plugin, text } => match text {
         Some(t) => {
           self.plugin_playbar_segments.insert(plugin, t);
@@ -115,6 +126,7 @@ impl App {
         }
       },
       Action::ShowPopup(popup) => self.show_plugin_popup(popup),
+      Action::ClosePopup => self.close_plugin_popup(),
       Action::SetTheme(pairs) => {
         for (field, color) in pairs {
           self.user_config.theme.set(field, color);
@@ -179,6 +191,8 @@ fn apply_navigate(app: &mut App, target: NavTarget) {
     }
     NavTarget::Settings => app.open_settings_screen(),
     NavTarget::Devices => app.open_source_device_picker(),
+    // The help KEY also clears the help filter first (`help_menu::open`); that
+    // reset needs the TUI's filtered-docs count, so it cannot live here.
     NavTarget::Help => app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu),
     NavTarget::Lyrics => app.push_navigation_stack(RouteId::LyricsView, ActiveBlock::LyricsView),
     // The network handler pushes the route once the data arrives, exactly like

--- a/src/core/action/mod.rs
+++ b/src/core/action/mod.rs
@@ -49,14 +49,32 @@ pub enum Action {
   Play,
   /// Pause playback if it is playing (intent, not a toggle).
   Pause,
+  /// Toggle play/pause, matching the toggle-playback key (and MPRIS
+  /// PlayPause) exactly.
+  TogglePlayback,
   NextTrack,
   PreviousTrack,
+  /// Always go to the previous track (or restart the current queue slot),
+  /// skipping the ">= 3s restarts the current track" rule of
+  /// [`Action::PreviousTrack`].
+  ForcePreviousTrack,
   /// Seek to an absolute position in the current track, in milliseconds.
   SeekTo(u32),
+  /// Seek forwards by the user's configured seek step.
+  SeekForward,
+  /// Seek backwards by the user's configured seek step.
+  SeekBackward,
   /// Set the volume to an absolute percentage (0-100).
   SetVolume(u8),
+  /// Raise the volume by the user's configured increment.
+  VolumeUp,
+  /// Lower the volume by the user's configured increment.
+  VolumeDown,
   /// Ensure shuffle matches the given state (intent, not a toggle).
   SetShuffle(bool),
+  /// Toggle shuffle, matching the shuffle key exactly (source-gated: decoded
+  /// queues reorder in place, radio and the native queue slot no-op).
+  ToggleShuffle,
   /// Cycle repeat off, then context, then track, matching the repeat key.
   CycleRepeat,
   /// Set repeat to an absolute mode. Mirrors the historic Lua `set_repeat`:
@@ -120,6 +138,19 @@ pub enum Action {
   Navigate(NavTarget),
   /// Pop the navigation stack (same as the back key).
   Back,
+  /// Open the album page of the item that is playing now; resolved from the
+  /// current playback context at apply time (episodes open their show).
+  JumpToAlbum,
+  /// Open the album list of the first artist of the track that is playing
+  /// now; resolved from the current playback context at apply time.
+  JumpToArtist,
+  /// Open the context (album/artist/playlist) that playback runs in;
+  /// resolved from the current playback context at apply time.
+  JumpToContext,
+  /// Generate a listening recap. The period is resolved at apply time: the
+  /// selected period on the Stats screen when that screen is current, 30
+  /// days anywhere else.
+  GenerateRecap,
   /// Set or clear a playbar segment for a plugin (keyed by plugin name).
   SetPlaybarSegment {
     plugin: String,
@@ -127,6 +158,8 @@ pub enum Action {
   },
   /// Show a plugin popup dialog.
   ShowPopup(PluginPopup),
+  /// Dismiss the plugin popup, if one is shown.
+  ClosePopup,
   /// Apply theme color overrides at runtime.
   SetTheme(Vec<(ThemeField, Color)>),
   /// Publish (retained) content for a registered plugin screen.

--- a/src/core/action/tests.rs
+++ b/src/core/action/tests.rs
@@ -56,13 +56,18 @@ fn playback_context(
 #[allow(deprecated)]
 fn playback_context_with_track(is_playing: bool) -> rspotify::model::CurrentPlaybackContext {
   use crate::core::test_helpers::full_track;
+  use rspotify::model::idtypes::ArtistId;
   use rspotify::model::PlayableItem;
   let mut ctx = playback_context(is_playing, false);
   ctx.progress = Some(chrono::Duration::milliseconds(0));
-  ctx.item = Some(PlayableItem::Track(full_track(
-    "4uLU6hMCjMI75M1A2tKUQC",
-    "Test Song",
-  )));
+  let mut track = full_track("4uLU6hMCjMI75M1A2tKUQC", "Test Song");
+  // `full_track` leaves the artist id unset; the jump-to-artist arm needs one.
+  track.artists[0].id = Some(
+    ArtistId::from_id("0OdUWJ0sBjDrqHygGUXeCF")
+      .unwrap()
+      .into_static(),
+  );
+  ctx.item = Some(PlayableItem::Track(track));
   ctx.currently_playing_type = rspotify::model::CurrentlyPlayingType::Track;
   ctx
 }
@@ -186,6 +191,165 @@ fn set_repeat_dispatches_the_absolute_repeat_state() {
     match rx.try_recv() {
       Ok(IoEvent::Repeat(state)) => assert_eq!(state, expected),
       _other => panic!("expected Repeat (IoEvent is not Debug)"),
+    }
+  }
+}
+
+#[test]
+fn toggle_playback_pauses_when_playing_and_starts_when_paused() {
+  let (mut app, rx) = app_with_channel();
+  app.current_playback_context = Some(playback_context(true, false));
+
+  app.apply(Action::TogglePlayback);
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::PausePlayback)));
+
+  app.current_playback_context = Some(playback_context(false, false));
+  app.apply(Action::TogglePlayback);
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::StartPlayback(None, None, None))
+  ));
+}
+
+#[test]
+fn force_previous_track_dispatches_the_force_event() {
+  let (mut app, rx) = app_with_channel();
+  app.song_progress_ms = 20_000;
+
+  app.apply(Action::ForcePreviousTrack);
+
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::ForcePreviousTrack)));
+  assert_eq!(app.song_progress_ms, 0, "a forced previous restarts at 0");
+}
+
+#[test]
+fn seek_actions_move_by_the_configured_step() {
+  // Start one step in, so forward lands at `2 * step + 1_000` and backward
+  // lands at `1_000`.
+  for (action, forward) in [(Action::SeekForward, true), (Action::SeekBackward, false)] {
+    let (mut app, _rx) = app_with_channel();
+    app.current_playback_context = Some(playback_context_with_track(true));
+    let step = app.user_config.behavior.seek_milliseconds as u128;
+    app.song_progress_ms = step + 1_000;
+
+    app.apply(action);
+
+    let expected = if forward { 2 * step + 1_000 } else { 1_000 };
+    assert_eq!(app.song_progress_ms, expected);
+  }
+}
+
+#[test]
+fn volume_actions_dispatch_the_stepped_volume() {
+  for (action, up) in [(Action::VolumeUp, true), (Action::VolumeDown, false)] {
+    let (mut app, rx) = app_with_channel();
+    app.current_playback_context = Some(playback_context(true, false));
+
+    app.apply(action);
+
+    let increment = app.user_config.behavior.volume_increment;
+    let expected = if up { 50 + increment } else { 50 - increment };
+    match rx.try_recv() {
+      Ok(IoEvent::ChangeVolume(v)) => assert_eq!(v, expected),
+      _other => panic!("expected ChangeVolume (IoEvent is not Debug)"),
+    }
+  }
+}
+
+#[test]
+fn toggle_shuffle_flips_the_spotify_shuffle_state() {
+  let (mut app, rx) = app_with_channel();
+  app.current_playback_context = Some(playback_context(true, false));
+
+  app.apply(Action::ToggleShuffle);
+
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::Shuffle(true))));
+}
+
+// --- jump-to navigation ---
+
+#[test]
+fn jump_to_album_opens_the_current_tracks_album() {
+  let (mut app, rx) = app_with_channel();
+  app.current_playback_context = Some(playback_context_with_track(false));
+
+  app.apply(Action::JumpToAlbum);
+
+  match rx.try_recv() {
+    Ok(IoEvent::GetAlbumTracks(album)) => assert_eq!(album.name, "Test Album"),
+    _other => panic!("expected GetAlbumTracks (IoEvent is not Debug)"),
+  }
+}
+
+#[test]
+fn jump_to_album_without_playback_is_a_noop() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::JumpToAlbum);
+
+  assert!(rx.try_recv().is_err(), "expected no IoEvent dispatched");
+}
+
+#[test]
+fn jump_to_artist_opens_the_first_artists_albums() {
+  let (mut app, rx) = app_with_channel();
+  app.current_playback_context = Some(playback_context_with_track(false));
+
+  app.apply(Action::JumpToArtist);
+
+  match rx.try_recv() {
+    Ok(IoEvent::GetArtist(id, name, _country)) => {
+      assert_eq!(id, "0OdUWJ0sBjDrqHygGUXeCF");
+      assert_eq!(name, "Test Artist");
+    }
+    _other => panic!("expected GetArtist (IoEvent is not Debug)"),
+  }
+}
+
+#[test]
+fn jump_to_context_opens_the_playlist_context() {
+  use rspotify::model::{context::Context, enums::Type};
+  let (mut app, rx) = app_with_channel();
+  let mut ctx = playback_context_with_track(true);
+  ctx.context = Some(Context {
+    uri: "spotify:playlist:37i9dQZF1DX4WYpdgoIcn6".to_string(),
+    href: String::new(),
+    external_urls: std::collections::HashMap::new(),
+    _type: Type::Playlist,
+  });
+  app.current_playback_context = Some(ctx);
+
+  app.apply(Action::JumpToContext);
+
+  assert_eq!(app.get_current_route().id, RouteId::TrackTable);
+  match rx.try_recv() {
+    Ok(IoEvent::GetPlaylistItems(id, _offset)) => {
+      assert_eq!(id, "37i9dQZF1DX4WYpdgoIcn6");
+    }
+    _other => panic!("expected GetPlaylistItems (IoEvent is not Debug)"),
+  }
+}
+
+// --- recap ---
+
+#[test]
+fn generate_recap_resolves_the_period_from_the_current_route() {
+  use crate::core::app::ActiveBlock;
+  use crate::infra::history::RecapPeriod;
+  // The stats selection is set in both cases, so the off-Stats case proves
+  // the selection is ignored anywhere else.
+  for (on_stats_screen, expected) in [(false, RecapPeriod::ThirtyDays), (true, RecapPeriod::Year)] {
+    let (mut app, rx) = app_with_channel();
+    app.stats_period = RecapPeriod::Year;
+    if on_stats_screen {
+      app.push_navigation_stack(RouteId::Stats, ActiveBlock::Stats);
+    }
+
+    app.apply(Action::GenerateRecap);
+
+    match rx.try_recv() {
+      Ok(IoEvent::GenerateRecap(period)) => assert_eq!(period, expected),
+      _other => panic!("expected GenerateRecap (IoEvent is not Debug)"),
     }
   }
 }
@@ -608,6 +772,21 @@ fn show_popup_sets_the_popup() {
     app.plugin_popup.as_ref().map(|p| p.title.as_str()),
     Some("Hi")
   );
+}
+
+#[test]
+fn close_popup_clears_the_popup() {
+  // The paired scroll reset is pinned by `core/app/plugins.rs` tests, which
+  // can seed the scroll field first.
+  let (mut app, _rx) = app_with_channel();
+  app.show_plugin_popup(crate::core::plugin_api::PluginPopup {
+    title: "Hi".to_string(),
+    lines: Vec::new(),
+  });
+
+  app.apply(Action::ClosePopup);
+
+  assert!(app.plugin_popup.is_none());
 }
 
 /// Reverse accessor for the loop test below, exhaustive over `ThemeField`

--- a/src/core/app/plugins.rs
+++ b/src/core/app/plugins.rs
@@ -59,6 +59,12 @@ impl App {
     self.view.plugin_popup_scroll = 0;
   }
 
+  /// Dismiss the plugin popup and reset its scroll.
+  pub(crate) fn close_plugin_popup(&mut self) {
+    self.plugin_popup = None;
+    self.view.plugin_popup_scroll = 0;
+  }
+
   /// Navigate to a registered plugin screen, resetting its scroll. A no-op
   /// push when the screen is already the current route (the scroll still
   /// resets, matching the historic behavior).
@@ -94,6 +100,22 @@ mod tests {
       app.plugin_popup.as_ref().map(|p| p.title.as_str()),
       Some("Hi")
     );
+    assert_eq!(app.view.plugin_popup_scroll, 0);
+  }
+
+  #[test]
+  fn close_plugin_popup_clears_the_popup_and_resets_the_scroll() {
+    let (tx, _rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    app.show_plugin_popup(crate::core::plugin_api::PluginPopup {
+      title: "Hi".to_string(),
+      lines: Vec::new(),
+    });
+    app.view.plugin_popup_scroll = 5;
+
+    app.close_plugin_popup();
+
+    assert!(app.plugin_popup.is_none());
     assert_eq!(app.view.plugin_popup_scroll, 0);
   }
 

--- a/src/core/app/route.rs
+++ b/src/core/app/route.rs
@@ -261,12 +261,13 @@ impl App {
 
   /// Remove every frame still serving as the error screen.
   ///
-  /// Matched on the id AND the block, not on the id alone. The search key
-  /// rewrites the error frame in place to `{ id: Error, active_block: Input }`
-  /// (it does not push), so an id-only match would delete a frame that is
-  /// holding live text-input focus and drop the user's next keystrokes into
-  /// the global bindings. Such a frame no longer draws the error screen, so
-  /// leaving it is harmless.
+  /// Matched on the id AND the block, not on the id alone. A mouse click on
+  /// the search input rewrites the error frame in place to `{ id: Error,
+  /// active_block: Input }` (it does not push; the search key instead
+  /// dismisses the error first), so an id-only match would delete a frame
+  /// that is holding live text-input focus and drop the user's next
+  /// keystrokes into the global bindings. Such a frame no longer draws the
+  /// error screen, so leaving it is harmless.
   ///
   /// Both `push_navigation_stack` and the frames below the top are covered:
   /// pushes dedupe only against the top frame, so navigating away and failing
@@ -313,5 +314,88 @@ impl App {
       self.push_navigation_stack(RouteId::Analysis, ActiveBlock::Analysis);
     }
     // Spectrum data will be updated by the audio capture system on each tick
+  }
+
+  /// Open the album page of the item that is playing now (episodes open
+  /// their show). A no-op without a playback context.
+  pub(crate) fn jump_to_album(&mut self) {
+    // Build the event under the borrow so only the payload is cloned, never
+    // the whole playback context.
+    let event = match self
+      .current_playback_context
+      .as_ref()
+      .and_then(|playback| playback.item.as_ref())
+    {
+      Some(PlayableItem::Track(track)) => {
+        Some(IoEvent::GetAlbumTracks(Box::new(track.album.clone())))
+      }
+      Some(PlayableItem::Episode(episode)) => Some(IoEvent::GetShowEpisodes(Box::new(
+        crate::core::plugin_api::ShowInfo::from(&episode.show),
+      ))),
+      _ => None,
+    };
+    if let Some(event) = event {
+      self.dispatch(event);
+    }
+  }
+
+  // NOTE: this only finds the first artist of the song and jumps to their albums
+  pub(crate) fn jump_to_artist_album(&mut self) {
+    let artist = match self
+      .current_playback_context
+      .as_ref()
+      .and_then(|playback| playback.item.as_ref())
+    {
+      Some(PlayableItem::Track(track)) => track.artists.first().and_then(|artist| {
+        artist
+          .id
+          .as_ref()
+          .map(|id| (id.id().to_string(), artist.name.clone()))
+      }),
+      // Episodes have no artist page to jump to (yet!)
+      _ => None,
+    };
+    if let Some((artist_id, artist_name)) = artist {
+      self.get_artist(artist_id, artist_name);
+    }
+  }
+
+  /// Open the context (album/artist/playlist) that playback runs in. A no-op
+  /// without a playback context.
+  pub(crate) fn jump_to_context(&mut self) {
+    let Some((context_type, playlist)) = self
+      .current_playback_context
+      .as_ref()
+      .and_then(|playback| playback.context.as_ref())
+      .map(|context| {
+        (
+          context._type.clone(),
+          crate::infra::network::ids::playlist_id(&context.uri),
+        )
+      })
+    else {
+      return;
+    };
+    match context_type {
+      rspotify::model::enums::Type::Album => self.jump_to_album(),
+      rspotify::model::enums::Type::Artist => self.jump_to_artist_album(),
+      rspotify::model::enums::Type::Playlist => {
+        if let Some(playlist_id) = playlist {
+          self.open_playlist_tracks(playlist_id, TrackTableContext::MyPlaylists);
+        }
+      }
+      _ => {}
+    }
+  }
+
+  /// Generate a listening recap: the selected period on the Stats screen
+  /// when that screen is current, 30 days anywhere else.
+  pub(crate) fn generate_recap(&mut self) {
+    let period = if self.get_current_route().active_block == ActiveBlock::Stats {
+      self.stats_period
+    } else {
+      RecapPeriod::ThirtyDays
+    };
+    self.dispatch(IoEvent::GenerateRecap(period));
   }
 }

--- a/src/core/app/status.rs
+++ b/src/core/app/status.rs
@@ -256,9 +256,10 @@ mod tests {
     assert_eq!(app.get_current_route().id, RouteId::Home);
   }
 
-  // The search key rewrites the error frame in place instead of pushing, so
-  // the frame can be holding text-input focus. Deleting it there would drop
-  // the user's next keystrokes into the global bindings.
+  // A mouse click on the search input rewrites the error frame in place
+  // instead of pushing, so the frame can be holding text-input focus.
+  // Deleting it there would drop the user's next keystrokes into the global
+  // bindings.
   #[test]
   fn clearing_an_error_leaves_a_frame_repurposed_as_a_search_input_alone() {
     let mut app = make_app_simple();

--- a/src/infra/audio/pipewire_capture.rs
+++ b/src/infra/audio/pipewire_capture.rs
@@ -158,6 +158,9 @@ fn run_pipewire_capture(
 
         // Decode the interleaved f32 stream; the analyzer owns the channel
         // rule (0/1 through, mono duplicated) so it is stated in one place.
+        // The `as_chunks` rewrite clippy 1.98 suggests must be verified on a
+        // Linux build (this module never compiles elsewhere), so it waits.
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let samples: Vec<f32> = valid_bytes
           .chunks_exact(mem::size_of::<f32>())
           .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap_or([0; 4])))

--- a/src/infra/scripting/engine.rs
+++ b/src/infra/scripting/engine.rs
@@ -345,7 +345,7 @@ impl ScriptEngine {
     if app.pending_plugin_screen_keys.is_empty() {
       return;
     }
-    let keys: Vec<(String, String)> = app.pending_plugin_screen_keys.drain(..).collect();
+    let keys: Vec<(String, String)> = std::mem::take(&mut app.pending_plugin_screen_keys);
     for (screen, key) in keys {
       self.call_screen_callback(&screen, "on_key", Some(key));
     }
@@ -495,7 +495,7 @@ impl ScriptEngine {
       return;
     }
     self.refresh_caches(app);
-    let names: Vec<String> = app.pending_plugin_commands.drain(..).collect();
+    let names: Vec<String> = std::mem::take(&mut app.pending_plugin_commands);
     let commands: mlua::Table = match self.lua.named_registry_value(COMMANDS_KEY) {
       Ok(t) => t,
       Err(_) => {

--- a/src/tui/handlers/help_menu.rs
+++ b/src/tui/handlers/help_menu.rs
@@ -1,7 +1,8 @@
 use super::common_key_events;
 use super::filter_input::{self, FilterEdit};
 use crate::{
-  core::app::{ActiveBlock, App, RouteId},
+  core::action::{Action, NavTarget},
+  core::app::App,
   tui::{event::Key, ui::help::get_filtered_help_docs},
 };
 
@@ -13,7 +14,7 @@ enum Direction {
 
 pub(super) fn open(app: &mut App) {
   clear_filter(app);
-  app.push_navigation_stack(RouteId::HelpMenu, ActiveBlock::HelpMenu);
+  app.apply(Action::Navigate(NavTarget::Help));
 }
 
 pub(super) fn clear_filter(app: &mut App) {
@@ -94,6 +95,7 @@ fn move_page(direction: Direction, app: &mut App) {
 mod tests {
   use super::*;
   use crate::{
+    core::app::{ActiveBlock, RouteId},
     core::source::Source,
     tui::{handlers::handle_app, ui::help::get_help_docs},
   };

--- a/src/tui/handlers/mod.rs
+++ b/src/tui/handlers/mod.rs
@@ -42,12 +42,10 @@ mod sort_menu;
 mod stats;
 mod track_table;
 
+use crate::core::action::{Action, NavTarget};
 use crate::core::app::{ActiveBlock, App, ArtistBlock, InputContext, RouteId, SearchResultBlock};
 use crate::core::source::Source;
-use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
-use rspotify::model::{context::CurrentPlaybackContext, PlayableItem};
-use rspotify::prelude::Id;
 
 pub use input::handler as input_handler;
 pub use mouse::handler as mouse_handler;
@@ -101,8 +99,7 @@ pub fn handle_app(key: Key, app: &mut App) {
   if app.plugin_popup.is_some() {
     match key {
       Key::Esc | Key::Char('q') => {
-        app.plugin_popup = None;
-        app.view.plugin_popup_scroll = 0;
+        app.apply(Action::ClosePopup);
       }
       k if common_key_events::up_event(k, &app.user_config.keys) => {
         app.view.plugin_popup_scroll = app.view.plugin_popup_scroll.saturating_sub(1);
@@ -204,13 +201,13 @@ pub fn handle_app(key: Key, app: &mut App) {
       }
     }
     _ if key == app.user_config.keys.jump_to_album => {
-      handle_jump_to_album(app);
+      app.apply(Action::JumpToAlbum);
     }
     _ if key == app.user_config.keys.jump_to_artist_album => {
-      handle_jump_to_artist_album(app);
+      app.apply(Action::JumpToArtist);
     }
     _ if key == app.user_config.keys.jump_to_context => {
-      handle_jump_to_context(app);
+      app.apply(Action::JumpToContext);
     }
     // Reachable from anywhere, including sources whose sidebar has no Library
     // panel (only Spotify draws one), which is why a global binding exists at all
@@ -236,46 +233,45 @@ pub fn handle_app(key: Key, app: &mut App) {
       ai_dj::open_picker(app);
     }
     _ if key == app.user_config.keys.manage_devices => {
-      app.open_source_device_picker();
+      app.apply(Action::Navigate(NavTarget::Devices));
     }
     _ if key == app.user_config.keys.decrease_volume => {
-      app.decrease_volume();
+      app.apply(Action::VolumeDown);
     }
     _ if key == app.user_config.keys.increase_volume => {
-      app.increase_volume();
+      app.apply(Action::VolumeUp);
     }
     // Press space to toggle playback
     _ if key == app.user_config.keys.toggle_playback => {
-      app.toggle_playback();
+      app.apply(Action::TogglePlayback);
     }
     _ if key == app.user_config.keys.seek_backwards => {
-      app.seek_backwards();
+      app.apply(Action::SeekBackward);
     }
     _ if key == app.user_config.keys.seek_forwards => {
-      app.seek_forwards();
+      app.apply(Action::SeekForward);
     }
     _ if key == app.user_config.keys.next_track => {
-      app.next_track();
+      app.apply(Action::NextTrack);
     }
     _ if key == app.user_config.keys.previous_track => {
-      app.previous_track();
+      app.apply(Action::PreviousTrack);
     }
     _ if key == app.user_config.keys.force_previous_track => {
-      app.force_previous_track();
+      app.apply(Action::ForcePreviousTrack);
     }
     _ if key == app.user_config.keys.help => {
       help_menu::open(app);
     }
     _ if key == app.user_config.keys.show_queue => {
-      app.dispatch(IoEvent::GetQueue);
-      app.push_navigation_stack(RouteId::Queue, ActiveBlock::Queue);
+      app.apply(Action::Navigate(NavTarget::Queue));
     }
 
     _ if key == app.user_config.keys.shuffle => {
-      app.shuffle();
+      app.apply(Action::ToggleShuffle);
     }
     _ if key == app.user_config.keys.repeat => {
-      app.repeat();
+      app.apply(Action::CycleRepeat);
     }
     Key::Ctrl('f')
       if app.get_current_route().active_block == ActiveBlock::TrackTable
@@ -291,6 +287,13 @@ pub fn handle_app(key: Key, app: &mut App) {
       // Search is gated on the active source's capability (no `Searcher` impl
       // for Local Files), so it's a no-op with a hint there.
       if app.active_source.supports_search() {
+        // Never rewrite the error frame in place to `{Error, Input}`: push
+        // dedupes on the top frame's id, so a surviving Error frame makes
+        // every later error silently fail to render. Dismiss the error and
+        // open search on the screen below.
+        if app.get_current_route().id == RouteId::Error {
+          app.clear_api_error();
+        }
         app.view.input_context = InputContext::GlobalSearch;
         app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
       } else {
@@ -314,16 +317,16 @@ pub fn handle_app(key: Key, app: &mut App) {
       app.copy_album_url();
     }
     _ if key == app.user_config.keys.audio_analysis => {
-      app.get_audio_analysis();
+      app.apply(Action::Navigate(NavTarget::Analysis));
     }
     _ if key == app.user_config.keys.lyrics_view => {
-      app.push_navigation_stack(RouteId::LyricsView, ActiveBlock::LyricsView);
+      app.apply(Action::Navigate(NavTarget::Lyrics));
     }
     _ if key == app.user_config.keys.miniplayer_view => {
       if is_input_mode(app) {
         handle_block_events(key, app);
       } else {
-        toggle_miniplayer(app);
+        app.apply(Action::Navigate(NavTarget::MiniPlayer));
       }
     }
     #[cfg(feature = "cover-art")]
@@ -331,7 +334,7 @@ pub fn handle_app(key: Key, app: &mut App) {
       app.push_navigation_stack(RouteId::CoverArtView, ActiveBlock::CoverArtView);
     }
     _ if key == app.user_config.keys.listening_party => {
-      app.push_navigation_stack(RouteId::Party, ActiveBlock::Party);
+      app.apply(Action::Navigate(NavTarget::Party));
     }
     _ if key == app.user_config.keys.like_track => {
       if is_input_mode(app) {
@@ -363,8 +366,7 @@ pub fn handle_app(key: Key, app: &mut App) {
       if is_input_mode(app) {
         handle_block_events(key, app);
       } else {
-        let period = recap_period_for_current_route(app);
-        app.dispatch(IoEvent::GenerateRecap(period));
+        app.apply(Action::GenerateRecap);
       }
     }
     // Resize sidebar: { decreases, } increases width
@@ -653,91 +655,13 @@ fn handle_escape(app: &mut App) {
   }
 }
 
-fn toggle_miniplayer(app: &mut App) {
-  if app.get_current_route().id == RouteId::MiniPlayer {
-    app.pop_navigation_stack();
-  } else {
-    app.push_navigation_stack(RouteId::MiniPlayer, ActiveBlock::MiniPlayer);
-  }
-}
-
-fn handle_jump_to_context(app: &mut App) {
-  if let Some(current_playback_context) = &app.current_playback_context {
-    if let Some(play_context) = current_playback_context.context.clone() {
-      match play_context._type {
-        rspotify::model::enums::Type::Album => handle_jump_to_album(app),
-        rspotify::model::enums::Type::Artist => handle_jump_to_artist_album(app),
-        rspotify::model::enums::Type::Playlist => {
-          if let Some(playlist_id) = crate::infra::network::ids::playlist_id(&play_context.uri) {
-            app.open_playlist_tracks(
-              playlist_id,
-              crate::core::app::TrackTableContext::MyPlaylists,
-            );
-          }
-        }
-        _ => {}
-      }
-    }
-  }
-}
-
-fn handle_jump_to_album(app: &mut App) {
-  if let Some(CurrentPlaybackContext {
-    item: Some(item), ..
-  }) = app.current_playback_context.to_owned()
-  {
-    match item {
-      PlayableItem::Track(track) => {
-        app.dispatch(IoEvent::GetAlbumTracks(Box::new(track.album)));
-      }
-      PlayableItem::Episode(episode) => {
-        app.dispatch(IoEvent::GetShowEpisodes(Box::new(
-          crate::core::plugin_api::ShowInfo::from(&episode.show),
-        )));
-      }
-      _ => {}
-    };
-  }
-}
-
-// NOTE: this only finds the first artist of the song and jumps to their albums
-fn handle_jump_to_artist_album(app: &mut App) {
-  if let Some(CurrentPlaybackContext {
-    item: Some(item), ..
-  }) = app.current_playback_context.to_owned()
-  {
-    match item {
-      PlayableItem::Track(track) => {
-        if let Some(artist) = track.artists.first() {
-          if let Some(artist_id) = &artist.id {
-            app.get_artist(artist_id.id().to_string(), artist.name.clone());
-          }
-        }
-      }
-      PlayableItem::Episode(_episode) => {
-        // Do nothing for episode (yet!)
-      }
-      _ => {}
-    }
-  };
-}
-
-/// The recap period the `generate_recap` key should use: the selected period
-/// on the Stats screen, 30 days anywhere else.
-fn recap_period_for_current_route(app: &App) -> crate::infra::history::RecapPeriod {
-  if app.get_current_route().active_block == ActiveBlock::Stats {
-    app.stats_period
-  } else {
-    crate::infra::history::RecapPeriod::ThirtyDays
-  }
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
   use crate::core::app::TrackTableContext;
   use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
+  use crate::infra::network::IoEvent;
   use chrono::Utc;
   use rspotify::model::{
     context::{Actions, CurrentPlaybackContext},
@@ -746,6 +670,7 @@ mod tests {
     idtypes::PlaylistId,
     CurrentlyPlayingType, Device, PlayableItem,
   };
+  use rspotify::prelude::Id;
   use std::{
     sync::mpsc::{channel, TryRecvError},
     time::SystemTime,
@@ -758,19 +683,26 @@ mod tests {
   }
 
   #[test]
-  fn recap_period_follows_stats_screen_selection() {
+  fn search_key_on_the_error_page_dismisses_the_error_first() {
     let mut app = App::default();
-    app.stats_period = crate::infra::history::RecapPeriod::Year;
-    assert_eq!(
-      recap_period_for_current_route(&app),
-      crate::infra::history::RecapPeriod::ThirtyDays
+    app.handle_error(anyhow::anyhow!("boom"));
+    assert_eq!(app.get_current_route().id, RouteId::Error);
+
+    handle_app(app.user_config.keys.search, &mut app);
+
+    let route = app.get_current_route();
+    assert_ne!(route.id, RouteId::Error, "the error frame must not survive");
+    assert_eq!(route.active_block, ActiveBlock::Input);
+    assert!(
+      app.api_error.is_empty(),
+      "the dismissal drops the message with the frame"
     );
 
-    app.push_navigation_stack(RouteId::Stats, ActiveBlock::Stats);
-    assert_eq!(
-      recap_period_for_current_route(&app),
-      crate::infra::history::RecapPeriod::Year
-    );
+    // A later error must still render: the dismissal above is what keeps the
+    // navigation stack free of a deduping `{Error, ...}` frame.
+    handle_app(Key::Esc, &mut app);
+    app.handle_error(anyhow::anyhow!("again"));
+    assert_eq!(app.get_current_route().id, RouteId::Error);
   }
 
   #[test]

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -7,10 +7,10 @@
 # the two adoption counters may only rise.
 
 crate_tui_refs_outside_tui = 2         # target 0
-app_field_writes_in_tui_handlers = 388 # target 0 (writes into app.view do not count)
-ioevent_refs_in_tui = 129              # target 0
+app_field_writes_in_tui_handlers = 386 # target 0 (writes into app.view do not count)
+ioevent_refs_in_tui = 125              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
-action_refs_in_tui_handlers = 0        # adoption: may only rise
-test_attribute_total = 1459            # adoption: may only rise
+action_refs_in_tui_handlers = 22       # adoption: may only rise
+test_attribute_total = 1471            # adoption: may only rise


### PR DESCRIPTION
# Summary

- New frontend-neutral `Action` variants for the global keybindings (`TogglePlayback`, `ForcePreviousTrack`, `SeekForward`/`SeekBackward`, `VolumeUp`/`VolumeDown`, `ToggleShuffle`, `JumpToAlbum`/`JumpToArtist`/`JumpToContext`, `GenerateRecap`, `ClosePopup`). Each arm delegates to the same ownership-aware `App` method the key already called, so behavior is identical by construction.
- The global key handlers (`tui/handlers/mod.rs`, `help_menu::open`) now route through `App::apply`; the navigation keys ride the existing `Navigate` arms. The three jump helpers move from the handler into `core/app`, and the production half of the global handler file no longer references `IoEvent` or rspotify types.
- Fixes the error-page search latch: the search key on the error page used to rewrite the error frame in place into an input frame, and because navigation pushes dedupe on the top frame's id, every later error silently failed to render for the rest of the session. The search key now dismisses the error first and opens search on the screen below. This is the one deliberate behavior change.
- Ratchet: `action_refs_in_tui_handlers` 0 -> 22, `app_field_writes_in_tui_handlers` 388 -> 386, `ioevent_refs_in_tui` 129 -> 125, `test_attribute_total` 1459 -> 1471 (16 new tests, 3 merged pairs).

# Testing

- `cargo fmt --all -- --check` clean
- clippy `-D warnings` clean on slim (`telemetry,tui`), default, and headless (`telemetry`)
- `cargo test` on all six legs (Windows; `audio-viz` swapped for `audio-viz-cpal` in the all-sources set): slim 690 / default 990 / headless 390 / mcp-only 813 / ai-dj-only 953 / all-sources 1430, all green except the known pre-existing Windows-only `infra::local::tests::uri_round_trip`
- `tools/check_gates_ratchet.sh main` ok; `Cargo.lock` untouched
- Manual smoke test of the converted keys on a live session (playback, seek, volume, shuffle/repeat, queue, devices, jumps, popup close, and the error-page search flow)

# Additional notes

- Deliberately not converted here: `handle_escape` (focus/modal state), the like and add-to-playlist keys (they delegate to playbar helpers, a later batch), the copy-URL keys, the DJ keys, the resize keys, and the cover-art view key (a nav target for it would put a feature-gated name into the Lua-advertised navigate list).
- The mouse path that focuses the search input still rewrites the error frame in place, which is why `drop_error_routes` keeps its compound predicate; that site converts with the mouse handler.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added playback controls for play/pause, previous track, seeking, volume, and shuffle.
  * Added shortcuts to open the current album, artist, or playback context.
  * Added listening recap generation with period-aware statistics.
  * Added the ability to close plugin popups and improved popup state handling.

* **Bug Fixes**
  * Searching from an error screen now dismisses the error and allows new errors to display correctly.
  * Improved navigation to preserve text-input focus in relevant screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->