### PR TITLE
fix(nix): bump nixpkgs past the crates.io 403 on crate downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - **Spamming Previous on the first track no longer bricks native streaming**: under native streaming, pressing Previous within the first 3 seconds of the first track of a context (or after skipping back through every earlier track) told librespot to go to a track that does not exist, and librespot answered by *stopping* playback: audio went silent, the progress bar froze, and Play, Pause, and Seek could not bring it back until a track was started by hand or playback was transferred from another device. That is upstream librespot behaviour, so the fix lives in our maintained fork (0.8.2): Previous with nothing before it now restarts the current track, the way Spotify's own clients do, and a seek made on the player also updates the position librespot uses for its 3-second rule, so a second press right after a restart goes to the previous track instead of restarting again ([#366](https://github.com/LargeModGames/spotatui/issues/366)).
 
+- **`nix build` and `nix run` download crates again**: since 2026-08-27 every crate fetch in the flake build failed with HTTP 403, on released tags too. crates.io now refuses the deprecated `api/v1/crates/<name>/<version>/download` endpoint to the fetcher nixpkgs uses, and the nixpkgs revision pinned in `flake.lock` (March 2026) downloaded every crate through it. The pin moves to current `nixos-unstable`, whose `importCargoLock` fetches from `static.crates.io` instead, and the Nix toolchain goes from Rust 1.93 to 1.97 with it. That nixpkgs (26.11) also dropped x86_64-darwin, so the flake no longer declares that system; Intel Mac users keep the release tarball, which is still built ([#493](https://github.com/LargeModGames/spotatui/issues/493)).
+
 ## [v0.41.0] 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Or if you use pipewire:
    ```
 
 
+The flake provides `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`. nixpkgs 26.11 dropped Intel Macs (`x86_64-darwin`), so on those use the Homebrew formula, the one-line installer, or the release tarball below.
+
 Or download pre-built binaries from [GitHub Releases](https://github.com/LargeModGames/spotatui/releases/latest).
 
 > **Which build has which sources?** The prebuilt Linux and Windows binaries (the one-line installer, GitHub Releases, and `cargo binstall`) include the extra music sources — Local Files, Subsonic, Internet Radio, YouTube, and Qobuz. macOS builds and a plain `cargo install --locked spotatui` do not; enable them with `--features local-files,subsonic,internet-radio,youtube,qobuz`.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,8 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachDefaultSystem (
+    # nixpkgs 26.11 dropped x86_64-darwin; Intel Macs use the release tarball.
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ] (
       system:
       let
         pkgs = import nixpkgs {


### PR DESCRIPTION
# Summary

Since 2026-08-27 every crate download in the Nix flake build fails with HTTP 403, so `nix build`, `nix run github:LargeModGames/spotatui`, and the `Flake` check are all red, on released tags too. crates.io now refuses the deprecated `api/v1/crates/<name>/<version>/download` endpoint to the curl user agent that nixpkgs' `fetchurl` sends (cargo and Nix's own fetcher still get 200), and the nixpkgs pinned in `flake.lock` (2026-03-03) fetched every crate through it. Current `nixos-unstable` has `importCargoLock` fetching from `static.crates.io` instead.

- `flake.lock`: `nix flake update nixpkgs`, 8c809a14 (2026-03-03) to 34ab9907 (2026-08-31). The Nix toolchain goes from Rust 1.93 to 1.97 with it.
- `flake.nix`: nixpkgs 26.11 dropped x86_64-darwin and throws at evaluation for it, which fails `nix flake check --all-systems`. The flake now lists `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin` explicitly instead of `eachDefaultSystem`. Intel Mac users keep the release tarball, which `cd.yml` still builds. I considered pinning `nixos-26.05` instead (it has the static.crates.io fix backported and still supports x86_64-darwin), but it goes EOL at the end of 2026 and the same decision would come back then.
- `CHANGELOG.md`: a Fixed entry, since released tags are affected too.
- `README.md`: the Nix section now lists the systems the flake provides and points Intel Mac users at Homebrew, the installer, or the release tarball.

Fixes #493.

# Testing

nix is not installed on this machine, so I ran the three steps of `nix.yml` through nix-portable (nix 2.20.6) against the final tree:

- `nix flake check --all-systems --no-build`: exit 0, all three systems evaluate (`packages`, `apps`, `devShells`).
- `nix build --no-link .#default.cargoDeps`: exit 0, 163 crates fetched from `static.crates.io`, zero 403s, vendor dir built.
- `nix develop --command cargo --version`: `cargo 1.97.0 (c980f4866 2026-06-30)`.
- `nix build --no-link --print-build-logs .#default`: exit 0, 453 crates compiled, `bin/spotatui` installed and stripped.
- `nix flake update nixpkgs` produced a `flake.lock` byte-identical to this diff.

No Rust source changes, so the cargo gate does not apply.

# Additional notes

The comment above the `Build the package` step in `nix.yml` still describes `cargoLock.outputHashes` and a `[patch]` block; neither exists any more since the librespot fork moved to crates.io. Left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Nix builds and runs so required Rust crates download successfully again.
  - Updated the Nix toolchain and package sources to restore reliable builds.

- **Documentation**
  - Clarified supported Nix targets: Linux x86_64, Linux ARM64, and macOS ARM64.
  - Added alternatives for Intel Mac users, including Homebrew, the installer, and release tarballs.
  - Documented the restored crate-download behavior in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->