### PR TITLE
feat(core): typed bootstrap onboarding requests

### DIFF
--- a/src/core/onboarding.rs
+++ b/src/core/onboarding.rs
@@ -13,8 +13,52 @@
 
 use crate::core::source::Source;
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// The 58-character rule line both first-run banners draw.
+pub(crate) const BANNER_RULE: &str = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+
+/// A typed question a caller needs answered before it can continue. The
+/// frontend owns presentation and input parsing; callers never interpret
+/// prompt prose.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OnboardingPrompt {
+  /// A yes/no question. The terminal frontend draws the banner rule around
+  /// `title`, then `body`, then asks `question` on its own line.
+  Confirm {
+    title: String,
+    body: String,
+    question: String,
+  },
+}
+
+/// The typed answer to [`OnboardingPrompt::Confirm`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OnboardingAnswer {
+  Yes,
+  No,
+}
+
+/// Parse one raw console line for [`OnboardingPrompt::Confirm`]: empty input,
+/// `y`, or `yes` (case-insensitive) means yes; anything else means no.
+pub(crate) fn confirm_answer(raw: &str) -> OnboardingAnswer {
+  match raw.trim().to_lowercase().as_str() {
+    "" | "y" | "yes" => OnboardingAnswer::Yes,
+    _ => OnboardingAnswer::No,
+  }
+}
 
 pub trait Onboarding: Send + Sync {
+  /// Whether this frontend can ask questions at all. The terminal frontend
+  /// checks stdin and stdout; a windowed frontend answers true while its
+  /// event loop runs.
+  fn is_interactive(&self) -> bool;
+
+  /// Ask one typed question and wait for the answer. Blocking on the
+  /// terminal frontend; a windowed frontend bridges to its event loop from
+  /// a blocking thread.
+  fn ask(&self, prompt: &OnboardingPrompt) -> Result<OnboardingAnswer>;
+
   /// Show one informational message, terminated like a line (a `println!` on
   /// the console). Multi-line text is passed whole.
   fn info(&self, text: &str);
@@ -36,4 +80,20 @@ pub trait Onboarding: Send + Sync {
   /// user cancelled or confirmed with nothing selected (the caller falls
   /// through to the Spotify wizard, matching the historical default).
   fn pick_sources(&self, options: &[Source]) -> Result<Option<Vec<Source>>>;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn confirm_answer_treats_empty_y_and_yes_as_yes() {
+    assert_eq!(confirm_answer(""), OnboardingAnswer::Yes);
+    assert_eq!(confirm_answer("\n"), OnboardingAnswer::Yes);
+    assert_eq!(confirm_answer(" y "), OnboardingAnswer::Yes);
+    assert_eq!(confirm_answer("YES\n"), OnboardingAnswer::Yes);
+    assert_eq!(confirm_answer("n"), OnboardingAnswer::No);
+    assert_eq!(confirm_answer("no"), OnboardingAnswer::No);
+    assert_eq!(confirm_answer("banana"), OnboardingAnswer::No);
+  }
 }

--- a/src/core/test_helpers.rs
+++ b/src/core/test_helpers.rs
@@ -191,14 +191,14 @@ impl crate::core::onboarding::Onboarding for ScriptedOnboarding {
     &self,
     prompt: &crate::core::onboarding::OnboardingPrompt,
   ) -> anyhow::Result<crate::core::onboarding::OnboardingAnswer> {
-    use crate::core::onboarding::{confirm_answer, OnboardingAnswer, OnboardingPrompt};
+    use crate::core::onboarding::{confirm_answer, OnboardingPrompt};
     self.asked.lock().unwrap().push(prompt.clone());
     // Record what the terminal impl would render, so `saw` can pin the text.
-    if let OnboardingPrompt::Confirm {
+    let OnboardingPrompt::Confirm {
       title,
       body,
       question,
-    } = prompt
+    } = prompt;
     {
       let mut shown = self.shown.lock().unwrap();
       shown.push(title.clone());

--- a/src/core/test_helpers.rs
+++ b/src/core/test_helpers.rs
@@ -130,6 +130,8 @@ pub fn full_track(id: &str, name: &str) -> FullTrack {
 pub struct ScriptedOnboarding {
   answers: std::sync::Mutex<std::collections::VecDeque<String>>,
   pub shown: std::sync::Mutex<Vec<String>>,
+  pub asked: std::sync::Mutex<Vec<crate::core::onboarding::OnboardingPrompt>>,
+  interactive: bool,
 }
 
 impl ScriptedOnboarding {
@@ -137,7 +139,17 @@ impl ScriptedOnboarding {
     Self {
       answers: std::sync::Mutex::new(answers.iter().map(|answer| format!("{answer}\n")).collect()),
       shown: std::sync::Mutex::new(Vec::new()),
+      asked: std::sync::Mutex::new(Vec::new()),
+      interactive: true,
     }
+  }
+
+  /// A double for the non-interactive path (`is_interactive` reports false),
+  /// matching what a windowed or piped frontend would see.
+  pub fn non_interactive(answers: &[&str]) -> Self {
+    let mut onboarding = Self::with_answers(answers);
+    onboarding.interactive = false;
+    onboarding
   }
 
   pub fn saw(&self, text: &str) -> bool {
@@ -169,5 +181,36 @@ impl crate::core::onboarding::Onboarding for ScriptedOnboarding {
     _options: &[crate::core::source::Source],
   ) -> anyhow::Result<Option<Vec<crate::core::source::Source>>> {
     Ok(None)
+  }
+
+  fn is_interactive(&self) -> bool {
+    self.interactive
+  }
+
+  fn ask(
+    &self,
+    prompt: &crate::core::onboarding::OnboardingPrompt,
+  ) -> anyhow::Result<crate::core::onboarding::OnboardingAnswer> {
+    use crate::core::onboarding::{confirm_answer, OnboardingAnswer, OnboardingPrompt};
+    self.asked.lock().unwrap().push(prompt.clone());
+    // Record what the terminal impl would render, so `saw` can pin the text.
+    if let OnboardingPrompt::Confirm {
+      title,
+      body,
+      question,
+    } = prompt
+    {
+      let mut shown = self.shown.lock().unwrap();
+      shown.push(title.clone());
+      shown.push(body.clone());
+      shown.push(question.clone());
+    }
+    let answer = self
+      .answers
+      .lock()
+      .unwrap()
+      .pop_front()
+      .ok_or_else(|| anyhow::anyhow!("script ran out of answers for prompt {prompt:?}"))?;
+    Ok(confirm_answer(&answer))
   }
 }

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -11,7 +11,7 @@ use crate::core::limits::MAX_PLAYBAR_ROWS;
 use crate::core::migrations::{
   apply_legacy_config_radio_station_migration, apply_legacy_config_runtime_state_migration,
 };
-use crate::core::onboarding::Onboarding;
+use crate::core::onboarding::{Onboarding, OnboardingAnswer, OnboardingPrompt};
 use crate::core::state::{PersistedRuntimeState, RuntimeState};
 use crate::core::user_config::{
   validate_tick_rate_milliseconds, BehaviorConfig, StartupBehavior, UserConfig, UserConfigPaths,
@@ -26,9 +26,9 @@ use rspotify::model::user::PrivateUser;
 use rspotify::AuthCodePkceSpotify;
 use std::{
   fs,
-  io::{self, Write},
+  io::Write,
   panic,
-  path::PathBuf,
+  path::{Path, PathBuf},
   sync::Arc,
 };
 use tokio::sync::Mutex;
@@ -208,9 +208,10 @@ fn describe_client_id_notice(notice: auth::ClientIdNotice) -> String {
 /// choice into `config.yml`. Asked before the first-run source picker so the
 /// answer applies to whichever source(s) the user sets up. Non-interactive runs
 /// default to opt-out so telemetry is never enabled for a user we couldn't ask.
-fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
-  use std::io::IsTerminal;
-
+fn prompt_global_song_count_opt_in(
+  user_config: &mut UserConfig,
+  onboarding: &dyn Onboarding,
+) -> Result<()> {
   let config_paths = match &user_config.path_to_config {
     Some(path) => path,
     None => {
@@ -234,29 +235,16 @@ fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
     !config_string.trim().is_empty() && config_string.contains("enable_global_song_count")
   };
 
-  let should_prompt = !client_yml_exists || !config_has_answer;
-
-  if !should_prompt {
+  if !should_prompt_global_song_count(client_yml_exists, config_has_answer) {
     return Ok(());
   }
 
-  let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+  let interactive = onboarding.is_interactive();
   let enable = if interactive {
-    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    println!("Global Song Counter");
-    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    println!("\nspotatui can contribute to a global counter showing total");
-    println!("songs played by all users worldwide.");
-    println!("\nPrivacy: This feature is completely anonymous.");
-    println!("• No personal information is collected");
-    println!("• No song names, artists, or listening history");
-    println!("• Only a simple increment when a new song starts");
-    println!("\nWould you like to participate? (Y/n): ");
-
-    let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-    let input = input.trim().to_lowercase();
-    input.is_empty() || input == "y" || input == "yes"
+    matches!(
+      onboarding.ask(&global_song_counter_prompt())?,
+      OnboardingAnswer::Yes
+    )
   } else {
     // Never enable anonymous telemetry for a user we couldn't prompt.
     false
@@ -264,8 +252,58 @@ fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
 
   user_config.behavior.enable_global_song_count = enable;
 
-  let config_yml = if config_paths.config_file_path.exists() {
-    fs::read_to_string(&config_paths.config_file_path).unwrap_or_default()
+  persist_global_song_count(&config_paths.config_file_path, enable)?;
+
+  if interactive {
+    if enable {
+      onboarding.info("Thank you for participating!\n");
+    } else {
+      onboarding.info("Opted out. You can change this anytime in Settings -> Behavior.\n");
+    }
+  }
+
+  Ok(())
+}
+
+/// A genuine first run has no answer yet; a stale config predating the setting
+/// is asked again even when `client.yml` exists.
+fn should_prompt_global_song_count(client_yml_exists: bool, config_has_answer: bool) -> bool {
+  !client_yml_exists || !config_has_answer
+}
+
+fn global_song_counter_prompt() -> OnboardingPrompt {
+  OnboardingPrompt::Confirm {
+    title: "Global Song Counter".to_string(),
+    body: "\nspotatui can contribute to a global counter showing total\nsongs played by all users worldwide.\n\nPrivacy: This feature is completely anonymous.\n• No personal information is collected\n• No song names, artists, or listening history\n• Only a simple increment when a new song starts".to_string(),
+    question: "\nWould you like to participate? (Y/n): ".to_string(),
+  }
+}
+
+fn auth_setup_migration_prompt() -> OnboardingPrompt {
+  OnboardingPrompt::Confirm {
+    title: "Authentication Setup Update".to_string(),
+    body: "\nConfiguration handling has changed and your authentication setup may need an update."
+      .to_string(),
+    question: "Would you like to run the new auth setup wizard now? (Y/n): ".to_string(),
+  }
+}
+
+/// Ask about the auth-setup migration. Deliberately NOT gated on
+/// interactivity: piped or closed stdin reads as empty input, which answers
+/// yes and runs the wizard, exactly as before this went through `Onboarding`.
+fn ask_auth_setup_migration(onboarding: &dyn Onboarding) -> Result<bool> {
+  Ok(matches!(
+    onboarding.ask(&auth_setup_migration_prompt())?,
+    OnboardingAnswer::Yes
+  ))
+}
+
+/// Merge `enable` into the `behavior` section of `config.yml`, creating the file
+/// when absent. Sibling keys are preserved; this hand-patch bypasses
+/// `UserConfig::save_config` on purpose (it runs before that config is loaded).
+fn persist_global_song_count(config_file_path: &Path, enable: bool) -> Result<()> {
+  let config_yml = if config_file_path.exists() {
+    fs::read_to_string(config_file_path).unwrap_or_default()
   } else {
     String::new()
   };
@@ -290,15 +328,7 @@ fn prompt_global_song_count_opt_in(user_config: &mut UserConfig) -> Result<()> {
   }
 
   let updated_config = serde_yaml::to_string(&config)?;
-  fs::write(&config_paths.config_file_path, updated_config)?;
-
-  if interactive {
-    if enable {
-      println!("Thank you for participating!\n");
-    } else {
-      println!("Opted out. You can change this anytime in Settings -> Behavior.\n");
-    }
-  }
+  fs::write(config_file_path, updated_config)?;
 
   Ok(())
 }
@@ -500,7 +530,7 @@ pub(super) async fn boot(matches: &ArgMatches, onboarding: Arc<dyn Onboarding>) 
   // Global song counter opt-in (interactive TUI only). Asked before the source
   // picker so the choice applies no matter which source(s) the user sets up.
   if matches.subcommand_name().is_none() {
-    prompt_global_song_count_opt_in(&mut user_config)?;
+    prompt_global_song_count_opt_in(&mut user_config, onboarding.as_ref())?;
   }
 
   let mut client_config = ClientConfig::new();
@@ -523,29 +553,16 @@ pub(super) async fn boot(matches: &ArgMatches, onboarding: Arc<dyn Onboarding>) 
   let reconfigure_auth = matches.get_flag("reconfigure-auth");
 
   if reconfigure_auth {
-    println!("\nReconfiguring client authentication...");
+    onboarding.info("\nReconfiguring client authentication...");
     client_config.reconfigure_auth(onboarding.as_ref())?;
-    println!("Client authentication setup updated.\n");
+    onboarding.info("Client authentication setup updated.\n");
   } else if matches.subcommand_name().is_none() && client_config.needs_auth_setup_migration() {
-    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    println!("Authentication Setup Update");
-    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-    println!(
-      "\nConfiguration handling has changed and your authentication setup may need an update."
-    );
-    println!("Would you like to run the new auth setup wizard now? (Y/n): ");
-
-    let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-    let input = input.trim().to_lowercase();
-    let run_migration = input.is_empty() || input == "y" || input == "yes";
-
-    if run_migration {
+    if ask_auth_setup_migration(onboarding.as_ref())? {
       client_config.reconfigure_auth(onboarding.as_ref())?;
-      println!("Client authentication setup updated.\n");
+      onboarding.info("Client authentication setup updated.\n");
     } else {
       client_config.mark_auth_setup_migrated()?;
-      println!("Skipped. You can run this anytime with `spotatui --reconfigure-auth`.\n");
+      onboarding.info("Skipped. You can run this anytime with `spotatui --reconfigure-auth`.\n");
     }
   }
 
@@ -685,9 +702,15 @@ pub(super) async fn boot(matches: &ArgMatches, onboarding: Arc<dyn Onboarding>) 
 
 #[cfg(test)]
 mod tests {
-  use super::apply_configured_runtime_defaults;
+  use super::{
+    apply_configured_runtime_defaults, ask_auth_setup_migration, auth_setup_migration_prompt,
+    global_song_counter_prompt, persist_global_song_count, prompt_global_song_count_opt_in,
+    should_prompt_global_song_count,
+  };
   use crate::core::limits::MAX_PLAYBAR_ROWS;
+  use crate::core::onboarding::OnboardingPrompt;
   use crate::core::state::{PersistedRuntimeState, RuntimeState};
+  use crate::core::test_helpers::ScriptedOnboarding;
   use crate::core::user_config::UserConfig;
 
   fn user_config_with_runtime_defaults() -> UserConfig {
@@ -745,5 +768,139 @@ mod tests {
     assert_eq!(runtime.sidebar_width_percent, 40);
     assert_eq!(runtime.playbar_height_rows, MAX_PLAYBAR_ROWS);
     assert_eq!(runtime.library_height_percent, 60);
+  }
+
+  fn user_config_at(config_file_path: std::path::PathBuf) -> UserConfig {
+    let mut config = UserConfig::new();
+    let path = crate::core::user_config::UserConfigPaths { config_file_path };
+    config.path_to_config.replace(path);
+    config
+  }
+
+  #[test]
+  fn global_song_counter_prompt_predicate_matches_first_run_and_stale_configs() {
+    // Genuine first run: no client.yml, nothing answered.
+    assert!(should_prompt_global_song_count(false, false));
+    // Stale config predating the setting.
+    assert!(should_prompt_global_song_count(true, false));
+    // No client.yml yet, even with an answer present.
+    assert!(should_prompt_global_song_count(false, true));
+    // Asked and answered already.
+    assert!(!should_prompt_global_song_count(true, true));
+  }
+
+  #[test]
+  fn first_run_prompts_carry_the_historical_banner_text() {
+    let OnboardingPrompt::Confirm {
+      title,
+      body,
+      question,
+    } = global_song_counter_prompt();
+    assert_eq!(title, "Global Song Counter");
+    assert_eq!(
+      body,
+      "\nspotatui can contribute to a global counter showing total\nsongs played by all users worldwide.\n\nPrivacy: This feature is completely anonymous.\n• No personal information is collected\n• No song names, artists, or listening history\n• Only a simple increment when a new song starts"
+    );
+    assert_eq!(question, "\nWould you like to participate? (Y/n): ");
+
+    let OnboardingPrompt::Confirm {
+      title,
+      body,
+      question,
+    } = auth_setup_migration_prompt();
+    assert_eq!(title, "Authentication Setup Update");
+    assert_eq!(
+      body,
+      "\nConfiguration handling has changed and your authentication setup may need an update."
+    );
+    assert_eq!(
+      question,
+      "Would you like to run the new auth setup wizard now? (Y/n): "
+    );
+  }
+
+  #[test]
+  fn scripted_yes_answers_the_global_song_counter_without_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yml");
+    std::fs::write(
+      &config_path,
+      "theme:\n  background: '#000000'\nbehavior:\n  volume_percent: 42\n",
+    )
+    .unwrap();
+    let mut user_config = user_config_at(config_path.clone());
+    let onboarding = ScriptedOnboarding::with_answers(&["y"]);
+
+    prompt_global_song_count_opt_in(&mut user_config, &onboarding).unwrap();
+
+    assert!(user_config.behavior.enable_global_song_count);
+    let persisted = std::fs::read_to_string(&config_path).unwrap();
+    assert!(persisted.contains("enable_global_song_count: true"));
+    assert!(persisted.contains("volume_percent: 42"));
+    assert!(persisted.contains("'#000000'"));
+    assert!(onboarding.saw("Global Song Counter"));
+    assert!(onboarding.saw("\nWould you like to participate? (Y/n): "));
+    assert!(onboarding.saw("Thank you for participating!\n"));
+  }
+
+  #[test]
+  fn scripted_no_answers_the_global_song_counter_and_persists_opt_out() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yml");
+    let mut user_config = user_config_at(config_path.clone());
+    let onboarding = ScriptedOnboarding::with_answers(&["nope"]);
+
+    prompt_global_song_count_opt_in(&mut user_config, &onboarding).unwrap();
+
+    assert!(!user_config.behavior.enable_global_song_count);
+    let persisted = std::fs::read_to_string(&config_path).unwrap();
+    assert!(persisted.contains("enable_global_song_count: false"));
+    assert!(onboarding.saw("Opted out. You can change this anytime in Settings -> Behavior.\n"));
+  }
+
+  #[test]
+  fn non_interactive_onboarding_silently_opts_out_and_persists_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yml");
+    let mut user_config = user_config_at(config_path.clone());
+    let onboarding = ScriptedOnboarding::non_interactive(&[]);
+
+    prompt_global_song_count_opt_in(&mut user_config, &onboarding).unwrap();
+
+    // Never enable anonymous telemetry for a user we couldn't prompt.
+    assert!(!user_config.behavior.enable_global_song_count);
+    let persisted = std::fs::read_to_string(&config_path).unwrap();
+    assert!(persisted.contains("enable_global_song_count: false"));
+    assert!(!onboarding.saw("\nWould you like to participate? (Y/n): "));
+    assert!(!onboarding.saw("Opted out. You can change this anytime in Settings -> Behavior.\n"));
+    assert!(!onboarding.saw("Thank you for participating!\n"));
+  }
+
+  #[test]
+  fn global_song_counter_write_creates_the_config_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.yml");
+
+    persist_global_song_count(&config_path, true).unwrap();
+
+    let persisted = std::fs::read_to_string(&config_path).unwrap();
+    assert!(persisted.contains("enable_global_song_count: true"));
+  }
+
+  #[test]
+  fn auth_setup_migration_ask_runs_the_wizard_on_an_empty_answer() {
+    let onboarding = ScriptedOnboarding::with_answers(&[""]);
+
+    assert!(ask_auth_setup_migration(&onboarding).unwrap());
+    assert!(onboarding.saw("Authentication Setup Update"));
+    assert!(onboarding.saw("Would you like to run the new auth setup wizard now? (Y/n): "));
+  }
+
+  #[test]
+  fn auth_setup_migration_ask_skips_the_wizard_on_a_decline() {
+    let onboarding = ScriptedOnboarding::with_answers(&["n"]);
+
+    assert!(!ask_auth_setup_migration(&onboarding).unwrap());
+    assert!(onboarding.saw("Would you like to run the new auth setup wizard now? (Y/n): "));
   }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -48,6 +48,30 @@ impl crate::core::onboarding::Onboarding for HeadlessOnboarding {
     Ok(input)
   }
 
+  fn is_interactive(&self) -> bool {
+    use std::io::IsTerminal;
+    io::stdin().is_terminal() && io::stdout().is_terminal()
+  }
+
+  fn ask(
+    &self,
+    prompt: &crate::core::onboarding::OnboardingPrompt,
+  ) -> Result<crate::core::onboarding::OnboardingAnswer> {
+    use crate::core::onboarding::{confirm_answer, OnboardingPrompt, BANNER_RULE};
+    // Both bootstrap prompts are UI-launch-only and headless builds bail out
+    // before boot there; keep a plain console fallback if this is reached.
+    let OnboardingPrompt::Confirm {
+      title,
+      body,
+      question,
+    } = prompt;
+    println!("\n{BANNER_RULE}\n{title}\n{BANNER_RULE}\n{body}");
+    println!("{question}");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(confirm_answer(&input))
+  }
+
   fn pick_sources(
     &self,
     _options: &[crate::core::source::Source],

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -5,7 +5,9 @@
 //! reads one raw line, and `pick_sources` is the terminal source picker in
 //! `tui/first_run.rs`.
 
-use crate::core::onboarding::Onboarding;
+use crate::core::onboarding::{
+  confirm_answer, Onboarding, OnboardingAnswer, OnboardingPrompt, BANNER_RULE,
+};
 use crate::core::source::Source;
 use anyhow::Result;
 use std::io::{stdin, stdout, Write};
@@ -13,6 +15,27 @@ use std::io::{stdin, stdout, Write};
 pub struct ConsoleOnboarding;
 
 impl Onboarding for ConsoleOnboarding {
+  fn is_interactive(&self) -> bool {
+    use std::io::IsTerminal;
+    stdin().is_terminal() && stdout().is_terminal()
+  }
+
+  fn ask(&self, prompt: &OnboardingPrompt) -> Result<OnboardingAnswer> {
+    let (title, body, question) = match prompt {
+      OnboardingPrompt::Confirm {
+        title,
+        body,
+        question,
+      } => (title, body, question),
+    };
+    println!("\n{BANNER_RULE}\n{title}\n{BANNER_RULE}\n{body}");
+    println!("{question}");
+    let _ = stdout().flush();
+    let mut input = String::new();
+    stdin().read_line(&mut input)?;
+    Ok(confirm_answer(&input))
+  }
+
   fn info(&self, text: &str) {
     println!("{text}");
   }

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -13,4 +13,4 @@ synthetic_keys_in_mouse_handler = 3    # target 0 (the content-table re-entries 
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
 action_refs_in_tui_handlers = 173      # adoption: may only rise
-test_attribute_total = 1657            # adoption: may only rise
+test_attribute_total = 1666            # adoption: may only rise


### PR DESCRIPTION
# Summary

The two raw console prompts in `runtime/bootstrap.rs` (global song counter opt-in, auth setup migration) now go through the `Onboarding` trait instead of `println!` + `stdin().read_line`.

- `core/onboarding.rs`: `OnboardingPrompt::Confirm { title, body, question }`, `OnboardingAnswer { Yes, No }` (both serde-derived), `BANNER_RULE`, the `confirm_answer` parser, and two trait methods `is_interactive` + `ask`.
- `ConsoleOnboarding` and `HeadlessOnboarding` render the banner and read one line. `ScriptedOnboarding` records prompts and pops canned answers, with a `non_interactive()` constructor.
- `bootstrap.rs`: `prompt_global_song_count_opt_in` takes `&dyn Onboarding`; persistence is extracted into `persist_global_song_count`; the migration question is `ask_auth_setup_migration`.

Behavior is unchanged. The console output is byte-identical. Non-TTY runs still opt out of the counter silently, and the migration question still answers yes on empty or piped stdin. The only routing change is the `--reconfigure-auth` banner, which now goes through `info()` (same bytes).

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings` (also default and headless)
- `cargo test --no-default-features --features telemetry,tui` (867), default (1167), headless (513), mcp-only (989), ai-dj-only (1143)
- `tools/check_gates_ratchet.sh main`: `test_attribute_total` 1657 -> 1666, nothing else moved

# Additional notes

Nine new tests: the answer parser, the prompt predicate, prompt-text pins, scripted yes/no persistence through a tempdir config, absent-file creation, migration yes/no, and the non-interactive silent opt-out.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured onboarding confirmations with clear Yes/No responses.
  * Onboarding prompts now work consistently in graphical and headless terminal modes.
  * Added detection for interactive input availability.

* **Bug Fixes**
  * Improved global song-count opt-in and authentication migration prompts across supported environments.

* **Tests**
  * Added coverage for affirmative, negative, interactive, and non-interactive onboarding flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->