### PR TITLE
fix(queue): refuse a plugin's repeat while the queue slot owns playback

### DIFF
--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -71,6 +71,18 @@ pub async fn route_queue_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool {
     return true;
   }
 
+  // Repeat has no meaning for the queue slot, which plays an explicit list over
+  // a suspended context. Consume it so a plugin's request never cycles repeat
+  // on the user's real Spotify device with nothing on screen to show for it;
+  // the keyboard and MPRIS paths already refuse (#376).
+  if let IoEvent::Repeat(_) = event {
+    let mut guard = app.lock().await;
+    if guard.queue_owns_playback() {
+      guard.set_status_message("Repeat does not apply to this source", 2);
+      return true;
+    }
+  }
+
   // Transport for the queue slot's own player (Pause / Seek / Volume / Next /
   // bare-resume). Only meaningful when a decoded queued track owns the sink;
   // compiles out entirely without a queueable decoded source.
@@ -1406,6 +1418,26 @@ mod tests {
     let app = test_app();
     assert!(route_queue_event(&app, &IoEvent::AdvanceNativeQueue).await);
     assert!(app.lock().await.native_queue.is_empty());
+  }
+
+  /// A plugin's `set_repeat` while the queue slot owns playback must be
+  /// refused, not forwarded to Spotify (#376). Without a slot it falls through.
+  #[cfg(feature = "streaming")]
+  #[tokio::test]
+  async fn repeat_is_refused_while_the_queue_slot_owns_playback() {
+    use crate::infra::queue::QueueNowPlaying;
+    let app = test_app();
+    let repeat = IoEvent::Repeat(rspotify::model::enums::RepeatState::Off);
+    assert!(!route_queue_event(&app, &repeat).await);
+
+    app.lock().await.queue_now = Some(QueueNowPlaying::Spotify {
+      track: track("spotify:track:queued", "Queued"),
+    });
+    assert!(route_queue_event(&app, &repeat).await);
+    assert_eq!(
+      app.lock().await.status_message.as_deref(),
+      Some("Repeat does not apply to this source")
+    );
   }
 
   #[cfg(feature = "streaming")]

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -13,4 +13,4 @@ synthetic_keys_in_mouse_handler = 3    # target 0 (the content-table re-entries 
 wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
 action_refs_in_tui_handlers = 173      # adoption: may only rise
-test_attribute_total = 1770            # adoption: may only rise
+test_attribute_total = 1771            # adoption: may only rise


### PR DESCRIPTION
# Summary

Closes the second half of #376. After #390 closed the internet-radio path, a plugin's `set_repeat` still reached the user's real Spotify device whenever the native queue slot owned playback: `Action::SetRepeat` dispatches a raw `IoEvent::Repeat`, no router consumed it, and `Network::repeat` changed repeat on a track the user was not listening to, with nothing on screen to show for it. This is reachable in a plain `default` build.

The fix is a `Repeat` arm in `route_queue_event`, gated on `queue_owns_playback()`. That router is compiled unconditionally and runs first in the pump, so it covers the Spotify and decoded queue slots in one place without touching the per-source dispatchers. It sets the same "Repeat does not apply to this source" status the keyboard path uses, so the plugin caller gets the same answer as the key.

`set_shuffle` does not have the same hole: `Action::SetShuffle` goes through `App::shuffle`, which already carries the queue-slot guard.

# Testing

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`: clean
- `cargo test --no-default-features --features telemetry,tui`: 906 passed
- `cargo clippy -- -D warnings`: clean
- `cargo test`: 1208 passed, including the new `repeat_is_refused_while_the_queue_slot_owns_playback` (gated on `streaming`, since the slim build's `QueueNowPlaying` has no variants)
- `tools/check_gates_ratchet.sh origin/main`: ok

Not verified: a live run with a Lua plugin calling `set_repeat` over a queued track.

# Additional notes

`test_attribute_total` moves 1770 to 1771 in `tools/gates.count` for the new test.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue playback now handles repeat actions directly while playback is active and displays a status message.
  * Repeat actions continue to be forwarded normally when the queue does not control playback.

* **Tests**
  * Added coverage for repeat handling in both playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->