### PR TITLE
fix(network): keep a 429 backoff off the serial pump

### DIFF
--- a/src/core/app/tick.rs
+++ b/src/core/app/tick.rs
@@ -36,7 +36,9 @@ impl App {
     // No Spotify session (free-source launch): the poll would hit the auth gate
     // and re-flash a "connect Spotify" status message every interval. Free
     // sources drive their own playback state, so skip the Spotify poll entirely.
-    if !self.spotify_connected {
+    // A decoded source that owns the sink has paused Spotify: the poll would
+    // only spend rate limit and pump time on a context nothing renders.
+    if !self.spotify_connected || self.active_decoded_source() {
       return;
     }
 

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -412,6 +412,13 @@ pub struct Network {
   artist_cache: metadata::MetadataTtlCache<metadata::CachedArtistData>,
   album_cache: metadata::MetadataTtlCache<rspotify::model::album::FullAlbum>,
   album_tracks_cache: metadata::MetadataTtlCache<Vec<rspotify::model::track::SimplifiedTrack>>,
+  /// The `Retry-After` window every Spotify call checks: the shared gate in
+  /// production, a private one in tests.
+  rate_gate: requests::ForcedRefreshGate,
+  /// Spotify-bound events held back while that window is open. Only the pump
+  /// sets `defers_rate_limited`; the CLI has no pump to block and waits inline.
+  deferred: Vec<IoEvent>,
+  pub(crate) defers_rate_limited: bool,
 }
 
 impl Network {
@@ -437,6 +444,9 @@ impl Network {
       artist_cache: Default::default(),
       album_cache: Default::default(),
       album_tracks_cache: Default::default(),
+      rate_gate: requests::shared_forced_refresh_gate().clone(),
+      deferred: Vec::new(),
+      defers_rate_limited: false,
     }
   }
 
@@ -461,6 +471,9 @@ impl Network {
       artist_cache: Default::default(),
       album_cache: Default::default(),
       album_tracks_cache: Default::default(),
+      rate_gate: requests::shared_forced_refresh_gate().clone(),
+      deferred: Vec::new(),
+      defers_rate_limited: false,
     }
   }
 
@@ -622,6 +635,19 @@ impl Network {
           app.pending_playlist_open = None;
         }
         return;
+      }
+      if let Some(left) = self.rate_gate.rate_limit_remaining().await {
+        if self.defers_rate_limited {
+          if self.deferred.is_empty() {
+            let secs = left.as_secs().max(1);
+            self
+              .show_status_message(format!("Spotify rate limit: waiting {secs}s"), secs)
+              .await;
+          }
+          self.deferred.push(io_event);
+          return;
+        }
+        tokio::time::sleep(left).await;
       }
       if !self.ensure_authentication_fresh(false).await {
         if let Some(id) = pending_playlist_id.as_deref() {
@@ -1048,7 +1074,30 @@ impl Network {
 
   async fn handle_error(&mut self, e: anyhow::Error) {
     let mut app = self.app.lock().await;
+    // The first hit of a window under the pump: every later event is held
+    // back, so a status message is enough. The CLI keeps its exit signal.
+    if self.defers_rate_limited && requests::is_rate_limited_error(&e) {
+      app.set_error_status_message(e.to_string(), 8);
+      return;
+    }
     app.handle_error(e);
+  }
+
+  /// When the pump must flush the held-back events: the window's end.
+  pub(crate) async fn deferred_deadline(&self) -> Option<std::time::Instant> {
+    if self.deferred.is_empty() {
+      return None;
+    }
+    let left = self.rate_gate.rate_limit_remaining().await;
+    Some(std::time::Instant::now() + left.unwrap_or_default())
+  }
+
+  /// Run the held-back events in their original order. A window that reopens
+  /// mid-flush holds the rest back again.
+  pub(crate) async fn flush_deferred(&mut self) {
+    for event in std::mem::take(&mut self.deferred) {
+      self.handle_network_event(event).await;
+    }
   }
 
   /// Aggregate local listening history for the Stats screen. Reads the
@@ -1926,6 +1975,72 @@ mod tests {
 
   fn session_free_network(app: &Arc<Mutex<App>>) -> Network {
     Network::new(None, ClientConfig::new(), app, temp_token_cache_path())
+  }
+
+  /// A pump-mode network with a session and a private, open rate-limit window.
+  async fn rate_limited_pump_network(app: &Arc<Mutex<App>>) -> Network {
+    let mut network = session_free_network(app);
+    network.spotify = Some(AuthCodePkceSpotify::new(
+      Credentials::default(),
+      OAuth::default(),
+    ));
+    network.defers_rate_limited = true;
+    network.rate_gate = requests::ForcedRefreshGate::default();
+    network
+      .rate_gate
+      .rate_limit_for(Duration::from_secs(30))
+      .await;
+    network
+  }
+
+  #[tokio::test]
+  async fn a_rate_limit_window_holds_spotify_bound_events_back_in_order() {
+    let app = app_without_a_session();
+    let mut network = rate_limited_pump_network(&app).await;
+
+    network.handle_network_event(IoEvent::GetPlaylists).await;
+    network.handle_network_event(IoEvent::GetUser).await;
+    network.flush_deferred().await;
+
+    assert!(matches!(
+      network.deferred.as_slice(),
+      [IoEvent::GetPlaylists, IoEvent::GetUser]
+    ));
+    assert!(network.deferred_deadline().await.is_some());
+    let app = app.lock().await;
+    assert!(app
+      .status_message()
+      .is_some_and(|m| m.contains("rate limit")));
+  }
+
+  #[tokio::test]
+  async fn a_rate_limit_error_under_the_pump_is_a_status_message_not_the_error_page() {
+    let app = app_without_a_session();
+    let mut network = rate_limited_pump_network(&app).await;
+
+    network
+      .handle_error(anyhow!(
+        "Spotify API 429 Too Many Requests failed: retry in 17s"
+      ))
+      .await;
+
+    let app = app.lock().await;
+    assert!(app.api_error().is_empty());
+    assert!(app.status_message_is_error());
+  }
+
+  #[tokio::test]
+  async fn a_rate_limit_error_without_the_pump_keeps_the_cli_exit_signal() {
+    let app = app_without_a_session();
+    let mut network = session_free_network(&app);
+
+    network
+      .handle_error(anyhow!(
+        "Spotify API 429 Too Many Requests failed: retry in 17s"
+      ))
+      .await;
+
+    assert!(!app.lock().await.api_error().is_empty());
   }
 
   fn app_without_a_session() -> Arc<Mutex<App>> {

--- a/src/infra/network/requests.rs
+++ b/src/infra/network/requests.rs
@@ -45,6 +45,10 @@ const FORCED_REFRESH_COOLDOWN: Duration = Duration::from_secs(30);
 /// identically, turning a recoverable blip into a surfaced error.
 const UNAUTHORIZED_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 
+/// Longest `Retry-After` honored: a bound on the window, so a bogus header
+/// value can neither park the app for a day nor overflow the deadline.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(600);
+
 /// Longest response body echoed into the diagnostics log.
 const MAX_LOGGED_BODY_CHARS: usize = 512;
 
@@ -76,8 +80,12 @@ impl ForcedRefreshGate {
     until.checked_duration_since(Instant::now())
   }
 
+  /// Open (or extend) the window: a shorter `Retry-After` that lands during a
+  /// longer one must not cut the longer one short.
   pub(crate) async fn rate_limit_for(&self, window: Duration) {
-    *self.rate_limited_until.lock().await = Some(Instant::now() + window);
+    let until = Instant::now() + window.min(MAX_RETRY_AFTER);
+    let mut slot = self.rate_limited_until.lock().await;
+    *slot = Some(slot.map_or(until, |current| current.max(until)));
   }
 
   /// Claims the right to force a refresh now. Returns `false` when one already
@@ -440,7 +448,7 @@ where
     }
 
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-      let window = retry_after_secs.max(1);
+      let window = retry_after_secs.max(1).min(MAX_RETRY_AFTER.as_secs());
       forced_refresh_gate
         .rate_limit_for(Duration::from_secs(window))
         .await;
@@ -1148,5 +1156,53 @@ mod tests {
     assert!(is_rate_limited_error(&first));
     assert!(is_rate_limited_error(&second));
     assert!(second.to_string().contains("retry in"), "{second}");
+  }
+
+  #[tokio::test]
+  async fn a_shorter_window_never_cuts_a_longer_one_short() {
+    let gate = ForcedRefreshGate::default();
+    gate.rate_limit_for(Duration::from_secs(30)).await;
+    gate.rate_limit_for(Duration::from_secs(1)).await;
+
+    let left = gate.rate_limit_remaining().await.unwrap();
+    assert!(left > Duration::from_secs(20), "{left:?}");
+  }
+
+  #[tokio::test]
+  async fn an_extreme_retry_after_is_bounded_and_does_not_panic() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+      let (mut stream, _) = listener.accept().await.unwrap();
+      let _ = read_http_request(&mut stream).await;
+      let response = format!(
+        "HTTP/1.1 429 Too Many Requests\r\nretry-after: {}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+        u64::MAX
+      );
+      stream.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let spotify = spotify_with_access_token("access").await;
+    let gate = ForcedRefreshGate::default();
+    let refresh = |_force| async move { Ok(Some(SystemTime::now() + Duration::from_secs(3600))) };
+    let error = spotify_api_request_json_for_base_with_refresh(
+      &spotify,
+      SpotifyApiRequest {
+        base_url: &base_url,
+        method: Method::GET,
+        path: "me/player",
+        query: &[],
+        body: None,
+      },
+      refresh,
+      &gate,
+    )
+    .await
+    .unwrap_err();
+    server.await.unwrap();
+
+    assert!(is_rate_limited_error(&error));
+    let left = gate.rate_limit_remaining().await.unwrap();
+    assert!(left <= MAX_RETRY_AFTER, "{left:?}");
   }
 }

--- a/src/infra/network/requests.rs
+++ b/src/infra/network/requests.rs
@@ -57,6 +57,8 @@ const MAX_LOGGED_BODY_CHARS: usize = 512;
 pub struct ForcedRefreshGate {
   last_forced_refresh: Arc<Mutex<Option<Instant>>>,
   cooldown: Duration,
+  /// End of the last `Retry-After` window: no request goes out before it.
+  rate_limited_until: Arc<Mutex<Option<Instant>>>,
 }
 
 impl ForcedRefreshGate {
@@ -64,7 +66,18 @@ impl ForcedRefreshGate {
     Self {
       last_forced_refresh: Arc::new(Mutex::new(None)),
       cooldown,
+      rate_limited_until: Arc::new(Mutex::new(None)),
     }
+  }
+
+  /// Time left in the `Retry-After` window, if one is open.
+  pub(crate) async fn rate_limit_remaining(&self) -> Option<Duration> {
+    let until = (*self.rate_limited_until.lock().await)?;
+    until.checked_duration_since(Instant::now())
+  }
+
+  pub(crate) async fn rate_limit_for(&self, window: Duration) {
+    *self.rate_limited_until.lock().await = Some(Instant::now() + window);
   }
 
   /// Claims the right to force a refresh now. Returns `false` when one already
@@ -117,7 +130,7 @@ impl std::error::Error for SpotifyApiError {}
 
 /// The process-wide gate used by every real Spotify request (one Spotify
 /// session per process). Tests drive the base helper with their own instance.
-fn shared_forced_refresh_gate() -> &'static ForcedRefreshGate {
+pub(crate) fn shared_forced_refresh_gate() -> &'static ForcedRefreshGate {
   static GATE: OnceLock<ForcedRefreshGate> = OnceLock::new();
   GATE.get_or_init(ForcedRefreshGate::default)
 }
@@ -283,6 +296,22 @@ where
     }
   }
 
+  // Inside a `Retry-After` window every call fails here, at once and with no
+  // request: a sleep would park the serial pump and every event behind it.
+  if let Some(left) = forced_refresh_gate.rate_limit_remaining().await {
+    return Err(
+      SpotifyApiError {
+        status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+        body: format!(
+          "rate limited by Spotify, retry in {}s",
+          left.as_secs().max(1)
+        ),
+        detail: None,
+      }
+      .into(),
+    );
+  }
+
   let client = shared_http_client();
   let mut attempt: u8 = 0;
   let max_attempts: u8 = 4;
@@ -410,11 +439,20 @@ where
       continue;
     }
 
-    if status == reqwest::StatusCode::TOO_MANY_REQUESTS && attempt + 1 < max_attempts {
-      let backoff_secs = retry_after_secs.max(1) + u64::from(attempt);
-      tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
-      attempt += 1;
-      continue;
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+      let window = retry_after_secs.max(1);
+      forced_refresh_gate
+        .rate_limit_for(Duration::from_secs(window))
+        .await;
+      // The raw body went to the log above; the user sees the wait instead.
+      return Err(
+        SpotifyApiError {
+          status,
+          body: format!("rate limited by Spotify, retry in {window}s"),
+          detail: None,
+        }
+        .into(),
+      );
     }
 
     return Err(
@@ -1063,5 +1101,52 @@ mod tests {
     server.await.unwrap();
 
     assert_eq!(result, Value::Null);
+  }
+
+  /// A 429 opens a `Retry-After` window on the gate: the call fails at once
+  /// (no sleep on the pump) and the next call fails without a request.
+  #[tokio::test]
+  async fn a_429_fails_at_once_and_blocks_the_next_call_locally() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1/", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+      let (mut stream, _) = listener.accept().await.unwrap();
+      let _ = read_http_request(&mut stream).await;
+      let body = r#"{"error":{"status":429}}"#;
+      let response = format!(
+        "HTTP/1.1 429 Too Many Requests\r\nretry-after: 30\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+      );
+      stream.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let spotify = spotify_with_access_token("access").await;
+    let gate = ForcedRefreshGate::default();
+    let request = || SpotifyApiRequest {
+      base_url: &base_url,
+      method: Method::GET,
+      path: "me/player",
+      query: &[],
+      body: None,
+    };
+    let refresh = |_force| async move { Ok(Some(SystemTime::now() + Duration::from_secs(3600))) };
+
+    let started_at = Instant::now();
+    let first = spotify_api_request_json_for_base_with_refresh(&spotify, request(), refresh, &gate)
+      .await
+      .unwrap_err();
+    server.await.unwrap();
+    let second =
+      spotify_api_request_json_for_base_with_refresh(&spotify, request(), refresh, &gate)
+        .await
+        .unwrap_err();
+
+    assert!(
+      started_at.elapsed() < Duration::from_secs(5),
+      "a 429 must not sleep"
+    );
+    assert!(is_rate_limited_error(&first));
+    assert!(is_rate_limited_error(&second));
+    assert!(second.to_string().contains("retry in"), "{second}");
   }
 }

--- a/src/runtime/pump.rs
+++ b/src/runtime/pump.rs
@@ -77,7 +77,12 @@ pub(super) async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, netwo
   let mut party_poll = tokio::time::interval(std::time::Duration::from_millis(25));
   party_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+  // Spotify-bound events that meet a rate limit are held back on the
+  // `Network` and flushed here when the window ends, so the pump never sleeps.
+  network.defers_rate_limited = true;
+
   loop {
+    let deferred_deadline = network.deferred_deadline().await;
     let io_event = tokio::select! {
       maybe_event = bridge_rx.recv() => match maybe_event {
         Some(io_event) => io_event,
@@ -85,6 +90,12 @@ pub(super) async fn start_tokio(io_rx: std::sync::mpsc::Receiver<IoEvent>, netwo
       },
       _ = party_poll.tick(), if network.party_incoming_rx.is_some() => {
         network.process_party_messages().await;
+        continue;
+      }
+      _ = tokio::time::sleep_until(tokio::time::Instant::from_std(
+        deferred_deadline.unwrap_or_else(std::time::Instant::now)
+      )), if deferred_deadline.is_some() => {
+        network.flush_deferred().await;
         continue;
       }
     };

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -14,4 +14,4 @@ wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
 pub_fields_on_app = 139                # target 1 (App.view stays public for the frontend; the rest go through App methods)
 action_refs_in_tui_handlers = 183      # adoption: may only rise
-test_attribute_total = 1810            # adoption: may only rise
+test_attribute_total = 1814            # adoption: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -14,4 +14,4 @@ wildcard_arms_in_action_tree = 0       # target 0, must stay 0
 view_writes_outside_tui = 12           # target 0 (producers outside tui/ and core/app/ writing App::view)
 pub_fields_on_app = 139                # target 1 (App.view stays public for the frontend; the rest go through App methods)
 action_refs_in_tui_handlers = 183      # adoption: may only rise
-test_attribute_total = 1814            # adoption: may only rise
+test_attribute_total = 1816            # adoption: may only rise


### PR DESCRIPTION
# Summary

A Spotify 429 no longer sleeps on the serial IoEvent pump.

With the shared ncspot client ID saturated, `GET /v1/me/player` answers 429 with a `Retry-After` of about 22 s. The retry loop in `requests.rs` slept that window on the pump, up to four attempts per poll, so every event behind it waited: a Qobuz track change took up to 30 s after the sink drained, a Qobuz skip took 20 s after the key press, and every Spotify browse waited in the same line. The poll also kept running while Qobuz owned the sink.

Now:

- A 429 stores its `Retry-After` window on the session gate and fails at once. Inside the window a call fails at once with no request, and the text names the wait.
- `Network` holds a Spotify-bound event back, in arrival order, while a window is open. The pump flushes the list when the window ends, so nothing is lost and the pump never sleeps. The first hit of a window is a status message under the pump. The CLI has no pump to block, waits inline, and keeps its `api_error` exit signal.
- The Spotify playback poll is skipped while a decoded source owns the sink.

Source events never reach this path (the routers run first), so a Qobuz skip is now immediate regardless of Spotify's state.

# Testing

- `cargo fmt --all`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`
- `cargo test --no-default-features --features telemetry,tui`: 947 passed
- `cargo clippy --features all-sources -- -D warnings`
- `cargo clippy --no-default-features --features telemetry -- -D warnings`
- Smoke test on Windows with Qobuz playing against the saturated shared ID: track changes and skips are immediate again, startup shows "Spotify rate limit: waiting Ns" instead of the error page, and the sidebar fills when the wait ends.

Four new tests: the window fails at once and blocks the next call locally, held-back events keep their order, a rate-limit error under the pump is a status message, and the same error without the pump keeps the CLI exit signal. `test_attribute_total` moves 1810 -> 1814.

# Additional notes

- A Spotify call that hangs on the network still holds the pump for its 30 s timeout. The full decoupling is a Spotify lane next to the service lane; separate PR.
- `fallback_client_id` only engages when authentication fails, never on a 429. A switch on a 429 storm needs a new login flow; separate PR.
- The startup `/me` check keeps its own gate on purpose (fallback candidates must not inherit a cooldown), so the first pump event of a session may still see one live 429.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Spotify rate limits by delaying requests and processing them in order once access is restored.
  - Rate-limit conditions in the continuous playback experience now appear as status updates instead of incorrectly showing an error page.
  - Reduced unnecessary Spotify polling during transitions to locally decoded playback sources.
  - Prevented rate-limited requests from unnecessarily blocking other playback processing.
  - Added safeguards for extended server-provided retry periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->