### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,40 @@ jobs:
           command: test
           args: ${{ matrix.args }}
 
+  # Line coverage for Codecov. One leg only: the all-sources feature set, so
+  # the report covers every subsystem that ships in the Linux release. Keep the
+  # feature list identical to the all-sources row above. The coverage build
+  # uses its own instrumentation flags, so it does not share the test job's
+  # cache. Fork pull requests have no secret and upload tokenless. A failed
+  # upload never turns the job red: coverage is a report, not a gate.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: prepare
+    env:
+      RUSTFLAGS: "-C linker-features=-lld"
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: llvm-tools-preview
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq pkg-config libssl-dev libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libpipewire-0.3-dev libspa-0.2-dev libasound2-dev
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests with coverage
+        run: cargo llvm-cov --locked --no-default-features --features telemetry,tui,streaming,discord-rpc,cover-art,self-update,scripting,mcp-server,ai-dj,audio-viz,mpris,local-files,subsonic,internet-radio,youtube --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,10 @@ jobs:
       RUSTFLAGS: "-C linker-features=-lld"
     steps:
       - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
           components: llvm-tools-preview
       - run: |
           sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 </p>
 
 [![Crates.io](https://img.shields.io/crates/v/spotatui.svg)](https://crates.io/crates/spotatui)
+[![codecov](https://codecov.io/gh/LargeModGames/spotatui/graph/badge.svg)](https://codecov.io/gh/LargeModGames/spotatui)
 [![Discord](https://img.shields.io/discord/1534820237122207815?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://spotatui.com/discord)
 [![Upstream](https://img.shields.io/badge/upstream-Rigellute%2Fspotify--tui-blue)](https://github.com/Rigellute/spotify-tui)
 [![X](https://img.shields.io/badge/@LargeModGames-000000?logo=x&logoColor=white)](https://twitter.com/LargeModGames)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,12 @@
-# Codecov settings. Both statuses are informational: they report on the pull
-# request but never fail it. Flip `informational` to false once the baseline
-# is stable and a coverage floor is wanted.
-coverage:
-  status:
+# Codecov settings, modelled on ratatui's codecov.yml.
+# Both statuses are informational: they report on the pull request but never
+# fail it. Flip `informational` to false once the baseline is stable and a
+# coverage floor is wanted.
+coverage: # https://docs.codecov.com/docs/codecovyml-reference#coverage
+  precision: 1 # e.g. 89.1%
+  round: down
+  range: 85..100 # https://docs.codecov.com/docs/coverage-configuration#section-range
+  status: # https://docs.codecov.com/docs/commit-status
     project:
       default:
         informational: true
@@ -10,6 +14,6 @@ coverage:
       default:
         informational: true
 
-comment:
-  layout: "condensed_header, diff, files"
+comment: # https://docs.codecov.com/docs/pull-request-comments
+  # make the comments less noisy
   require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Codecov settings. Both statuses are informational: they report on the pull
+# request but never fail it. Flip `informational` to false once the baseline
+# is stable and a coverage floor is wanted.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true


### PR DESCRIPTION
# Summary

Adds line coverage to CI and uploads it to Codecov.

- A new `Coverage` job in `ci.yml` runs the tests with `cargo-llvm-cov` on the `all-sources` feature set (the Linux release set) and uploads `lcov.info` with `codecov/codecov-action@v5`. `fail_ci_if_error` is `false`: a failed upload never turns the job red, and `Coverage` is not a required check. Coverage is a report, not a gate.
- A root `codecov.yml` makes both the `project` and the `patch` statuses informational, so a PR never goes red on coverage. The PR comment is condensed and only appears when coverage changes.
- A Codecov badge in the README.

# Testing

- The workflow file was parsed with js-yaml; all seven jobs load and the `coverage` steps resolve as expected.
- `codecov.yml` was validated with `https://codecov.io/validate` (result: `Valid!`).
- The coverage build itself was not run locally: the `all-sources` set includes `audio-viz` (PipeWire), which only compiles on Linux. The first CI run on this PR is the test.

# Additional notes

- The `CODECOV_TOKEN` Actions secret is set. Dependabot PRs do not see Actions secrets, so they get no coverage report; their other jobs are unaffected. A Dependabot secret can be added later if wanted.
- The feature list in the `coverage` job is a fourth copy of the `all-sources` string and must stay in sync with the other three and with `cd.yml`.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI & Quality**
  * Added automated code coverage reporting to continuous integration.
  * Coverage results are uploaded to Codecov for visibility.

* **Documentation**
  * Added a coverage status badge to the project README.

* **Reporting**
  * Configured coverage precision, rounding, and an 85–100% reporting range.
  * Kept project and change coverage statuses informational.
  * Updated pull-request coverage comments to highlight required changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->