### PR TITLE
refactor(tui): route list handlers through App::apply

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -272,8 +272,9 @@ directly, and TUI handlers adopt it as the conversion sub-PRs land
   identity (URIs, ids, names), never by list ordinal.
 - Every arm delegates to the same ownership-aware `App` method the
   equivalent keybinding uses. Playback starts go through
-  `App::start_playback_uris` / `start_playback_context` - never a
-  hand-built `IoEvent::StartPlayback` in an arm.
+  `App::start_playback_uris` / `start_playback_context` /
+  `start_playback_track_in_context` - never a hand-built
+  `IoEvent::StartPlayback` in an arm.
 - No wildcard match arm anywhere under `src/core/action/`:
   `wildcard_arms_in_action_tree` is pinned at 0 by a raw text scan that
   includes tests, comments, and string literals. Write catch-all test arms

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,8 +274,9 @@ directly, and TUI handlers adopt it as the conversion sub-PRs land
   identity (URIs, ids, names), never by list ordinal.
 - Every arm delegates to the same ownership-aware `App` method the
   equivalent keybinding uses. Playback starts go through
-  `App::start_playback_uris` / `start_playback_context` - never a
-  hand-built `IoEvent::StartPlayback` in an arm.
+  `App::start_playback_uris` / `start_playback_context` /
+  `start_playback_track_in_context` - never a hand-built
+  `IoEvent::StartPlayback` in an arm.
 - No wildcard match arm anywhere under `src/core/action/`:
   `wildcard_arms_in_action_tree` is pinned at 0 by a raw text scan that
   includes tests, comments, and string literals. Write catch-all test arms

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,8 +274,9 @@ directly, and TUI handlers adopt it as the conversion sub-PRs land
   identity (URIs, ids, names), never by list ordinal.
 - Every arm delegates to the same ownership-aware `App` method the
   equivalent keybinding uses. Playback starts go through
-  `App::start_playback_uris` / `start_playback_context` - never a
-  hand-built `IoEvent::StartPlayback` in an arm.
+  `App::start_playback_uris` / `start_playback_context` /
+  `start_playback_track_in_context` - never a hand-built
+  `IoEvent::StartPlayback` in an arm.
 - No wildcard match arm anywhere under `src/core/action/`:
   `wildcard_arms_in_action_tree` is pinned at 0 by a raw text scan that
   includes tests, comments, and string literals. Write catch-all test arms

--- a/src/core/action/apply.rs
+++ b/src/core/action/apply.rs
@@ -57,6 +57,9 @@ impl App {
       }
       Action::PlayUris { uris, offset } => self.start_playback_uris(uris, offset),
       Action::PlayContext { uri, offset } => self.start_playback_context(uri, offset),
+      Action::PlayTrackInContext { context, track } => {
+        self.start_playback_track_in_context(context, track);
+      }
       Action::TransferPlayback { device_id, persist } => {
         self.dispatch(IoEvent::TransferPlaybackToDevice(device_id, persist));
       }
@@ -64,6 +67,28 @@ impl App {
       Action::Search(query) => {
         let country = self.get_user_country();
         self.dispatch(IoEvent::GetSearchResults(query, country));
+      }
+      Action::SearchActiveSource(query) => match self.active_source {
+        crate::core::source::Source::Subsonic => {
+          self.dispatch(IoEvent::GetSubsonicSearchResults(query));
+        }
+        crate::core::source::Source::Radio => {
+          self.dispatch(IoEvent::GetRadioSearchResults(query));
+        }
+        crate::core::source::Source::YouTube => {
+          self.dispatch(IoEvent::GetYouTubeSearchResults(query));
+        }
+        // Spotify and Local both land on the Web API search, exactly like
+        // the search input's if-chain (which has no Local branch).
+        crate::core::source::Source::Spotify | crate::core::source::Source::Local => {
+          let country = self.get_user_country();
+          self.dispatch(IoEvent::GetSearchResults(query, country));
+        }
+      },
+      Action::SearchPlaylistTracks { playlist_id, query } => {
+        self.pending_playlist_track_search = Some(query.clone());
+        self.set_status_message(format!("Searching playlist for \"{query}\"..."), 60);
+        self.dispatch(IoEvent::SearchPlaylistTracks(playlist_id, query));
       }
       Action::CreatePlaylist { name, track_uris } => {
         self.dispatch(IoEvent::CreateNewPlaylist(name, track_uris));
@@ -113,10 +138,38 @@ impl App {
       Action::Back => {
         self.pop_navigation_stack();
       }
+      Action::LoadMore(target) => match target {
+        super::ListTarget::PlaylistTracks => self.get_playlist_tracks_next(),
+        super::ListTarget::SavedTracks => self.get_current_user_saved_tracks_next(),
+      },
+      Action::Open(target) => match target {
+        super::OpenTarget::Album(id) => self.dispatch(IoEvent::GetAlbum(id)),
+        super::OpenTarget::Artist { id, name } => self.get_artist(id, name),
+        super::OpenTarget::Playlist { id, from_search } => {
+          // Same silent no-op on an unparseable id as today's opening paths.
+          if let Some(playlist_id) = crate::infra::network::ids::playlist_id(&id) {
+            let context = if from_search {
+              crate::core::app::TrackTableContext::PlaylistSearch
+            } else {
+              crate::core::app::TrackTableContext::MyPlaylists
+            };
+            self.open_playlist_tracks(playlist_id, context);
+          }
+        }
+        super::OpenTarget::Show(id) => self.dispatch(IoEvent::GetShow(id)),
+        super::OpenTarget::TrackAlbum(track_id) => {
+          self.dispatch(IoEvent::GetAlbumForTrack(track_id));
+        }
+      },
+      Action::OpenLibrary(target) => self.open_library_section(target),
+      Action::SelectSource(source) => self.set_active_source(source),
+      Action::OpenAddTrackDialog => self.begin_add_track_to_playlist_flow_from_selection(),
+      Action::OpenRemoveTrackDialog => self.begin_remove_track_from_playlist_flow(),
       Action::JumpToAlbum => self.jump_to_album(),
       Action::JumpToArtist => self.jump_to_artist_album(),
       Action::JumpToContext => self.jump_to_context(),
       Action::GenerateRecap => self.generate_recap(),
+      Action::RecommendFromTrack(track) => self.load_recommendations_for_track(track),
       Action::SetPlaybarSegment { plugin, text } => match text {
         Some(t) => {
           self.plugin_playbar_segments.insert(plugin, t);

--- a/src/core/action/mod.rs
+++ b/src/core/action/mod.rs
@@ -32,6 +32,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::core::plugin_api::{PluginPopup, PluginScreenContent, TrackInfo};
+use crate::core::source::Source;
 use crate::core::theme::{Color, ThemeField};
 
 mod apply;
@@ -93,6 +94,14 @@ pub enum Action {
     uri: String,
     offset: Option<usize>,
   },
+  /// Play one track URI as the first track inside a Spotify context URI:
+  /// the playlist Enter-start that keeps the selected track first even with
+  /// shuffle on (the network layer deliberately does not trim the uri list
+  /// when a context is present).
+  PlayTrackInContext {
+    context: String,
+    track: String,
+  },
   /// Transfer playback to a Connect device. `persist` records the device as
   /// the user's saved preference; producers other than the interactive
   /// device picker pass `false`.
@@ -102,8 +111,22 @@ pub enum Action {
   },
   /// Add one playable URI (track or episode) to the queue.
   AddToQueue(String),
-  /// Run a search; the user country is resolved at apply time.
+  /// Run a search against the Spotify catalog; the user country is resolved
+  /// at apply time. Deliberately source-blind: existing producers (Lua
+  /// `spotatui.search`) contracted the Web API search, so browsing scope
+  /// does not reroute it. The terminal search box uses
+  /// [`Action::SearchActiveSource`] instead.
   Search(String),
+  /// Run a search against the active browse source's catalog; falls back to
+  /// the Spotify catalog when the active source has no own search (the
+  /// Local-files scope behaves this way too).
+  SearchActiveSource(String),
+  /// Search one playlist's tracks; apply records the pending search and
+  /// announces it, exactly like the playlist filter input does today.
+  SearchPlaylistTracks {
+    playlist_id: String,
+    query: String,
+  },
   CreatePlaylist {
     name: String,
     track_uris: Vec<String>,
@@ -138,6 +161,25 @@ pub enum Action {
   Navigate(NavTarget),
   /// Pop the navigation stack (same as the back key).
   Back,
+  /// Fetch the next page of a paginated list surface - the shared "hit the
+  /// end of the list" consequence that GUI infinite scroll also fires.
+  /// Self-guarding: a no-op when no next page exists.
+  LoadMore(ListTarget),
+  /// Open a resource page (album/artist/show/playlist) by id. Never starts
+  /// playback; Open and Play stay disjoint.
+  Open(OpenTarget),
+  /// Open a library sidebar section and fetch its data, mirroring the
+  /// library row's Enter consequence exactly.
+  OpenLibrary(LibraryTarget),
+  /// Switch the active browse source (and persist the choice). Browse scope
+  /// only: never interrupts playback.
+  SelectSource(Source),
+  /// Open the add-to-playlist picker for the track table's current
+  /// selection; resolved from the selection at apply time.
+  OpenAddTrackDialog,
+  /// Stage a remove-track-from-playlist confirmation for the track table's
+  /// current selection; resolved from the selection at apply time.
+  OpenRemoveTrackDialog,
   /// Open the album page of the item that is playing now; resolved from the
   /// current playback context at apply time (episodes open their show).
   JumpToAlbum,
@@ -151,6 +193,10 @@ pub enum Action {
   /// selected period on the Stats screen when that screen is current, 30
   /// days anywhere else.
   GenerateRecap,
+  /// Seed the track-radio recommendations flow from one track. The full
+  /// snapshot rides along because the results table prepends it as the
+  /// context row.
+  RecommendFromTrack(TrackInfo),
   /// Set or clear a playbar segment for a plugin (keyed by plugin name).
   SetPlaybarSegment {
     plugin: String,
@@ -250,5 +296,91 @@ impl NavTarget {
   /// Look up a target by name; `None` for unknown names.
   pub fn from_name(name: &str) -> Option<NavTarget> {
     NavTarget::ALL.into_iter().find(|t| t.name() == name)
+  }
+}
+
+/// A paginated list surface [`Action::LoadMore`] can advance. Grows
+/// additively as later screens adopt continuous pagination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ListTarget {
+  /// The open playlist's track table (MyPlaylists / PlaylistSearch).
+  PlaylistTracks,
+  /// The liked-songs (saved tracks) table.
+  SavedTracks,
+}
+
+/// A resource deep-link [`Action::Open`] can address, by id.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpenTarget {
+  /// Open an album page.
+  Album(String),
+  /// Open an artist page. The display name rides along because
+  /// `App::get_artist` seeds the header with it before data arrives.
+  Artist { id: String, name: String },
+  /// Open a playlist's track table. `from_search` selects the table context
+  /// the producer uses (search results vs the user's playlists), matching
+  /// what each opening path has always passed.
+  Playlist { id: String, from_search: bool },
+  /// Open a podcast show's episode list.
+  Show(String),
+  /// Open the album containing this track.
+  TrackAlbum(String),
+}
+
+/// Library sidebar sections reachable through [`Action::OpenLibrary`].
+/// Deliberately NOT advertised through the Lua `navigate()` API (unlike
+/// [`NavTarget`]): adding rows there would expand the published plugin
+/// surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LibraryTarget {
+  Discover,
+  RecentlyPlayed,
+  Friends,
+  Stats,
+  LikedSongs,
+  Albums,
+  Artists,
+  Podcasts,
+  /// Row only present under `local-files`; a no-op without it.
+  LocalFiles,
+  /// Row only present under `ai-dj`; a no-op without it.
+  AiDj,
+}
+
+impl LibraryTarget {
+  /// Every target, in the stable subset order of `library_options()`
+  /// (feature-gated rows are appended there and matched by name).
+  pub const ALL: [LibraryTarget; 10] = [
+    LibraryTarget::Discover,
+    LibraryTarget::RecentlyPlayed,
+    LibraryTarget::Friends,
+    LibraryTarget::Stats,
+    LibraryTarget::LikedSongs,
+    LibraryTarget::Albums,
+    LibraryTarget::Artists,
+    LibraryTarget::Podcasts,
+    LibraryTarget::LocalFiles,
+    LibraryTarget::AiDj,
+  ];
+
+  /// The exact `library_options()` sidebar label for this target.
+  pub fn name(self) -> &'static str {
+    match self {
+      LibraryTarget::Discover => "Discover",
+      LibraryTarget::RecentlyPlayed => "Recently Played",
+      LibraryTarget::Friends => "Friends",
+      LibraryTarget::Stats => "Stats",
+      LibraryTarget::LikedSongs => "Liked Songs",
+      LibraryTarget::Albums => "Albums",
+      LibraryTarget::Artists => "Artists",
+      LibraryTarget::Podcasts => "Podcasts",
+      LibraryTarget::LocalFiles => "Local Files",
+      LibraryTarget::AiDj => "AI DJ",
+    }
+  }
+
+  /// Look up a target by sidebar label; `None` for unknown names.
+  pub fn from_name(name: &str) -> Option<LibraryTarget> {
+    LibraryTarget::ALL.into_iter().find(|t| t.name() == name)
   }
 }

--- a/src/core/action/tests.rs
+++ b/src/core/action/tests.rs
@@ -979,3 +979,817 @@ mod dj_actions {
     assert_eq!(app.dj.vibe, None);
   }
 }
+
+// --- pagination, open family, source-routed search, library rows, dialogs ---
+
+use super::{LibraryTarget, ListTarget, OpenTarget};
+use crate::core::app::{ActiveBlock, DialogContext, PendingTrackSelection, RecommendationsContext};
+use crate::core::pagination::Paged;
+use crate::core::plugin_api::{PlaylistInfo, TrackInfo};
+use crate::core::source::Source;
+use crate::core::test_helpers::{full_track, playlist_info};
+
+fn track(id: &str, name: &str) -> TrackInfo {
+  TrackInfo::from(&full_track(id, name))
+}
+
+fn track_page(offset: u32, ids: &[&str], has_next: bool) -> Paged<TrackInfo> {
+  Paged {
+    items: ids
+      .iter()
+      .enumerate()
+      .map(|(i, id)| track(id, &format!("Track {offset}-{i}")))
+      .collect(),
+    offset,
+    limit: ids.len() as u32,
+    total: 4,
+    next: has_next.then(|| "https://example.com/next".to_string()),
+    previous: None,
+  }
+}
+
+/// The playlist track table's page type carries snapshot positions.
+fn playlist_items_page(has_next: bool) -> Paged<(u32, crate::core::plugin_api::PlayableInfo)> {
+  Paged {
+    items: vec![(
+      0,
+      crate::core::plugin_api::PlayableInfo::Track(track("0000000000000000000001", "T1")),
+    )],
+    offset: 0,
+    limit: 1,
+    total: 4,
+    next: has_next.then(|| "https://example.com/next".to_string()),
+    previous: None,
+  }
+}
+
+// --- LoadMore ---
+
+#[test]
+fn load_more_playlist_tracks_dispatches_the_next_page_fetch() {
+  let (mut app, rx) = app_with_channel();
+  app.playlist_track_table_id = Some(
+    rspotify::model::idtypes::PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static(),
+  );
+  let page = playlist_items_page(true);
+  app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+  app.playlist_tracks = Some(page.clone());
+  app.playlist_track_pages.upsert_page_by_offset(page);
+
+  app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
+
+  match rx.try_recv() {
+    Ok(IoEvent::GetPlaylistItems(id, offset)) => {
+      assert_eq!(id, "37i9dQZF1DX4WYpdgoIcn6");
+      assert_eq!(offset, 1);
+    }
+    _other => panic!("expected GetPlaylistItems"),
+  }
+}
+
+#[test]
+fn load_more_playlist_tracks_is_a_noop_under_an_active_filter() {
+  let (mut app, rx) = app_with_channel();
+  app.playlist_track_table_id = Some(
+    rspotify::model::idtypes::PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static(),
+  );
+  let page = playlist_items_page(true);
+  app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+  app.playlist_tracks = Some(page.clone());
+  app.playlist_track_pages.upsert_page_by_offset(page);
+  app.active_playlist_track_filter = Some("query".to_string());
+
+  app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
+
+  assert!(rx.try_recv().is_err(), "filtered playlists never paginate");
+}
+
+#[test]
+fn load_more_saved_tracks_fetches_the_missing_continuous_page() {
+  let (mut app, rx) = app_with_channel();
+  let page = track_page(
+    0,
+    &["0000000000000000000001", "0000000000000000000002"],
+    true,
+  );
+  app.library.saved_tracks.upsert_page_by_offset(page);
+
+  app.apply(Action::LoadMore(ListTarget::SavedTracks));
+
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetCurrentSavedTracks(Some(2)))
+  ));
+}
+
+#[test]
+fn load_more_saved_tracks_is_a_noop_at_the_end_of_the_list() {
+  let (mut app, rx) = app_with_channel();
+  let page = track_page(0, &["0000000000000000000001"], false);
+  app.library.saved_tracks.upsert_page_by_offset(page);
+
+  app.apply(Action::LoadMore(ListTarget::SavedTracks));
+
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn load_more_does_not_touch_pending_track_table_selection() {
+  let (mut app, rx) = app_with_channel();
+  let page = track_page(0, &["0000000000000000000001"], false);
+  app.library.saved_tracks.upsert_page_by_offset(page);
+  app.pending_track_table_selection = Some(PendingTrackSelection::Index(9));
+
+  app.apply(Action::LoadMore(ListTarget::SavedTracks));
+
+  assert_eq!(
+    app.pending_track_table_selection,
+    Some(PendingTrackSelection::Index(9)),
+    "the cursor-follow side effect belongs to the caller, not to LoadMore"
+  );
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn load_more_saved_tracks_does_not_refetch_an_in_flight_page() {
+  let (mut app, rx) = app_with_channel();
+  let page = track_page(
+    0,
+    &["0000000000000000000001", "0000000000000000000002"],
+    true,
+  );
+  app.library.saved_tracks.upsert_page_by_offset(page);
+
+  app.apply(Action::LoadMore(ListTarget::SavedTracks));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetCurrentSavedTracks(Some(2)))
+  ));
+
+  // The fetch marked offset 2 as in flight; a second apply must not
+  // re-dispatch it (the prefetch dedupe the arm inherits).
+  app.apply(Action::LoadMore(ListTarget::SavedTracks));
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn load_more_playlist_tracks_does_not_refetch_an_in_flight_page() {
+  let (mut app, rx) = app_with_channel();
+  app.playlist_track_table_id = Some(
+    rspotify::model::idtypes::PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static(),
+  );
+  app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+  let page = playlist_items_page(true);
+  app.playlist_tracks = Some(page.clone());
+  app.playlist_track_pages.upsert_page_by_offset(page);
+
+  app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetPlaylistItems(_, 1))));
+
+  app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
+  assert!(
+    rx.try_recv().is_err(),
+    "the in-flight page is not refetched"
+  );
+}
+
+// --- Open family ---
+
+#[test]
+fn open_album_dispatches_get_album() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Album(
+    "5gzLOflH95LkKYE6XSXE9k".to_string(),
+  )));
+
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetAlbum(id)) if id == "5gzLOflH95LkKYE6XSXE9k"
+  ));
+}
+
+#[test]
+fn open_artist_resolves_the_country_and_dispatches_get_artist() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Artist {
+    id: "2ye2Wgw4gimLv2eAKyk1NB".to_string(),
+    name: String::new(),
+  }));
+
+  match rx.try_recv() {
+    Ok(IoEvent::GetArtist(id, name, country)) => {
+      assert_eq!(id, "2ye2Wgw4gimLv2eAKyk1NB");
+      assert_eq!(name, "");
+      assert_eq!(country, None, "no user loaded, so no market");
+    }
+    _other => panic!("expected GetArtist"),
+  }
+}
+
+#[test]
+fn open_track_album_dispatches_get_album_for_track() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::TrackAlbum(
+    "10igKaIKsSB6ZnWxPxPvKO".to_string(),
+  )));
+
+  assert!(
+    matches!(
+      rx.try_recv(),
+      Ok(IoEvent::GetAlbumForTrack(id)) if id == "10igKaIKsSB6ZnWxPxPvKO"
+    ),
+    "the track id rides through unchanged"
+  );
+}
+
+#[test]
+fn open_show_dispatches_get_show() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Show(
+    "3aNsrV6lkzmcU1w8u8kA7N".to_string(),
+  )));
+
+  assert!(
+    matches!(
+      rx.try_recv(),
+      Ok(IoEvent::GetShow(id)) if id == "3aNsrV6lkzmcU1w8u8kA7N"
+    ),
+    "the show id rides through unchanged"
+  );
+}
+
+#[test]
+fn open_playlist_opens_the_track_table_in_the_playlists_context() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Playlist {
+    id: "37i9dQZF1DX4WYpdgoIcn6".to_string(),
+    from_search: false,
+  }));
+
+  assert_eq!(app.get_current_route().id, RouteId::TrackTable);
+  assert_eq!(
+    app.track_table.context,
+    Some(crate::core::app::TrackTableContext::MyPlaylists)
+  );
+  assert_eq!(
+    app.pending_playlist_open.as_deref(),
+    Some("37i9dQZF1DX4WYpdgoIcn6")
+  );
+  match rx.try_recv() {
+    Ok(IoEvent::GetPlaylistItems(id, offset)) => {
+      assert_eq!(id, "37i9dQZF1DX4WYpdgoIcn6");
+      assert_eq!(offset, 0);
+    }
+    _other => panic!("expected GetPlaylistItems"),
+  }
+}
+
+#[test]
+fn open_playlist_from_search_uses_the_search_context() {
+  let (mut app, _rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Playlist {
+    id: "37i9dQZF1DX4WYpdgoIcn6".to_string(),
+    from_search: true,
+  }));
+
+  assert_eq!(
+    app.track_table.context,
+    Some(crate::core::app::TrackTableContext::PlaylistSearch)
+  );
+}
+
+#[test]
+fn open_playlist_with_an_unparseable_id_is_a_silent_noop() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::Open(OpenTarget::Playlist {
+    id: "not a base62 id!".to_string(),
+    from_search: false,
+  }));
+
+  assert!(
+    rx.try_recv().is_err(),
+    "the opening paths drop bad ids silently"
+  );
+  assert_eq!(app.get_current_route().id, RouteId::Home);
+}
+
+#[test]
+fn open_playlist_twice_while_pending_open_fetches_only_once() {
+  let (mut app, rx) = app_with_channel();
+
+  let target = OpenTarget::Playlist {
+    id: "37i9dQZF1DX4WYpdgoIcn6".to_string(),
+    from_search: false,
+  };
+  app.apply(Action::Open(target.clone()));
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetPlaylistItems(_, 0))));
+
+  // Same open already in flight: no second fetch, only the screen shown.
+  app.apply(Action::Open(target));
+  assert!(rx.try_recv().is_err());
+}
+
+// --- SearchActiveSource (Action::Search stays Spotify-only) ---
+
+#[test]
+fn search_active_source_routes_by_the_active_source() {
+  let (mut app, rx) = app_with_channel();
+  let query = "coltrane".to_string();
+
+  app.active_source = Source::Subsonic;
+  app.apply(Action::SearchActiveSource(query.clone()));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetSubsonicSearchResults(q)) if q == "coltrane"
+  ));
+
+  app.active_source = Source::Radio;
+  app.apply(Action::SearchActiveSource(query.clone()));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetRadioSearchResults(q)) if q == "coltrane"
+  ));
+
+  app.active_source = Source::YouTube;
+  app.apply(Action::SearchActiveSource(query.clone()));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetYouTubeSearchResults(q)) if q == "coltrane"
+  ));
+
+  app.active_source = Source::Spotify;
+  app.apply(Action::SearchActiveSource(query.clone()));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetSearchResults(q, _)) if q == "coltrane"
+  ));
+
+  // Local falls into the Spotify branch, matching the search input's
+  // if-chain, which has no Local branch.
+  app.active_source = Source::Local;
+  app.apply(Action::SearchActiveSource(query));
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetSearchResults(_, None))
+  ));
+}
+
+#[test]
+fn search_active_source_resolves_a_loaded_users_country() {
+  let (mut app, rx) = app_with_channel();
+  app.user = Some(crate::core::app::UserInfo {
+    id: "user1".to_string(),
+    display_name: None,
+    country: Some("US".to_string()),
+  });
+  app.active_source = Source::Spotify;
+
+  app.apply(Action::SearchActiveSource("coltrane".to_string()));
+
+  assert!(
+    matches!(rx.try_recv(), Ok(IoEvent::GetSearchResults(_, Some(_)))),
+    "the loaded user's market rides along"
+  );
+}
+
+#[test]
+fn search_stays_on_the_spotify_catalog_when_browsing_other_sources() {
+  let (mut app, rx) = app_with_channel();
+  app.active_source = Source::YouTube;
+
+  app.apply(Action::Search("daft punk".to_string()));
+
+  // Lua spotatui.search contracted the Web API search; browsing scope does
+  // not reroute it (only SearchActiveSource does).
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetSearchResults(q, None)) if q == "daft punk"
+  ));
+}
+
+#[test]
+fn search_playlist_tracks_records_the_pending_search_and_dispatches() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::SearchPlaylistTracks {
+    playlist_id: "37i9dQZF1DX4WYpdgoIcn6".to_string(),
+    query: "queen rock".to_string(),
+  });
+
+  assert_eq!(
+    app.pending_playlist_track_search.as_deref(),
+    Some("queen rock")
+  );
+  assert_eq!(
+    app.status_message.as_deref(),
+    Some("Searching playlist for \"queen rock\"...")
+  );
+  match rx.try_recv() {
+    Ok(IoEvent::SearchPlaylistTracks(id, query)) => {
+      assert_eq!(id, "37i9dQZF1DX4WYpdgoIcn6");
+      assert_eq!(query, "queen rock");
+    }
+    _other => panic!("expected SearchPlaylistTracks"),
+  }
+}
+
+// --- playback starts ---
+
+#[test]
+fn play_track_in_context_dispatches_the_combined_start() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::PlayTrackInContext {
+    context: "spotify:playlist:p1".to_string(),
+    track: "spotify:track:t1".to_string(),
+  });
+
+  match rx.try_recv() {
+    Ok(IoEvent::StartPlayback(context, uris, offset)) => {
+      assert_eq!(context.as_deref(), Some("spotify:playlist:p1"));
+      assert_eq!(uris, Some(vec!["spotify:track:t1".to_string()]));
+      assert_eq!(offset, Some(0));
+    }
+    _other => panic!("expected StartPlayback"),
+  }
+}
+
+#[test]
+fn recommend_from_track_sets_song_context_and_keeps_the_unseeded_request() {
+  let (mut app, rx) = app_with_channel();
+  let seed = track("4uLU6hMCjMI75M1A2tKUQC", "Song A");
+
+  app.apply(Action::RecommendFromTrack(seed.clone()));
+
+  assert_eq!(
+    app.recommendations_context,
+    Some(RecommendationsContext::Song)
+  );
+  assert_eq!(app.recommendations_seed, "Song A");
+  match rx.try_recv() {
+    Ok(IoEvent::GetRecommendationsForSeed(seed_artists, seed_tracks, first_track, country)) => {
+      assert!(seed_artists.is_none());
+      // Preserved historic bug: the full URI is fed as the seed and the
+      // request goes out unseeded. Fixing it is a separate verified change.
+      assert_eq!(seed_tracks, Some(vec![seed.uri.clone().unwrap()]));
+      assert_eq!(
+        (*first_track).as_ref().map(|t| t.name.as_str()),
+        Some("Song A")
+      );
+      assert_eq!(country, None);
+    }
+    _other => panic!("expected GetRecommendationsForSeed"),
+  }
+}
+
+#[test]
+fn recommend_from_track_without_a_uri_still_carries_the_context_row() {
+  let (mut app, rx) = app_with_channel();
+  let mut seed = track("4uLU6hMCjMI75M1A2tKUQC", "Local Song");
+  seed.uri = None;
+
+  app.apply(Action::RecommendFromTrack(seed));
+
+  assert_eq!(
+    app.recommendations_context,
+    Some(RecommendationsContext::Song)
+  );
+  assert_eq!(app.recommendations_seed, "Local Song");
+  match rx.try_recv() {
+    Ok(IoEvent::GetRecommendationsForSeed(seed_artists, seed_tracks, first_track, _)) => {
+      assert!(seed_artists.is_none());
+      assert!(seed_tracks.is_none(), "no uri means no seed list");
+      assert_eq!(
+        (*first_track).as_ref().map(|t| t.name.as_str()),
+        Some("Local Song")
+      );
+    }
+    _other => panic!("expected GetRecommendationsForSeed"),
+  }
+}
+
+// --- dialogs ---
+
+#[test]
+fn open_add_track_dialog_without_a_selection_is_a_noop() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenAddTrackDialog);
+
+  assert!(rx.try_recv().is_err());
+  assert!(app.pending_playlist_track_add.is_none());
+}
+
+#[test]
+fn open_add_track_dialog_stages_the_selected_row_for_the_picker() {
+  let (mut app, rx) = app_with_channel();
+  app.active_source = Source::YouTube;
+  app.youtube_playlists = vec![PlaylistInfo {
+    uri: "youtube:playlist:y1".to_string(),
+    ..playlist_info("y1", "Local List", "owner", false)
+  }];
+  app.track_table.tracks = vec![track("0000000000000000000001", "Track 1")];
+  app.track_table.selected_index = 0;
+
+  app.apply(Action::OpenAddTrackDialog);
+
+  assert_eq!(
+    app.get_current_route().active_block,
+    ActiveBlock::Dialog(DialogContext::AddTrackToPlaylistPicker)
+  );
+  let pending = app
+    .pending_playlist_track_add
+    .as_ref()
+    .expect("staged for the picker");
+  assert_eq!(pending.track_name, "Track 1");
+  assert!(
+    rx.try_recv().is_err(),
+    "the YouTube path fetches nothing when playlists exist"
+  );
+}
+
+#[test]
+fn open_add_track_dialog_without_destinations_requests_them() {
+  let (mut app, rx) = app_with_channel();
+  app.active_source = Source::Spotify;
+  app.track_table.tracks = vec![track("0000000000000000000001", "Track 1")];
+  app.track_table.selected_index = 0;
+
+  app.apply(Action::OpenAddTrackDialog);
+
+  // No user profile and no playlists loaded yet: the flow fetches both
+  // first and tells the user to retry.
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetUser)));
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetPlaylists)));
+  assert!(app.pending_playlist_track_add.is_none());
+}
+
+#[test]
+fn open_remove_track_dialog_stages_the_spotify_removal_with_position() {
+  let (mut app, rx) = app_with_channel();
+  app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+  app.playlist_track_table_id = Some(
+    rspotify::model::idtypes::PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static(),
+  );
+  app.all_playlists = vec![playlist_info(
+    "37i9dQZF1DX4WYpdgoIcn6",
+    "My List",
+    "owner",
+    false,
+  )];
+  app.track_table.tracks = vec![track("0000000000000000000001", "Track 1")];
+  app.track_table.selected_index = 0;
+  app.playlist_track_positions = Some(vec![7]);
+
+  app.apply(Action::OpenRemoveTrackDialog);
+
+  let pending = app
+    .pending_playlist_track_removal
+    .as_ref()
+    .expect("staged removal");
+  assert_eq!(pending.playlist_name, "My List");
+  assert_eq!(pending.track_id, "0000000000000000000001");
+  assert_eq!(pending.position, 7);
+  assert_eq!(
+    app.get_current_route().active_block,
+    ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm)
+  );
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn open_remove_track_dialog_without_a_position_reports_an_error() {
+  let (mut app, rx) = app_with_channel();
+  app.track_table.context = Some(crate::core::app::TrackTableContext::MyPlaylists);
+  app.playlist_track_table_id = Some(
+    rspotify::model::idtypes::PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+      .unwrap()
+      .into_static(),
+  );
+  app.all_playlists = vec![playlist_info(
+    "37i9dQZF1DX4WYpdgoIcn6",
+    "My List",
+    "owner",
+    false,
+  )];
+  app.track_table.tracks = vec![track("0000000000000000000001", "Track 1")];
+  app.track_table.selected_index = 0;
+
+  app.apply(Action::OpenRemoveTrackDialog);
+
+  assert_eq!(
+    app.status_message.as_deref(),
+    Some("Cannot resolve track position for removal"),
+  );
+  assert!(app.pending_playlist_track_removal.is_none());
+  assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn open_remove_track_dialog_youtube_routes_the_local_edit() {
+  let (mut app, rx) = app_with_channel();
+  app.track_table.context = Some(crate::core::app::TrackTableContext::YouTubePlaylist);
+  app.youtube_open_playlist = Some("youtube:playlist:y1".to_string());
+  app.youtube_playlists = vec![PlaylistInfo {
+    uri: "youtube:playlist:y1".to_string(),
+    ..playlist_info("y1", "Local List", "owner", false)
+  }];
+  app.track_table.tracks = vec![track("0000000000000000000001", "Track 1")];
+  app.track_table.selected_index = 0;
+
+  app.apply(Action::OpenRemoveTrackDialog);
+
+  let pending = app
+    .pending_playlist_track_removal
+    .as_ref()
+    .expect("staged local edit");
+  assert_eq!(pending.playlist_id, "youtube:playlist:y1");
+  assert_eq!(pending.position, 0, "unused for local YouTube playlists");
+  assert_eq!(
+    app.get_current_route().active_block,
+    ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm)
+  );
+  assert!(rx.try_recv().is_err());
+}
+
+// --- library sections ---
+
+#[test]
+fn open_library_stats_marks_loading_dispatches_and_pushes() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Stats));
+
+  assert!(app.stats_loading);
+  assert_eq!(app.get_current_route().id, RouteId::Stats);
+  let expected_period = app.stats_period;
+  assert!(
+    matches!(
+      rx.try_recv(),
+      Ok(IoEvent::LoadListeningStats(period)) if period == expected_period
+    ),
+    "the selected stats period rides along"
+  );
+}
+
+#[test]
+fn open_library_recently_played_pushes_before_the_data_arrives() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::RecentlyPlayed));
+
+  // The row pushes immediately; only the global navigate binding defers
+  // the push to the network result.
+  assert_eq!(app.get_current_route().id, RouteId::RecentlyPlayed);
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetRecentlyPlayed)));
+}
+
+#[test]
+fn open_library_friends_first_open_fetches_code_and_list() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Friends));
+
+  assert_eq!(app.get_current_route().id, RouteId::Friends);
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetFriendCode)));
+  assert!(matches!(rx.try_recv(), Ok(IoEvent::GetFriends)));
+}
+
+#[test]
+fn open_library_friends_skips_fetched_state_on_reopen() {
+  let (mut app, rx) = app_with_channel();
+  app.friend_code = Some("code".to_string());
+  app.friends_loading = true;
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Friends));
+
+  assert_eq!(app.get_current_route().id, RouteId::Friends);
+  assert!(
+    rx.try_recv().is_err(),
+    "nothing refetches once loaded/loading"
+  );
+}
+
+#[test]
+fn open_library_rows_push_their_routes_and_fetch() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Discover));
+  assert_eq!(app.get_current_route().id, RouteId::Discover);
+  assert!(rx.try_recv().is_err());
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Albums));
+  assert_eq!(app.get_current_route().id, RouteId::AlbumList);
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetCurrentUserSavedAlbums(None))
+  ));
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Artists));
+  assert_eq!(app.get_current_route().id, RouteId::Artists);
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetFollowedArtists(None))
+  ));
+
+  app.apply(Action::OpenLibrary(LibraryTarget::Podcasts));
+  assert_eq!(app.get_current_route().id, RouteId::Podcasts);
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetCurrentUserSavedShows(None))
+  ));
+}
+
+#[cfg(all(test, feature = "local-files"))]
+#[test]
+fn open_library_local_files_pushes_the_browser_route() {
+  let (mut app, rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::LocalFiles));
+
+  assert_eq!(app.get_current_route().id, RouteId::LocalBrowser);
+  assert!(rx.try_recv().is_err());
+}
+
+#[cfg(all(test, feature = "ai-dj"))]
+#[test]
+fn open_library_ai_dj_opens_the_screen_through_app() {
+  let (mut app, _rx) = app_with_channel();
+
+  app.apply(Action::OpenLibrary(LibraryTarget::AiDj));
+
+  assert_eq!(app.get_current_route().id, RouteId::AiDj);
+}
+
+#[test]
+fn open_library_liked_songs_resets_the_cache_and_fetches() {
+  let (mut app, rx) = app_with_channel();
+  let page = track_page(0, &["0000000000000000000001"], false);
+  app.library.saved_tracks.upsert_page_by_offset(page);
+
+  app.apply(Action::OpenLibrary(LibraryTarget::LikedSongs));
+
+  assert_eq!(app.get_current_route().id, RouteId::TrackTable);
+  assert!(app.library.saved_tracks.pages.is_empty(), "cache reset");
+  assert!(matches!(
+    rx.try_recv(),
+    Ok(IoEvent::GetCurrentSavedTracks(None))
+  ));
+}
+
+#[test]
+fn library_target_names_round_trip_and_cover_every_sidebar_row() {
+  for target in LibraryTarget::ALL {
+    assert_eq!(LibraryTarget::from_name(target.name()), Some(target));
+  }
+  // Every sidebar label resolves to a DISTINCT target: this is the
+  // load-bearing invariant (name() must equal the library_options()
+  // strings, or the handler's name resolution remaps rows).
+  let options = crate::core::app::library_options();
+  let mut resolved = Vec::new();
+  for label in options {
+    let target = LibraryTarget::from_name(label)
+      .unwrap_or_else(|| panic!("sidebar row {label} has no LibraryTarget"));
+    assert!(!resolved.contains(&target), "duplicate label {label}");
+    resolved.push(target);
+  }
+  assert_eq!(LibraryTarget::from_name("no such row"), None);
+}
+
+// --- SelectSource ---
+
+#[test]
+fn select_source_flips_scope_mirrors_runtime_state_and_persists() {
+  let dir = tempfile::tempdir().unwrap();
+  let (mut app, rx) = app_with_channel();
+  app.state_path = Some(dir.path().join("state.yml"));
+
+  app.apply(Action::SelectSource(Source::Local));
+
+  assert_eq!(app.active_source, Source::Local);
+  assert_eq!(app.runtime_state.active_source, Source::Local);
+  let written = std::fs::read_to_string(dir.path().join("state.yml")).unwrap();
+  assert!(
+    written.contains("active_source") && written.contains("Local"),
+    "sparse patch persisted the choice"
+  );
+  assert!(
+    rx.try_recv().is_err(),
+    "sidebar loading stays with the caller"
+  );
+}

--- a/src/core/app/discover.rs
+++ b/src/core/app/discover.rs
@@ -64,4 +64,21 @@ impl App {
     let user_country = self.get_user_country();
     self.dispatch(IoEvent::GetRecommendationsForTrackId(id, user_country));
   }
+
+  /// Seed the track-radio recommendations flow from one track: set the Song
+  /// context, record the seed label, and fetch recommendations for it.
+  ///
+  /// NOTE: preserves a pre-existing bug. The historic handler fed the
+  /// track's full URI ("spotify:track:...") as the seed, which
+  /// `TrackId::from_id` rejects, so the whole seed_tracks list collapses to
+  /// `None` and the recommendation request goes out unseeded.
+  /// `TrackInfo::uri` reproduces that exact URI string; switching to
+  /// `track.id` (base62) would change behavior. Fix the seeding separately
+  /// with its own verification.
+  pub fn load_recommendations_for_track(&mut self, track: TrackInfo) {
+    let seed_tracks = track.uri.clone().map(|uri| vec![uri]);
+    self.recommendations_context = Some(RecommendationsContext::Song);
+    self.recommendations_seed = track.name.clone();
+    self.get_recommendations_for_seed(None, seed_tracks, Some(track));
+  }
 }

--- a/src/core/app/dj.rs
+++ b/src/core/app/dj.rs
@@ -95,7 +95,7 @@ impl App {
   /// Moved verbatim from the terminal DJ handler; reached through
   /// `Action::OpenLibrary(LibraryTarget::AiDj)`.
   #[cfg(feature = "ai-dj")]
-  pub(crate) fn open_ai_dj_screen(&mut self) {
+  pub(super) fn open_ai_dj_screen(&mut self) {
     // Pushed only when the DJ is not already the current route, for the reason
     // `open_picker` documents: a second `RouteId::AiDj` on the stack turns the Esc
     // that should leave the DJ into one that lands back on it. Reachable with the

--- a/src/core/app/dj.rs
+++ b/src/core/app/dj.rs
@@ -83,6 +83,54 @@ impl App {
       .retain(|track| !track.uri.as_ref().is_some_and(|uri| dj_uris.contains(uri)));
     before - self.native_queue.len()
   }
+
+  /// Open the DJ screen, warming the library index if the filter is already
+  /// on.
+  ///
+  /// Every entry point goes through here so the crawl is never left to the
+  /// resolve step. `behavior.dj_avoid_library: true` seeds the toggle without
+  /// going through `toggle_fresh_only`, so without this the first turn of such
+  /// a session would crawl inline on the serial IoEvent lane — head-of-line
+  /// blocking every other event behind a few seconds of pagination.
+  /// Moved verbatim from the terminal DJ handler; reached through
+  /// `Action::OpenLibrary(LibraryTarget::AiDj)`.
+  #[cfg(feature = "ai-dj")]
+  pub(crate) fn open_ai_dj_screen(&mut self) {
+    // Pushed only when the DJ is not already the current route, for the reason
+    // `open_picker` documents: a second `RouteId::AiDj` on the stack turns the Esc
+    // that should leave the DJ into one that lands back on it. Reachable with the
+    // DJ already open because focus can be elsewhere — Left to the sidebar, then
+    // the open key or the sidebar's own "AI DJ" row — which is also why focus is
+    // restored rather than left where it was.
+    if self.get_current_route().id == RouteId::AiDj {
+      self.set_current_route_state(Some(ActiveBlock::AiDj), Some(ActiveBlock::AiDj));
+    } else {
+      self.push_navigation_stack(RouteId::AiDj, ActiveBlock::AiDj);
+    }
+    // Asked once, on the first visit, and only here because `open` is the single
+    // funnel every entry point goes through. Not in `first_run.rs`: that runs before
+    // the TUI, gated on the absence of client.yml, and would interrogate every user
+    // about coding agents even if they never open the DJ.
+    //
+    // An already-open picker is rebuilt rather than resumed. That state means the user
+    // left the screen by a route the picker's own Esc never saw (a mouse click on the
+    // sidebar), so its rows were detected against a session that has moved on.
+    if self.dj.setup.is_some() || !self.user_config.behavior.dj_is_configured() {
+      use crate::infra::dj::setup::DjSetup;
+      self.dj.setup = Some(DjSetup::new(&self.user_config.behavior));
+    }
+    self.request_dj_library_index();
+  }
+
+  /// Kick off the library crawl unless it has already run or is running.
+  /// Shared by the screen opener and the "only tracks I do not already have"
+  /// toggle in the terminal handler.
+  #[cfg(feature = "ai-dj")]
+  pub(crate) fn request_dj_library_index(&mut self) {
+    if self.dj.avoid_library && self.dj.library.is_none() && !self.dj.library_indexing {
+      self.dispatch(IoEvent::DjIndexLibrary);
+    }
+  }
 }
 
 #[cfg(all(test, feature = "dj-core"))]

--- a/src/core/app/library.rs
+++ b/src/core/app/library.rs
@@ -154,6 +154,70 @@ impl App {
     self.track_table.context = Some(TrackTableContext::SavedTracks);
   }
 
+  /// Open a library sidebar section: the whole Enter consequence of a
+  /// library row (fetches, route pushes, bookkeeping), moved verbatim from
+  /// the library handler so every frontend fires the same sequence through
+  /// `Action::OpenLibrary`.
+  pub fn open_library_section(&mut self, target: crate::core::action::LibraryTarget) {
+    use crate::core::action::LibraryTarget;
+    match target {
+      LibraryTarget::Discover => {
+        self.push_navigation_stack(RouteId::Discover, ActiveBlock::Discover);
+      }
+      // The row pushes the route immediately; only the global navigate
+      // binding defers the push to the network result.
+      LibraryTarget::RecentlyPlayed => {
+        self.dispatch(IoEvent::GetRecentlyPlayed);
+        self.push_navigation_stack(RouteId::RecentlyPlayed, ActiveBlock::RecentlyPlayed);
+      }
+      LibraryTarget::Friends => {
+        self.push_navigation_stack(RouteId::Friends, ActiveBlock::Friends);
+        // Load friend code + friends list on first open (or if empty)
+        if self.friend_code.is_none() {
+          self.dispatch(IoEvent::GetFriendCode);
+        }
+        if self.friends.is_empty() && !self.friends_loading {
+          self.dispatch(IoEvent::GetFriends);
+        }
+        self.last_friends_refresh_at = std::time::Instant::now();
+      }
+      LibraryTarget::Stats => {
+        self.stats_loading = true;
+        self.dispatch(IoEvent::LoadListeningStats(self.stats_period));
+        self.push_navigation_stack(RouteId::Stats, ActiveBlock::Stats);
+      }
+      LibraryTarget::LikedSongs => {
+        self.reset_saved_tracks_view();
+        self.dispatch(IoEvent::GetCurrentSavedTracks(None));
+        self.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+      }
+      LibraryTarget::Albums => {
+        self.dispatch(IoEvent::GetCurrentUserSavedAlbums(None));
+        self.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
+      }
+      LibraryTarget::Artists => {
+        self.dispatch(IoEvent::GetFollowedArtists(None));
+        self.push_navigation_stack(RouteId::Artists, ActiveBlock::Artists);
+      }
+      LibraryTarget::Podcasts => {
+        self.dispatch(IoEvent::GetCurrentUserSavedShows(None));
+        self.push_navigation_stack(RouteId::Podcasts, ActiveBlock::Podcasts);
+      }
+      // The row cannot be selected in builds without `local-files`, so the
+      // arm is a no-op there.
+      LibraryTarget::LocalFiles => {
+        #[cfg(feature = "local-files")]
+        self.push_navigation_stack(RouteId::LocalBrowser, ActiveBlock::LocalBrowser);
+      }
+      // The row cannot be selected in builds without `ai-dj`, so the arm is
+      // a no-op there.
+      LibraryTarget::AiDj => {
+        #[cfg(feature = "ai-dj")]
+        self.open_ai_dj_screen();
+      }
+    }
+  }
+
   pub fn next_missing_saved_tracks_offset(&self, page_index: usize) -> Option<u32> {
     let saved_tracks_page = self.library.saved_tracks.get_results(Some(page_index))?;
     saved_tracks_page.next.as_ref()?;

--- a/src/core/app/playlists.rs
+++ b/src/core/app/playlists.rs
@@ -184,6 +184,136 @@ impl App {
     );
   }
 
+  /// Resolve the track table's current selection and open the
+  /// add-to-playlist picker for it. Silent no-op when no row is selected,
+  /// exactly like the `w` key that has always driven it.
+  pub fn begin_add_track_to_playlist_flow_from_selection(&mut self) {
+    let Some(track) = self.track_table.tracks.get(self.track_table.selected_index) else {
+      return;
+    };
+    let track_id = track.id.clone();
+    let track_name = track.name.clone();
+    self.begin_add_track_to_playlist_flow(track_id, track_name);
+  }
+
+  /// Stage a remove-track-from-playlist confirmation for the track table's
+  /// current selection and push the confirm dialog. Body moved verbatim
+  /// from the track-table handler's `open_remove_from_playlist_dialog`.
+  pub fn begin_remove_track_from_playlist_flow(&mut self) {
+    // Local YouTube playlist: same confirm dialog, routed (by the
+    // `youtube:playlist:` prefix in the pending target) to the local file edit
+    // instead of the Spotify API. No snapshot position — removal is by video id.
+    if self.track_table.context == Some(TrackTableContext::YouTubePlaylist) {
+      let Some(playlist_uri) = self.youtube_open_playlist.clone() else {
+        self.set_status_message("No YouTube playlist is open".to_string(), 4);
+        return;
+      };
+      let playlist_name = self
+        .youtube_playlists
+        .iter()
+        .find(|p| p.uri == playlist_uri)
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| "YouTube playlist".to_string());
+      let Some(track) = self.track_table.tracks.get(self.track_table.selected_index) else {
+        return;
+      };
+      let Some(track_id) = track.id.clone() else {
+        self.set_status_message("Track cannot be edited in playlist".to_string(), 4);
+        return;
+      };
+      let track_name = track.name.clone();
+      self.clear_dialog_state();
+      self.pending_playlist_track_removal = Some(PendingPlaylistTrackRemoval {
+        playlist_id: playlist_uri,
+        playlist_name,
+        track_id,
+        track_name,
+        position: 0, // unused for local YouTube playlists
+      });
+      self.push_navigation_stack(
+        RouteId::Dialog,
+        ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm),
+      );
+      return;
+    }
+
+    let playlist_context = match self.current_playlist_removal_target() {
+      Some(context) => context,
+      None => {
+        self.set_status_message(
+          "Remove only works in selected playlist views".to_string(),
+          4,
+        );
+        return;
+      }
+    };
+
+    let track = match self.track_table.tracks.get(self.track_table.selected_index) {
+      Some(track) => track,
+      None => return,
+    };
+
+    let track_id = match track.id.clone() {
+      Some(id) => id,
+      None => {
+        self.set_status_message("Track cannot be edited in playlist".to_string(), 4);
+        return;
+      }
+    };
+    let track_name = track.name.clone();
+
+    let position = match self
+      .playlist_track_positions
+      .as_ref()
+      .and_then(|positions| positions.get(self.track_table.selected_index))
+      .copied()
+    {
+      Some(position) => position,
+      None => {
+        self.set_status_message("Cannot resolve track position for removal".to_string(), 4);
+        return;
+      }
+    };
+
+    self.clear_dialog_state();
+    self.pending_playlist_track_removal = Some(PendingPlaylistTrackRemoval {
+      playlist_id: playlist_context.0,
+      playlist_name: playlist_context.1,
+      track_id,
+      track_name,
+      position,
+    });
+    self.push_navigation_stack(
+      RouteId::Dialog,
+      ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm),
+    );
+  }
+
+  /// The active playlist's (base62 id, name) pair for the removal flow.
+  fn current_playlist_removal_target(&self) -> Option<(String, String)> {
+    let playlist_id = self.current_playlist_track_table_id()?;
+    let playlist_id = playlist_id.id().to_string();
+    let playlist_name = self
+      .all_playlists
+      .iter()
+      .find(|playlist| playlist.id.as_deref() == Some(playlist_id.as_str()))
+      .map(|playlist| playlist.name.clone())
+      .or_else(|| {
+        self
+          .search_results
+          .playlists
+          .as_ref()
+          .and_then(|playlists| {
+            playlists
+              .items
+              .iter()
+              .find(|playlist| playlist.id.as_deref() == Some(playlist_id.as_str()))
+          })
+          .map(|playlist| playlist.name.clone())
+      })?;
+    Some((playlist_id, playlist_name))
+  }
+
   pub fn user_follow_playlist(&mut self) {
     info!("following playlist");
     if let SearchResult {

--- a/src/core/app/route.rs
+++ b/src/core/app/route.rs
@@ -219,6 +219,20 @@ impl App {
     }
   }
 
+  /// Switch the active browse source and mirror + persist the choice so the
+  /// selection survives restarts. Browse scope only: never interrupts
+  /// playback (routing goes by URI scheme). Sidebar data loading and any
+  /// view resets stay with the caller.
+  pub fn set_active_source(&mut self, source: Source) {
+    self.active_source = source;
+    self.runtime_state.active_source = source;
+    if let Err(e) = self.save_runtime_state(
+      &crate::core::state::PersistedRuntimeState::active_source(self.runtime_state.active_source),
+    ) {
+      log::warn!("[source] failed to persist active_source: {e}");
+    }
+  }
+
   // The navigation_stack actually only controls the large block to the right of `library` and
   // `playlists`
   pub fn push_navigation_stack(&mut self, next_route_id: RouteId, next_active_block: ActiveBlock) {

--- a/src/core/app/transport.rs
+++ b/src/core/app/transport.rs
@@ -362,6 +362,19 @@ impl App {
     self.dispatch(IoEvent::StartPlayback(Some(context_uri), None, offset));
   }
 
+  /// Start playback of one track URI as the first track inside a Spotify
+  /// context URI. The third start shape beside the two twins above: the
+  /// network layer deliberately does not trim the uri list when a context is
+  /// present, which is what keeps the selected track first under shuffle.
+  #[cfg_attr(not(feature = "scripting"), allow(dead_code))]
+  pub(crate) fn start_playback_track_in_context(&mut self, context_uri: String, track_uri: String) {
+    self.dispatch(IoEvent::StartPlayback(
+      Some(context_uri),
+      Some(vec![track_uri]),
+      Some(0),
+    ));
+  }
+
   pub fn copy_song_url(&mut self) {
     info!("copying song url to clipboard");
     let clipboard = match &mut self.clipboard {

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -133,6 +133,7 @@ mod tests {
     for source in Source::ALL {
       let wire = serde_json::to_string(&source).unwrap();
       assert_eq!(wire, format!("\"{}\"", source.to_config_str()));
+      assert_eq!(serde_json::from_str::<Source>(&wire).unwrap(), source);
     }
   }
 

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -129,6 +129,14 @@ mod tests {
   use super::*;
 
   #[test]
+  fn serde_tokens_match_the_config_tokens() {
+    for source in Source::ALL {
+      let wire = serde_json::to_string(&source).unwrap();
+      assert_eq!(wire, format!("\"{}\"", source.to_config_str()));
+    }
+  }
+
+  #[test]
   fn spotify_supports_all_capabilities() {
     assert!(Source::Spotify.supports_search());
     assert!(Source::Spotify.supports_library());

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -23,6 +23,7 @@
 
 use crate::core::plugin_api::{AlbumInfo, ArtistInfo, PlaylistInfo, SearchResults, TrackInfo};
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 /// The source the UI is currently scoped to — which catalog the sidebar, search
 /// and capability gating reflect.
@@ -35,7 +36,11 @@ use anyhow::Result;
 /// build (including the slim `telemetry`-only CI build) so handlers and UI code
 /// never need `#[cfg]`. Only the per-source *data loading* is gated behind that
 /// source's feature (`local-files`, `subsonic`).
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+///
+/// The serde derives are the action-vocabulary wire shape; the derived unit-
+/// variant strings coincide with the `to_config_str()` tokens, while the
+/// `state.yml` persistence keeps its own lenient hand-written helpers.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub enum Source {
   #[default]
   Spotify,

--- a/src/tui/handlers/ai_dj.rs
+++ b/src/tui/handlers/ai_dj.rs
@@ -9,6 +9,7 @@
 //!   CJK or emoji prompt keeps its caret in the right place.
 
 use super::common_key_events;
+use crate::core::action::{Action, LibraryTarget};
 use crate::core::app::{ActiveBlock, App, RouteId};
 use crate::infra::dj::setup::{DjSetup, DjSetupChoice, DjSetupStep};
 use crate::infra::dj::{AskDjRequest, DjLine, TurnKind, MAX_BATCH};
@@ -266,36 +267,11 @@ pub fn toggle_auto_queue(app: &mut App) {
 }
 
 /// Open the DJ screen, warming the library index if the filter is already on.
-///
-/// Every entry point goes through here so the crawl is never left to the resolve
-/// step. `behavior.dj_avoid_library: true` seeds the toggle without going through
-/// `toggle_fresh_only`, so without this the first turn of such a session would
-/// crawl inline on the serial IoEvent lane — head-of-line blocking every other
-/// event behind a few seconds of pagination.
+/// The whole consequence lives on `App` (`open_ai_dj_screen`) and is reached
+/// through the shared `Action::OpenLibrary(LibraryTarget::AiDj)` vocabulary,
+/// so every entry point (key, library row) fires the same sequence.
 pub fn open(app: &mut App) {
-  // Pushed only when the DJ is not already the current route, for the reason
-  // `open_picker` documents: a second `RouteId::AiDj` on the stack turns the Esc
-  // that should leave the DJ into one that lands back on it. Reachable with the
-  // DJ already open because focus can be elsewhere — Left to the sidebar, then
-  // the open key or the sidebar's own "AI DJ" row — which is also why focus is
-  // restored rather than left where it was.
-  if app.get_current_route().id == RouteId::AiDj {
-    app.set_current_route_state(Some(ActiveBlock::AiDj), Some(ActiveBlock::AiDj));
-  } else {
-    app.push_navigation_stack(RouteId::AiDj, ActiveBlock::AiDj);
-  }
-  // Asked once, on the first visit, and only here because `open` is the single
-  // funnel every entry point goes through. Not in `first_run.rs`: that runs before
-  // the TUI, gated on the absence of client.yml, and would interrogate every user
-  // about coding agents even if they never open the DJ.
-  //
-  // An already-open picker is rebuilt rather than resumed. That state means the user
-  // left the screen by a route the picker's own Esc never saw (a mouse click on the
-  // sidebar), so its rows were detected against a session that has moved on.
-  if app.dj.setup.is_some() || !app.user_config.behavior.dj_is_configured() {
-    open_setup(app);
-  }
-  request_library_index(app);
+  app.apply(Action::OpenLibrary(LibraryTarget::AiDj));
 }
 
 /// Show the picker, whether or not the DJ screen is already open.
@@ -314,7 +290,7 @@ pub fn open_picker(app: &mut App) {
   } else {
     app.push_navigation_stack(RouteId::AiDj, ActiveBlock::AiDj);
   }
-  request_library_index(app);
+  app.request_dj_library_index();
   open_setup(app);
 }
 
@@ -549,13 +525,6 @@ fn commit(app: &mut App) {
   persist_dj_setup(app, &message);
 }
 
-/// Kick off the crawl unless it has already run or is running.
-fn request_library_index(app: &mut App) {
-  if app.dj.avoid_library && app.dj.library.is_none() && !app.dj.library_indexing {
-    app.dispatch(IoEvent::DjIndexLibrary);
-  }
-}
-
 /// Toggle "only tracks I do not already have".
 ///
 /// Switching it on kicks off the playlist crawl straight away rather than waiting
@@ -566,7 +535,7 @@ pub fn toggle_fresh_only(app: &mut App) {
   app.dj.avoid_library = !app.dj.avoid_library;
   if app.dj.avoid_library {
     app.set_status_message("DJ: only tracks you don't already have", 4);
-    request_library_index(app);
+    app.request_dj_library_index();
   } else {
     app.set_status_message("DJ: recommending from everything", 4);
   }

--- a/src/tui/handlers/input.rs
+++ b/src/tui/handlers/input.rs
@@ -1,7 +1,7 @@
 extern crate unicode_width;
 
+use crate::core::action::{Action, OpenTarget};
 use crate::core::app::{ActiveBlock, App, InputContext, RouteId};
-use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
 use rspotify::prelude::Id;
 use std::convert::TryInto;
@@ -123,17 +123,9 @@ fn process_input(app: &mut App, input: String) {
     return;
   }
 
-  // Default fallback behavior: treat the input as a raw search phrase, routed to
-  // the active source's catalog.
-  if app.active_source == crate::core::source::Source::Subsonic {
-    app.dispatch(IoEvent::GetSubsonicSearchResults(input));
-  } else if app.active_source == crate::core::source::Source::Radio {
-    app.dispatch(IoEvent::GetRadioSearchResults(input));
-  } else if app.active_source == crate::core::source::Source::YouTube {
-    app.dispatch(IoEvent::GetYouTubeSearchResults(input));
-  } else {
-    app.dispatch(IoEvent::GetSearchResults(input, app.get_user_country()));
-  }
+  // Default fallback behavior: treat the input as a raw search phrase, routed
+  // to the active source's catalog.
+  app.apply(Action::SearchActiveSource(input));
   app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
   // push_navigation_stack is a no-op when the Search route is already on top, which
   // otherwise leaves focus trapped in the input box. Force focus onto the results so
@@ -155,12 +147,10 @@ fn process_playlist_track_search(app: &mut App, input: String) {
   }
 
   if let Some(playlist_id) = app.current_playlist_track_table_id() {
-    app.pending_playlist_track_search = Some(query.clone());
-    app.set_status_message(format!("Searching playlist for \"{query}\"..."), 60);
-    app.dispatch(IoEvent::SearchPlaylistTracks(
-      playlist_id.id().to_string(),
+    app.apply(Action::SearchPlaylistTracks {
+      playlist_id: playlist_id.id().to_string(),
       query,
-    ));
+    });
   }
 }
 
@@ -180,36 +170,37 @@ fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) ->
 fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> bool {
   let (album_id, matched) = spotify_resource_id(base, input, sep, "album");
   if matched {
-    app.dispatch(IoEvent::GetAlbum(album_id));
+    app.apply(Action::Open(OpenTarget::Album(album_id)));
     return true;
   }
 
   let (artist_id, matched) = spotify_resource_id(base, input, sep, "artist");
   if matched {
-    app.get_artist(artist_id, "".to_string());
+    app.apply(Action::Open(OpenTarget::Artist {
+      id: artist_id,
+      name: String::new(),
+    }));
     return true;
   }
 
   let (track_id, matched) = spotify_resource_id(base, input, sep, "track");
   if matched {
-    app.dispatch(IoEvent::GetAlbumForTrack(track_id));
+    app.apply(Action::Open(OpenTarget::TrackAlbum(track_id)));
     return true;
   }
 
   let (playlist_id, matched) = spotify_resource_id(base, input, sep, "playlist");
   if matched {
-    if let Some(playlist_id) = crate::infra::network::ids::playlist_id(&playlist_id) {
-      app.open_playlist_tracks(
-        playlist_id,
-        crate::core::app::TrackTableContext::MyPlaylists,
-      );
-    }
+    app.apply(Action::Open(OpenTarget::Playlist {
+      id: playlist_id,
+      from_search: false,
+    }));
     return true;
   }
 
   let (show_id, matched) = spotify_resource_id(base, input, sep, "show");
   if matched {
-    app.dispatch(IoEvent::GetShow(show_id));
+    app.apply(Action::Open(OpenTarget::Show(show_id)));
     return true;
   }
 
@@ -226,6 +217,7 @@ fn compute_character_width(character: char) -> u16 {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::infra::network::IoEvent;
   use rspotify::model::idtypes::PlaylistId;
   use rspotify::prelude::Id;
 

--- a/src/tui/handlers/library.rs
+++ b/src/tui/handlers/library.rs
@@ -1,8 +1,8 @@
 use super::common_key_events;
-use crate::core::app::{library_options, ActiveBlock, App, RouteId};
+use crate::core::action::{Action, LibraryTarget};
+use crate::core::app::{library_options, App};
 #[cfg(feature = "local-files")]
 use crate::core::source::Source;
-use crate::infra::network::IoEvent;
 use crate::tui::event::Key;
 
 pub fn handler(key: Key, app: &mut App) {
@@ -37,101 +37,46 @@ pub fn handler(key: Key, app: &mut App) {
     // `library` should probably be an array of structs with enums rather than just using indexes
     // like this
     Key::Enter => {
-      // Every feature-gated row is matched by NAME, before the positional arms
-      // below, because its index depends on which features are built in: with
-      // `local-files` off, "AI DJ" sits where "Local Files" sits without it. The
-      // positional arms cover only the rows that are always present.
-      #[cfg(feature = "ai-dj")]
-      if Some(app.library.selected_index) == library_options().iter().position(|o| *o == "AI DJ") {
-        super::ai_dj::open(app);
+      // Every row is resolved by NAME (through `LibraryTarget`), never by
+      // position: feature-gated rows shift the indices of everything after
+      // them, so a positional match silently remaps when features change.
+      let Some(name) = library_options().get(app.library.selected_index).copied() else {
         return;
-      }
+      };
+      let Some(target) = LibraryTarget::from_name(name) else {
+        return;
+      };
+
       #[cfg(feature = "local-files")]
-      if Some(app.library.selected_index)
-        == library_options().iter().position(|o| *o == "Local Files")
-      {
+      if target == LibraryTarget::LocalFiles {
         open_local_source(app);
         return;
       }
-      match app.library.selected_index {
-        // Discover
-        0 => {
-          app.push_navigation_stack(RouteId::Discover, ActiveBlock::Discover);
-        }
-        // Recently Played
-        1 => {
-          app.dispatch(IoEvent::GetRecentlyPlayed);
-          app.push_navigation_stack(RouteId::RecentlyPlayed, ActiveBlock::RecentlyPlayed);
-        }
-        // Friends
-        2 => {
-          app.push_navigation_stack(RouteId::Friends, ActiveBlock::Friends);
-          // Load friend code + friends list on first open (or if empty)
-          if app.friend_code.is_none() {
-            app.dispatch(IoEvent::GetFriendCode);
-          }
-          if app.friends.is_empty() && !app.friends_loading {
-            app.dispatch(IoEvent::GetFriends);
-          }
-          app.last_friends_refresh_at = std::time::Instant::now();
-        }
-        // Stats
-        3 => {
-          app.stats_loading = true;
-          app.dispatch(IoEvent::LoadListeningStats(app.stats_period));
-          app.push_navigation_stack(RouteId::Stats, ActiveBlock::Stats);
-        }
-        // Liked Songs
-        4 => {
-          app.reset_saved_tracks_view();
-          app.dispatch(IoEvent::GetCurrentSavedTracks(None));
-          app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
-        }
-        // Albums
-        5 => {
-          app.dispatch(IoEvent::GetCurrentUserSavedAlbums(None));
-          app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
-        }
-        // Artists
-        6 => {
-          app.dispatch(IoEvent::GetFollowedArtists(None));
-          app.push_navigation_stack(RouteId::Artists, ActiveBlock::Artists);
-        }
-        // Podcasts
-        7 => {
-          app.dispatch(IoEvent::GetCurrentUserSavedShows(None));
-          app.push_navigation_stack(RouteId::Podcasts, ActiveBlock::Podcasts);
-        }
-        // This is required because Rust can't tell if this pattern is exhaustive
-        _ => {}
-      }
+      app.apply(Action::OpenLibrary(target));
     }
     _ => (),
   };
 }
 
 /// Doubles as the "switch to Local source" shortcut: it flips the active source
-/// so the sidebar re-scopes to local folders, then opens the browser.
+/// so the sidebar re-scopes to local folders, then opens the browser. The
+/// sidebar cursor resets are presentation state and stay in the TUI.
 #[cfg(feature = "local-files")]
 fn open_local_source(app: &mut App) {
-  app.active_source = Source::Local;
-  // Mirror the persisted value so the selection survives restarts.
-  app.runtime_state.active_source = Source::Local;
-  if let Err(e) = app.save_runtime_state(&crate::core::state::PersistedRuntimeState::active_source(
-    app.runtime_state.active_source,
-  )) {
-    log::warn!("[source] failed to persist active_source: {e}");
-  }
+  use crate::infra::network::IoEvent;
   app.view.selected_playlist_index = Some(0);
   app.view.local_playlists_index = 0;
+  app.apply(Action::SelectSource(Source::Local));
   app.dispatch(IoEvent::GetLocalPlaylists);
-  app.push_navigation_stack(RouteId::LocalBrowser, ActiveBlock::LocalBrowser);
+  app.apply(Action::OpenLibrary(LibraryTarget::LocalFiles));
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::core::app::RouteId;
   use crate::core::user_config::UserConfig;
+  use crate::infra::network::IoEvent;
   use std::sync::mpsc::channel;
   use std::time::SystemTime;
 
@@ -168,5 +113,26 @@ mod tests {
       rx.try_recv(),
       Ok(IoEvent::GetCurrentSavedTracks(None))
     ));
+  }
+
+  #[cfg(feature = "local-files")]
+  #[test]
+  fn enter_on_local_files_switches_source_and_opens_the_browser() {
+    let index = library_options()
+      .iter()
+      .position(|o| *o == "Local Files")
+      .unwrap();
+    let (mut app, rx) = app_with_selection(index);
+    // The source switch persists; without a seeded path it would write the
+    // developer's real state.yml.
+    let dir = tempfile::tempdir().unwrap();
+    app.state_path = Some(dir.path().join("state.yml"));
+    handler(Key::Enter, &mut app);
+    assert_eq!(app.active_source, Source::Local);
+    assert_eq!(app.runtime_state.active_source, Source::Local);
+    assert_eq!(app.get_current_route().id, RouteId::LocalBrowser);
+    assert!(matches!(rx.try_recv(), Ok(IoEvent::GetLocalPlaylists)));
+    assert_eq!(app.view.selected_playlist_index, Some(0));
+    assert_eq!(app.view.local_playlists_index, 0);
   }
 }

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -1,9 +1,6 @@
 use super::common_key_events;
-use crate::core::app::{
-  ActiveBlock, App, DialogContext, PendingPlaylistTrackRemoval, PendingTrackSelection,
-  RecommendationsContext, RouteId, TrackTable, TrackTableContext,
-};
-use crate::infra::network::IoEvent;
+use crate::core::action::{Action, ListTarget};
+use crate::core::app::{App, PendingTrackSelection, TrackTable, TrackTableContext};
 use crate::tui::event::Key;
 use rspotify::prelude::Id;
 
@@ -26,7 +23,7 @@ pub fn handler(key: Key, app: &mut App) {
           Some(TrackTableContext::MyPlaylists) | Some(TrackTableContext::PlaylistSearch) => {
             if app.current_playlist_has_more_tracks() {
               app.pending_track_table_selection = Some(PendingTrackSelection::Index(tracks_len));
-              app.get_playlist_tracks_next();
+              app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
               return;
             }
             app.track_table.selected_index = 0;
@@ -38,7 +35,7 @@ pub fn handler(key: Key, app: &mut App) {
           Some(TrackTableContext::SavedTracks) => {
             if app.current_saved_tracks_has_more_tracks() {
               app.pending_track_table_selection = Some(PendingTrackSelection::Index(tracks_len));
-              app.get_current_user_saved_tracks_next();
+              app.apply(Action::LoadMore(ListTarget::SavedTracks));
               return;
             }
             app.track_table.selected_index = 0;
@@ -85,13 +82,12 @@ pub fn handler(key: Key, app: &mut App) {
       if let Some(context) = &app.track_table.context {
         match context {
           TrackTableContext::MyPlaylists | TrackTableContext::PlaylistSearch => {
-            if app.current_playlist_has_more_tracks() {
-              app.get_playlist_tracks_next();
-            }
+            // Self-guarding: a no-op when there is no next page.
+            app.apply(Action::LoadMore(ListTarget::PlaylistTracks));
           }
           TrackTableContext::RecommendedTracks => {}
           TrackTableContext::SavedTracks => {
-            app.get_current_user_saved_tracks_next();
+            app.apply(Action::LoadMore(ListTarget::SavedTracks));
           }
           TrackTableContext::AlbumSearch => {}
           TrackTableContext::DiscoverPlaylist => {}
@@ -122,8 +118,12 @@ pub fn handler(key: Key, app: &mut App) {
         }
       };
     }
-    Key::Char('w') => open_add_to_playlist_dialog(app),
-    Key::Char('x') => open_remove_from_playlist_dialog(app),
+    Key::Char('w') => {
+      app.apply(Action::OpenAddTrackDialog);
+    }
+    Key::Char('x') => {
+      app.apply(Action::OpenRemoveTrackDialog);
+    }
     Key::Char('q') if app.is_playlist_track_filter_active() => {
       app.clear_playlist_track_filter();
     }
@@ -144,107 +144,27 @@ pub fn handler(key: Key, app: &mut App) {
   }
 }
 
-fn open_add_to_playlist_dialog(app: &mut App) {
-  let track = match app.track_table.tracks.get(app.track_table.selected_index) {
-    Some(track) => track,
-    None => return,
+fn handle_save_track_event(app: &mut App) {
+  if let Some(track) = app.track_table.tracks.get(app.track_table.selected_index) {
+    if let Some(playable_id) = track.uri.clone() {
+      app.apply(Action::ToggleSaveTrack(playable_id));
+    }
   };
-
-  let track_id = track.id.clone();
-  let track_name = track.name.clone();
-  app.begin_add_track_to_playlist_flow(track_id, track_name);
 }
 
-fn open_remove_from_playlist_dialog(app: &mut App) {
-  // Local YouTube playlist: same confirm dialog, routed (by the
-  // `youtube:playlist:` prefix in the pending target) to the local file edit
-  // instead of the Spotify API. No snapshot position — removal is by video id.
-  if app.track_table.context == Some(TrackTableContext::YouTubePlaylist) {
-    let Some(playlist_uri) = app.youtube_open_playlist.clone() else {
-      app.set_status_message("No YouTube playlist is open".to_string(), 4);
-      return;
-    };
-    let playlist_name = app
-      .youtube_playlists
-      .iter()
-      .find(|p| p.uri == playlist_uri)
-      .map(|p| p.name.clone())
-      .unwrap_or_else(|| "YouTube playlist".to_string());
-    let Some(track) = app.track_table.tracks.get(app.track_table.selected_index) else {
-      return;
-    };
-    let Some(track_id) = track.id.clone() else {
-      app.set_status_message("Track cannot be edited in playlist".to_string(), 4);
-      return;
-    };
-    let track_name = track.name.clone();
-    app.clear_dialog_state();
-    app.pending_playlist_track_removal = Some(PendingPlaylistTrackRemoval {
-      playlist_id: playlist_uri,
-      playlist_name,
-      track_id,
-      track_name,
-      position: 0, // unused for local YouTube playlists
-    });
-    app.push_navigation_stack(
-      RouteId::Dialog,
-      ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm),
-    );
-    return;
-  }
-
-  let playlist_context = match current_playlist_target_for_track_table_context(app) {
-    Some(context) => context,
-    None => {
-      app.set_status_message(
-        "Remove only works in selected playlist views".to_string(),
-        4,
-      );
-      return;
-    }
-  };
-
-  let track = match app.track_table.tracks.get(app.track_table.selected_index) {
-    Some(track) => track,
-    None => return,
-  };
-
-  let track_id = match track.id.clone() {
-    Some(id) => id,
-    None => {
-      app.set_status_message("Track cannot be edited in playlist".to_string(), 4);
-      return;
-    }
-  };
-  let track_name = track.name.clone();
-
-  let position = match app
-    .playlist_track_positions
-    .as_ref()
-    .and_then(|positions| positions.get(app.track_table.selected_index))
-    .copied()
+fn handle_recommended_tracks(app: &mut App) {
+  if let Some(track) = app
+    .track_table
+    .tracks
+    .get(app.track_table.selected_index)
+    .cloned()
   {
-    Some(position) => position,
-    None => {
-      app.set_status_message("Cannot resolve track position for removal".to_string(), 4);
-      return;
-    }
+    app.apply(Action::RecommendFromTrack(track));
   };
-
-  app.clear_dialog_state();
-  app.pending_playlist_track_removal = Some(PendingPlaylistTrackRemoval {
-    playlist_id: playlist_context.0,
-    playlist_name: playlist_context.1,
-    track_id,
-    track_name,
-    position,
-  });
-  app.push_navigation_stack(
-    RouteId::Dialog,
-    ActiveBlock::Dialog(DialogContext::RemoveTrackFromPlaylistConfirm),
-  );
 }
 
+/// Play a random track from the table's context. Offsets are computed here so
+/// `apply` stays deterministic.
 fn play_random_song(app: &mut App) {
   if let Some(context) = &app.track_table.context {
     match context {
@@ -252,12 +172,14 @@ fn play_random_song(app: &mut App) {
         let context_id = current_playlist_context_id(app);
         let track_json = current_playlist_total_tracks(app);
 
-        if let Some(val) = track_json {
-          app.dispatch(IoEvent::StartPlayback(
-            context_id,
-            None,
-            Some(rand::random_range(0..val as usize)),
-          ));
+        // The no-id degenerate case (unreachable through normal navigation,
+        // since the table only opens with an id set) is skipped rather than
+        // dispatched as a bare resume with a random offset.
+        if let (Some(uri), Some(val)) = (context_id, track_json) {
+          app.apply(Action::PlayContext {
+            uri,
+            offset: Some(rand::random_range(0..val as usize)),
+          });
         }
       }
       TrackTableContext::RecommendedTracks => {}
@@ -270,11 +192,10 @@ fn play_random_song(app: &mut App) {
           .collect();
         if !playable_ids.is_empty() {
           let rand_idx = rand::random_range(0..playable_ids.len());
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(playable_ids),
-            Some(rand_idx),
-          ))
+          app.apply(Action::PlayUris {
+            uris: playable_ids,
+            offset: Some(rand_idx),
+          });
         }
       }
       TrackTableContext::AlbumSearch => {}
@@ -289,15 +210,19 @@ fn play_random_song(app: &mut App) {
         }
         if !playable_ids.is_empty() {
           let rand_idx = rand::random_range(0..playable_ids.len());
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(playable_ids),
-            Some(rand_idx),
-          ));
+          app.apply(Action::PlayUris {
+            uris: playable_ids,
+            offset: Some(rand_idx),
+          });
         }
       }
       TrackTableContext::LocalPlaylist | TrackTableContext::SubsonicPlaylist => {
         // Single-file playback: play one random track from the folder/playlist.
+        // Wire shape changed with the Action conversion: this used to send the
+        // track in the context slot (`StartPlayback(Some(uri), None, None)`).
+        // A one-item URI list is equivalent: the local, Subsonic and YouTube
+        // routers start a one-track queue at offset 0 for both shapes, and the
+        // queue router clears its slot on both.
         let playable_ids: Vec<String> = app
           .track_table
           .tracks
@@ -306,11 +231,10 @@ fn play_random_song(app: &mut App) {
           .collect();
         if !playable_ids.is_empty() {
           let rand_idx = rand::random_range(0..playable_ids.len());
-          app.dispatch(IoEvent::StartPlayback(
-            Some(playable_ids[rand_idx].clone()),
-            None,
-            None,
-          ));
+          app.apply(Action::PlayUris {
+            uris: vec![playable_ids[rand_idx].clone()],
+            offset: None,
+          });
         }
       }
       TrackTableContext::YouTubePlaylist => {
@@ -324,41 +248,13 @@ fn play_random_song(app: &mut App) {
           .collect();
         if !playable_ids.is_empty() {
           let rand_idx = rand::random_range(0..playable_ids.len());
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(playable_ids),
-            Some(rand_idx),
-          ));
+          app.apply(Action::PlayUris {
+            uris: playable_ids,
+            offset: Some(rand_idx),
+          });
         }
       }
     }
-  };
-}
-
-fn handle_save_track_event(app: &mut App) {
-  let (selected_index, tracks) = (&app.track_table.selected_index, &app.track_table.tracks);
-  if let Some(track) = tracks.get(*selected_index) {
-    if let Some(playable_id) = track.uri.clone() {
-      app.dispatch(IoEvent::ToggleSaveTrack(playable_id));
-    }
-  };
-}
-
-fn handle_recommended_tracks(app: &mut App) {
-  let (selected_index, tracks) = (&app.track_table.selected_index, &app.track_table.tracks);
-  if let Some(track) = tracks.get(*selected_index) {
-    let first_track = track.clone();
-    // NOTE: preserves a pre-existing bug. The previous code fed the track's
-    // full URI ("spotify:track:...") as the seed, which `TrackId::from_id`
-    // rejects, so the whole seed_tracks list collapses to `None` and the
-    // recommendation request goes out unseeded. `TrackInfo::uri` reproduces
-    // that exact URI string; switching to `track.id` (base62) would change
-    // behavior. Fix the seeding separately with its own verification.
-    let track_id_list = track.uri.clone().map(|uri| vec![uri]);
-
-    app.recommendations_context = Some(RecommendationsContext::Song);
-    app.recommendations_seed = first_track.name.clone();
-    app.get_recommendations_for_seed(None, track_id_list, Some(first_track));
   };
 }
 
@@ -386,19 +282,29 @@ fn on_enter(app: &mut App) {
           // If we have a track ID, play it directly within the context
           // This ensures the selected track plays first, even with shuffle on
           if let Some(playable_id) = track_playable_id {
-            app.dispatch(IoEvent::StartPlayback(
-              context_id,
-              Some(vec![playable_id]),
-              Some(0), // Play the first (and only) track in the URIs list
-            ));
-          } else {
+            if let Some(context_uri) = context_id {
+              app.apply(Action::PlayTrackInContext {
+                context: context_uri,
+                track: playable_id,
+              });
+            } else {
+              // Degenerate no-id case: the same context-less event this
+              // path has always sent.
+              app.apply(Action::PlayUris {
+                uris: vec![playable_id],
+                offset: Some(0), // Play the first (and only) track in the URIs list
+              });
+            }
+          } else if let Some(context_uri) = context_id {
             // Fallback to context playback with offset
-            app.dispatch(IoEvent::StartPlayback(
-              context_id,
-              None,
-              app.selected_playlist_track_position(),
-            ));
+            app.apply(Action::PlayContext {
+              uri: context_uri,
+              offset: app.selected_playlist_track_position(),
+            });
           }
+          // The no-id, no-uri degenerate case (unreachable through normal
+          // navigation) is skipped rather than dispatched as a bare resume
+          // with an offset.
         };
       }
       TrackTableContext::RecommendedTracks => {
@@ -415,20 +321,18 @@ fn on_enter(app: &mut App) {
         }
 
         if !playable_ids.is_empty() {
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(playable_ids),
-            Some(selected_offset.unwrap_or(0)),
-          ));
+          app.apply(Action::PlayUris {
+            uris: playable_ids,
+            offset: Some(selected_offset.unwrap_or(0)),
+          });
         }
       }
       TrackTableContext::SavedTracks => {
         if let Some((all_playable_ids, absolute_offset)) = saved_tracks_playback_request(app) {
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(all_playable_ids),
-            Some(absolute_offset),
-          ));
+          app.apply(Action::PlayUris {
+            uris: all_playable_ids,
+            offset: Some(absolute_offset),
+          });
         }
       }
       TrackTableContext::AlbumSearch => {}
@@ -447,11 +351,10 @@ fn on_enter(app: &mut App) {
         }
 
         if !playable_ids.is_empty() {
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(playable_ids),
-            Some(selected_offset.unwrap_or(0)),
-          ));
+          app.apply(Action::PlayUris {
+            uris: playable_ids,
+            offset: Some(selected_offset.unwrap_or(0)),
+          });
         }
       }
       TrackTableContext::LocalPlaylist
@@ -465,11 +368,10 @@ fn on_enter(app: &mut App) {
         if !uris.is_empty() {
           // `selected_index` is into the full track list; the filter above keeps
           // every track (each carries a uri), so the index lines up.
-          app.dispatch(IoEvent::StartPlayback(
-            None,
-            Some(uris),
-            Some(*selected_index),
-          ));
+          app.apply(Action::PlayUris {
+            uris,
+            offset: Some(*selected_index),
+          });
         }
       }
     }
@@ -498,40 +400,6 @@ fn on_queue(app: &mut App) {
 
 fn jump_to_start(app: &mut App) {
   app.track_table.selected_index = 0;
-}
-
-/// The active playlist's base62 id (from the playlist track-table context).
-fn current_playlist_id_static(app: &App) -> Option<String> {
-  app
-    .current_playlist_track_table_id()
-    .map(|id| id.id().to_string())
-}
-
-fn current_playlist_target_for_track_table_context(app: &App) -> Option<(String, String)> {
-  let playlist_id = current_playlist_id_static(app)?;
-  let playlist_name = playlist_name_for_id(app, &playlist_id)?;
-  Some((playlist_id, playlist_name))
-}
-
-fn playlist_name_for_id(app: &App, playlist_id: &str) -> Option<String> {
-  app
-    .all_playlists
-    .iter()
-    .find(|playlist| playlist.id.as_deref() == Some(playlist_id))
-    .map(|playlist| playlist.name.clone())
-    .or_else(|| {
-      app
-        .search_results
-        .playlists
-        .as_ref()
-        .and_then(|playlists| {
-          playlists
-            .items
-            .iter()
-            .find(|playlist| playlist.id.as_deref() == Some(playlist_id))
-        })
-        .map(|playlist| playlist.name.clone())
-    })
 }
 
 /// The active playlist's `spotify:playlist:` context URI, for `StartPlayback`.
@@ -566,6 +434,7 @@ mod tests {
   use crate::core::plugin_api::{PlayableInfo, TrackInfo};
   use crate::core::test_helpers::full_track;
   use crate::core::user_config::UserConfig;
+  use crate::infra::network::IoEvent;
   use chrono::Utc;
   use rspotify::model::{idtypes::PlaylistId, page::Page, track::SavedTrack};
   use std::sync::mpsc::channel;
@@ -904,6 +773,35 @@ mod tests {
       IoEvent::GetCurrentSavedTracks(Some(offset)) => assert_eq!(offset, 2),
       other => panic!("unexpected event: {:?}", event_name(&other)),
     }
+  }
+
+  #[test]
+  fn next_page_on_saved_tracks_dispatches_without_moving_the_cursor() {
+    let (mut app, rx) = app_with_saved_tracks();
+    let page = saved_tracks_page(
+      0,
+      &["0000000000000000000001", "0000000000000000000002"],
+      true,
+    );
+    // Seeded through App methods and a key press, not field writes: the
+    // handler write counter scans this whole file, tests included.
+    app.library.saved_tracks.upsert_page_by_offset(page);
+    app.set_saved_tracks_to_table_continuous();
+    handler(Key::Down, &mut app);
+    assert_eq!(app.track_table.selected_index, 1);
+    assert!(rx.try_recv().is_err(), "a mid-list Down fetches nothing");
+
+    handler(Key::Ctrl('d'), &mut app);
+
+    // next_page fetches but does NOT set pending selection: the cursor
+    // clamps into the loaded rows instead of following into the new page
+    // (that follow is the down-at-last-row path's behavior).
+    assert_eq!(app.pending_track_table_selection, None);
+    match rx.recv().unwrap() {
+      IoEvent::GetCurrentSavedTracks(Some(offset)) => assert_eq!(offset, 2),
+      other => panic!("unexpected event: {:?}", event_name(&other)),
+    }
+    assert_eq!(app.track_table.selected_index, 1);
   }
 
   #[test]

--- a/src/tui/handlers/track_table.rs
+++ b/src/tui/handlers/track_table.rs
@@ -174,8 +174,13 @@ fn play_random_song(app: &mut App) {
 
         // The no-id degenerate case (unreachable through normal navigation,
         // since the table only opens with an id set) is skipped rather than
-        // dispatched as a bare resume with a random offset.
+        // dispatched as a bare resume with a random offset. An empty playlist
+        // reports a total of 0, and `random_range(0..0)` panics, so that is
+        // skipped too.
         if let (Some(uri), Some(val)) = (context_id, track_json) {
+          if val == 0 {
+            return;
+          }
           app.apply(Action::PlayContext {
             uri,
             offset: Some(rand::random_range(0..val as usize)),
@@ -646,6 +651,34 @@ mod tests {
       other => panic!("unexpected event: {:?}", event_name(&other)),
     }
     assert!(app.native_queue.is_empty());
+  }
+
+  #[test]
+  fn random_play_on_an_empty_playlist_does_nothing() {
+    let (tx, rx) = channel();
+    let mut app = App::new(tx, UserConfig::new(), Some(SystemTime::now()));
+    // Seeded through App methods, not field writes: the handler write counter
+    // scans this whole file. The open dispatches the first page fetch.
+    app.open_playlist_tracks(
+      PlaylistId::from_id("37i9dQZF1DX4WYpdgoIcn6")
+        .unwrap()
+        .into_static(),
+      TrackTableContext::MyPlaylists,
+    );
+    assert!(rx.try_recv().is_ok(), "the open fetched its first page");
+    app.playlist_track_pages.upsert_page_by_offset(Paged {
+      items: vec![],
+      limit: 50,
+      next: None,
+      offset: 0,
+      previous: None,
+      total: 0,
+    });
+
+    // `random_range(0..0)` panics; the guard must skip the start instead.
+    handler(Key::Char('S'), &mut app);
+
+    assert!(rx.try_recv().is_err(), "an empty playlist starts nothing");
   }
 
   #[test]

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -7,14 +7,12 @@ use crate::tui::handlers;
 use crate::tui::ui;
 use anyhow::{anyhow, Result};
 use crossterm::{
-  cursor::MoveTo,
   event::{
     DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
     PushKeyboardEnhancementFlags,
   },
   execute,
   terminal::{supports_keyboard_enhancement, SetTitle},
-  ExecutableCommand,
 };
 use log::info;
 use ratatui::backend::Backend;
@@ -420,6 +418,14 @@ pub async fn start_ui(
       #[cfg(feature = "cover-art")]
       crate::tui::cover_art::sync(&app.cover_art);
 
+      // The cursor must be invisible while the frame diff is written. Ratatui
+      // applies the diff first and shows or hides the cursor afterwards, so a
+      // cursor left visible by the previous frame travels over every freshly
+      // written cell run and shows up as a strobing block inside the animated
+      // banner. Hide it here; the draw closure below re-shows it at the input
+      // position after the write.
+      terminal.hide_cursor()?;
+
       terminal.draw(|f| {
         use ratatui::{prelude::Style, widgets::Block};
         f.render_widget(
@@ -462,20 +468,20 @@ pub async fn start_ui(
 
         // Plugin popup overlays every screen.
         ui::draw_plugin_popup(f, &app);
+
+        // Cursor management lives inside the frame: ratatui shows and moves the
+        // terminal cursor when a widget requests a position and hides it when
+        // none does. The old post-draw hide/show pair ran on every animation
+        // frame (16 ms on Home), and the alternating toggle reset the
+        // terminal's blink phase each frame, so the cursor strobed.
+        if current_route.active_block == ActiveBlock::Input {
+          let cursor_offset = crate::tui::layout::main_layout_margin(&app) + 1;
+          f.set_cursor_position((
+            cursor_offset + app.view.input_cursor_position - app.view.input_scroll_offset.get(),
+            cursor_offset,
+          ));
+        }
       })?;
-
-      if current_route.active_block == ActiveBlock::Input {
-        terminal.show_cursor()?;
-      } else {
-        terminal.hide_cursor()?;
-      }
-
-      let cursor_offset = crate::tui::layout::main_layout_margin(&app) + 1;
-
-      terminal.backend_mut().execute(MoveTo(
-        cursor_offset + app.view.input_cursor_position - app.view.input_scroll_offset.get(),
-        cursor_offset,
-      ))?;
 
       driver.next_window_title(&app)
     };

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -86,6 +86,20 @@ fn key_reaches_handlers_before_back(app: &App, key: Key) -> bool {
   help_menu_captures_key_before_back(app, key)
 }
 
+/// Where the terminal cursor goes in this frame: inside the search box while
+/// the input block is focused, `None` (hidden) on every other screen. The
+/// frame applies it through `Frame::set_cursor_position`.
+fn frame_cursor_position(app: &App, active_block: ActiveBlock) -> Option<(u16, u16)> {
+  if active_block != ActiveBlock::Input {
+    return None;
+  }
+  let cursor_offset = crate::tui::layout::main_layout_margin(app) + 1;
+  Some((
+    cursor_offset + app.view.input_cursor_position - app.view.input_scroll_offset.get(),
+    cursor_offset,
+  ))
+}
+
 /// One keypress, from the runner's event loop. Returns `true` when the user asked
 /// to quit and the loop must break.
 ///
@@ -195,6 +209,33 @@ mod tests {
   // `help_menu_captures_key_before_back` directly. On the Help route the two agree,
   // but only the outer one fails when Help stops being wired into the gate at all,
   // which is the way this protection would realistically be lost.
+  #[test]
+  fn input_frame_places_the_cursor_after_the_visible_prefix() {
+    let mut app = app();
+    app.view.input_cursor_position = 7;
+    app.view.input_scroll_offset.set(2);
+    let offset = crate::tui::layout::main_layout_margin(&app) + 1;
+
+    assert_eq!(
+      frame_cursor_position(&app, ActiveBlock::Input),
+      Some((offset + 5, offset))
+    );
+  }
+
+  #[test]
+  fn non_input_frames_leave_the_cursor_hidden() {
+    let mut app = app();
+    app.view.input_cursor_position = 7;
+
+    for block in [
+      ActiveBlock::Home,
+      ActiveBlock::TrackTable,
+      ActiveBlock::Library,
+    ] {
+      assert_eq!(frame_cursor_position(&app, block), None);
+    }
+  }
+
   #[test]
   fn help_filter_captures_back_key_while_editing() {
     let mut app = app();
@@ -474,12 +515,8 @@ pub async fn start_ui(
         // none does. The old post-draw hide/show pair ran on every animation
         // frame (16 ms on Home), and the alternating toggle reset the
         // terminal's blink phase each frame, so the cursor strobed.
-        if current_route.active_block == ActiveBlock::Input {
-          let cursor_offset = crate::tui::layout::main_layout_margin(&app) + 1;
-          f.set_cursor_position((
-            cursor_offset + app.view.input_cursor_position - app.view.input_scroll_offset.get(),
-            cursor_offset,
-          ));
+        if let Some(position) = frame_cursor_position(&app, current_route.active_block) {
+          f.set_cursor_position(position);
         }
       })?;
 

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -13,4 +13,4 @@ synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
 action_refs_in_tui_handlers = 54       # adoption: may only rise
-test_attribute_total = 1511            # adoption: may only rise
+test_attribute_total = 1515            # adoption: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -7,10 +7,10 @@
 # the two adoption counters may only rise.
 
 crate_tui_refs_outside_tui = 2         # target 0
-app_field_writes_in_tui_handlers = 386 # target 0 (writes into app.view do not count)
-ioevent_refs_in_tui = 125              # target 0
+app_field_writes_in_tui_handlers = 378 # target 0 (writes into app.view do not count)
+ioevent_refs_in_tui = 98              # target 0
 synthetic_keys_in_mouse_handler = 15   # target 0 (13 production + 2 test sites)
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
-action_refs_in_tui_handlers = 22       # adoption: may only rise
-test_attribute_total = 1471            # adoption: may only rise
+action_refs_in_tui_handlers = 54       # adoption: may only rise
+test_attribute_total = 1511            # adoption: may only rise


### PR DESCRIPTION
# Summary

Converts the three densest list handlers (`track_table.rs`, `library.rs`, `input.rs`, plus `ai_dj::open`) to the shared `Action` vocabulary, so every non-cursor consequence of a key press is one `app.apply(Action::…)` line.

- 10 new `Action` variants: `PlayTrackInContext`, `SearchActiveSource`, `SearchPlaylistTracks`, `LoadMore(ListTarget)`, `Open(OpenTarget)`, `OpenLibrary(LibraryTarget)`, `SelectSource(Source)`, `OpenAddTrackDialog`, `OpenRemoveTrackDialog`, `RecommendFromTrack(TrackInfo)`.
- `LoadMore` is the shared "hit the end of the list" consequence; it is self-guarding (no next page, active filter, or in-flight page all make it a no-op).
- Library sidebar rows resolve by name through `LibraryTarget::from_name` instead of by position, so feature-gated rows no longer shift the indices of everything after them.
- The moved consequences live on `App`: `open_library_section`, `begin_add_track_to_playlist_flow_from_selection`, `begin_remove_track_from_playlist_flow`, `set_active_source`, `load_recommendations_for_track`, `open_ai_dj_screen`, `start_playback_track_in_context`.
- `Action::Search` stays on the Spotify catalog (the Lua `spotatui.search` contract). The terminal search box uses `SearchActiveSource`, which routes by the active browse source.
- `Source` gains serde derives (the action wire shape).
- Rider: the search-box cursor flickered at the 16 ms Home animation tick. The cursor is now hidden before the draw and positioned from inside the frame.

Three deliberate behavior changes, all in `track_table.rs`, everything else is 1:1:

1. Random play (`S`) in a playlist table with no context id is skipped instead of sent as a bare resume with a random offset.
2. Enter on a playlist row with no track id and no context id is skipped likewise.
3. Random play in a Local or Subsonic playlist sends a one-item URI list instead of the track in the context slot. All four source routers treat both shapes as a one-track queue at offset 0.

Both cases 1 and 2 are unreachable through normal navigation (the table only opens with an id set).

Gates: `app_field_writes_in_tui_handlers` 386 -> 378, `ioevent_refs_in_tui` 125 -> 98, `action_refs_in_tui_handlers` 22 -> 54, `test_attribute_total` 1471 -> 1511.

# Testing

On Windows:

- `cargo fmt --all -- --check`: clean
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`: clean
- `cargo test --no-default-features --features telemetry,tui`: 727 passed
- `cargo check --no-default-features --features telemetry` (headless): clean
- `cargo check --no-default-features --features telemetry,tui,ai-dj`: clean
- `cargo test --no-default-features --features telemetry,tui,local-files,subsonic,internet-radio,youtube`: 808 passed, 1 failed (the known pre-existing Windows `uri_round_trip`)
- `tools/check_gates_ratchet.sh main`: ok
- The cursor fix was confirmed in the running app: the caret sits still in the search box on the Home screen with the banner animation on.

41 new tests in `core/action/tests.rs` cover every new arm differentially (the `IoEvent` each arm dispatches, the state it sets, and the no-op guards).

# Additional notes

- `OpenTarget::Playlist { from_search: true }` has no producer yet; the search-result handler adopts it in the next conversion batch.
- `select_device.rs` still hand-writes the source switch; it moves to `Action::SelectSource` with the remaining handler files.
- A test that switches the source must seed `app.state_path`; `App::new` leaves it `None` and `save_runtime_state` then writes the real `state.yml`. The one such test here seeds a tempdir.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded library navigation for playlists, albums, artists, shows, local files, and AI DJ.
  * Added source-aware searches, playlist-track searches, pagination, and track-based recommendations.
  * Added playlist track add/remove workflows with confirmation dialogs.
  * Added music-source switching and context-aware track playback.
  * Improved AI DJ setup and library indexing.

* **Bug Fixes**
  * Fixed terminal cursor flickering during animated screen updates.
  * Improved handling of empty playlists and invalid navigation selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->