### PR TITLE
fix(config): keep a symlinked config.yml, survive read-only

### DIFF
--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -112,16 +112,29 @@ pub(crate) fn write_private_file(path: &Path, contents: &[u8]) -> std::io::Resul
 /// Atomically replace `path` with `contents`, written privately (0o600 on Unix
 /// via [`write_private_file`]).
 ///
-/// The bytes go to a process-unique temporary sibling first, then a rename swaps
-/// it over `path`. The unique suffix (pid plus a per-process counter) keeps two
+/// The bytes go to a process-unique temporary sibling of the resolved target
+/// first, then a rename swaps it over that target, so a symlinked `path` keeps
+/// its link. The unique suffix (pid plus a per-process counter) keeps two
 /// concurrent writers from sharing one temp file and renaming each other's
 /// half-written bytes into place. On a failed write or rename the temp file is
 /// removed best-effort so aborted writes do not accumulate.
 pub(crate) fn write_private_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
-  let tmp = unique_temp_path(path);
+  // Follow the link chain by hand: `canonicalize` fails on a dangling link and
+  // would let the rename replace the link itself. The bound stops a link loop.
+  // `join` keeps an absolute link and resolves a relative one against the
+  // link's directory.
+  let mut target = path.to_path_buf();
+  for _ in 0..40 {
+    let Ok(link) = fs::read_link(&target) else {
+      break;
+    };
+    target = target.parent().unwrap_or(Path::new("")).join(link);
+  }
+  let tmp = unique_temp_path(&target);
   // Clean up on either failure (write or rename). Each attempt uses a fresh
   // unique name, so a leaked temp from a partial write would otherwise persist.
-  if let Err(error) = write_private_file(&tmp, contents).and_then(|()| std::fs::rename(&tmp, path))
+  if let Err(error) =
+    write_private_file(&tmp, contents).and_then(|()| std::fs::rename(&tmp, &target))
   {
     let _ = std::fs::remove_file(&tmp);
     return Err(error.into());
@@ -660,6 +673,10 @@ pub async fn token_expiry(spotify: &AuthCodePkceSpotify) -> Result<SystemTime> {
 mod tests {
   use super::*;
   use chrono::{TimeDelta, Utc};
+  #[cfg(unix)]
+  use std::os::unix::fs::symlink as symlink_file;
+  #[cfg(windows)]
+  use std::os::windows::fs::symlink_file;
 
   const PERSONAL_CLIENT_ID: &str = "0123456789abcdef0123456789abcdef";
 
@@ -1047,5 +1064,78 @@ mod tests {
     assert!(spotify_rejected_token(&anyhow!(
       "http error: status code 400 Bad Request"
     )));
+  }
+
+  /// A `config.yml` link in one directory to a target in another (the dotfiles
+  /// shape); `None` when the platform refuses to create symlinks.
+  fn linked_config(seed: Option<&[u8]>) -> Option<(tempfile::TempDir, PathBuf, PathBuf)> {
+    let root = tempfile::tempdir().unwrap();
+    let target = root.path().join("store").join("config.yml");
+    let link = root.path().join("config").join("config.yml");
+    fs::create_dir(target.parent().unwrap()).unwrap();
+    fs::create_dir(link.parent().unwrap()).unwrap();
+    if let Some(bytes) = seed {
+      fs::write(&target, bytes).unwrap();
+    }
+    symlink_file(&target, &link).ok()?;
+    Some((root, target, link))
+  }
+
+  fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).unwrap().file_type().is_symlink()
+  }
+
+  #[test]
+  fn atomic_write_through_a_dangling_symlink_keeps_the_link() {
+    let Some((_root, target, link)) = linked_config(None) else {
+      return;
+    };
+
+    write_private_file_atomic(&link, b"new").unwrap();
+
+    assert!(is_symlink(&link));
+    assert_eq!(fs::read(&target).unwrap(), b"new");
+  }
+
+  #[test]
+  fn atomic_write_through_a_symlink_keeps_the_link() {
+    let Some((_root, target, link)) = linked_config(Some(b"old")) else {
+      return;
+    };
+
+    write_private_file_atomic(&link, b"new").unwrap();
+
+    assert!(is_symlink(&link));
+    assert_eq!(fs::read(&target).unwrap(), b"new");
+  }
+
+  #[test]
+  fn atomic_write_onto_a_read_only_target_keeps_the_link() {
+    let Some((_root, target, link)) = linked_config(Some(b"old")) else {
+      return;
+    };
+    let store = target.parent().unwrap();
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::PermissionsExt;
+      fs::set_permissions(store, fs::Permissions::from_mode(0o500)).unwrap();
+    }
+    #[cfg(windows)]
+    {
+      let mut permissions = fs::metadata(&target).unwrap().permissions();
+      permissions.set_readonly(true);
+      fs::set_permissions(&target, permissions).unwrap();
+    }
+
+    let _ = write_private_file_atomic(&link, b"new");
+
+    assert!(is_symlink(&link));
+    // No temp sibling is left behind, on a failed write or on a root-run success.
+    assert_eq!(fs::read_dir(store).unwrap().count(), 1);
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::PermissionsExt;
+      fs::set_permissions(store, fs::Permissions::from_mode(0o700)).unwrap();
+    }
   }
 }

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -130,16 +130,35 @@ pub(crate) fn write_private_file_atomic(path: &Path, contents: &[u8]) -> Result<
     };
     target = target.parent().unwrap_or(Path::new("")).join(link);
   }
+  if fs::read_link(&target).is_ok() {
+    return Err(anyhow!(
+      "{} is a symlink loop or chain too long",
+      path.display()
+    ));
+  }
   let tmp = unique_temp_path(&target);
   // Clean up on either failure (write or rename). Each attempt uses a fresh
   // unique name, so a leaked temp from a partial write would otherwise persist.
-  if let Err(error) =
-    write_private_file(&tmp, contents).and_then(|()| std::fs::rename(&tmp, &target))
+  if let Err(error) = create_private_file_exclusive(&tmp)
+    .and_then(|mut file| std::io::Write::write_all(&mut file, contents))
+    .and_then(|()| std::fs::rename(&tmp, &target))
   {
     let _ = std::fs::remove_file(&tmp);
     return Err(error.into());
   }
   Ok(())
+}
+
+/// Create a new private file; an existing path, a symlink included, is refused.
+fn create_private_file_exclusive(path: &Path) -> std::io::Result<std::fs::File> {
+  let mut options = std::fs::OpenOptions::new();
+  options.write(true).create_new(true);
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::OpenOptionsExt;
+    options.mode(0o600);
+  }
+  options.open(path)
 }
 
 /// A temporary sibling of `path` that no other process (or concurrent save in
@@ -1137,5 +1156,30 @@ mod tests {
       use std::os::unix::fs::PermissionsExt;
       fs::set_permissions(store, fs::Permissions::from_mode(0o700)).unwrap();
     }
+  }
+
+  #[test]
+  fn atomic_write_into_a_symlink_loop_fails_and_keeps_both_links() {
+    let Some((_root, target, link)) = linked_config(None) else {
+      return;
+    };
+    symlink_file(&link, &target).unwrap();
+
+    assert!(write_private_file_atomic(&link, b"new").is_err());
+
+    assert!(is_symlink(&link));
+    assert!(is_symlink(&target));
+  }
+
+  #[test]
+  fn an_exclusive_create_refuses_a_planted_symlink() {
+    let Some((_root, target, link)) = linked_config(None) else {
+      return;
+    };
+
+    let error = create_private_file_exclusive(&link).unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert!(!target.exists());
   }
 }

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -34,12 +34,16 @@ fn config_file_path_display(user_config: &UserConfig) -> String {
 }
 
 /// A config that cannot be written (a read-only dotfiles link) does not abort
-/// the picker.
-fn save_config_or_warn(user_config: &UserConfig, onboarding: &dyn Onboarding) {
-  if let Err(e) = user_config.save_config() {
-    let path = config_file_path_display(user_config);
-    log::warn!("could not save {path}: {e}");
-    onboarding.info(&format!("Could not save {path}: {e}"));
+/// the picker; `false` when the save failed.
+fn save_config_or_warn(user_config: &UserConfig, onboarding: &dyn Onboarding) -> bool {
+  match user_config.save_config() {
+    Ok(()) => true,
+    Err(e) => {
+      let path = config_file_path_display(user_config);
+      log::warn!("could not save {path}: {e}");
+      onboarding.info(&format!("Could not save {path}: {e}"));
+      false
+    }
   }
 }
 
@@ -269,7 +273,7 @@ async fn configure_subsonic(
   user_config.behavior.subsonic_url = Some(url.clone());
   user_config.behavior.subsonic_username = Some(username.clone());
   user_config.behavior.subsonic_password = Some(password.clone());
-  save_config_or_warn(user_config, onboarding);
+  let saved = save_config_or_warn(user_config, onboarding);
 
   // Best-effort connectivity check: a failure is not fatal (the server may just
   // be temporarily down), the details are already saved.
@@ -279,10 +283,14 @@ async fn configure_subsonic(
     Ok(()) => onboarding.info("OK"),
     Err(e) => {
       onboarding.info(&format!("failed: {e}"));
-      onboarding.info(&format!(
-        "Saved anyway. Fix the details in {} and relaunch if needed.",
-        config_file_path_display(user_config)
-      ));
+      if saved {
+        onboarding.info(&format!(
+          "Saved anyway. Fix the details in {} and relaunch if needed.",
+          config_file_path_display(user_config)
+        ));
+      } else {
+        onboarding.info("The details are kept for this session only.");
+      }
     }
   }
 
@@ -352,5 +360,33 @@ fn prompt_required(onboarding: &dyn Onboarding, label: &str) -> Result<String> {
     if retries >= MAX_RETRIES {
       return Err(anyhow!("Maximum retries ({MAX_RETRIES}) exceeded."));
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::core::test_helpers::ScriptedOnboarding;
+
+  #[test]
+  fn a_failed_config_save_warns_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    // A missing parent fails the write on every platform, root included.
+    let config_path = dir.path().join("no-such-directory").join("config.yml");
+    let mut user_config = UserConfig::new();
+    user_config
+      .path_to_config
+      .replace(crate::core::user_config::UserConfigPaths {
+        config_file_path: config_path.clone(),
+      });
+    let onboarding = ScriptedOnboarding::with_answers(&[]);
+
+    assert!(!save_config_or_warn(&user_config, &onboarding));
+
+    assert!(!config_path.exists());
+    let shown = onboarding.shown.lock().unwrap();
+    assert!(shown
+      .iter()
+      .any(|line| line.starts_with(&format!("Could not save {}: ", config_path.display()))));
   }
 }

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -23,7 +23,6 @@ use crate::core::user_config::UserConfig;
 use anyhow::anyhow;
 use anyhow::Result;
 
-#[cfg(any(feature = "subsonic", feature = "youtube", feature = "local-files"))]
 fn config_file_path_display(user_config: &UserConfig) -> String {
   user_config
     .path_to_config
@@ -32,6 +31,16 @@ fn config_file_path_display(user_config: &UserConfig) -> String {
     .or_else(|| crate::core::paths::app_config_dir().map(|dir| dir.join("config.yml")))
     .map(|path| path.display().to_string())
     .unwrap_or_else(|| "config.yml".to_string())
+}
+
+/// A config that cannot be written (a read-only dotfiles link) does not abort
+/// the picker.
+fn save_config_or_warn(user_config: &UserConfig, onboarding: &dyn Onboarding) {
+  if let Err(e) = user_config.save_config() {
+    let path = config_file_path_display(user_config);
+    log::warn!("could not save {path}: {e}");
+    onboarding.info(&format!("Could not save {path}: {e}"));
+  }
 }
 
 /// Run the interactive first-run source picker. A no-op after the first launch
@@ -102,7 +111,7 @@ async fn apply_selections(
   // The global song counter opt-in is asked before this picker runs, so the
   // user's choice already sits on `user_config`; save_config persists it here.
   // The active source is runtime state, so save it separately.
-  user_config.save_config()?;
+  save_config_or_warn(user_config, onboarding);
   let state_path = crate::core::state::default_state_path()?;
   crate::core::state::save(
     &state_path,
@@ -260,7 +269,7 @@ async fn configure_subsonic(
   user_config.behavior.subsonic_url = Some(url.clone());
   user_config.behavior.subsonic_username = Some(username.clone());
   user_config.behavior.subsonic_password = Some(password.clone());
-  user_config.save_config()?;
+  save_config_or_warn(user_config, onboarding);
 
   // Best-effort connectivity check: a failure is not fatal (the server may just
   // be temporarily down), the details are already saved.

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -252,7 +252,19 @@ fn prompt_global_song_count_opt_in(
 
   user_config.behavior.enable_global_song_count = enable;
 
-  persist_global_song_count(&config_paths.config_file_path, enable)?;
+  if let Err(e) = persist_global_song_count(&config_paths.config_file_path, enable) {
+    log::warn!(
+      "could not save the global song counter answer to {}: {e}",
+      config_paths.config_file_path.display()
+    );
+    if interactive {
+      onboarding.info(&format!(
+        "Could not save your answer to {} (read-only config?). Set `enable_global_song_count` under `behavior:` there to stop this prompt.\n",
+        config_paths.config_file_path.display()
+      ));
+    }
+    return Ok(());
+  }
 
   if interactive {
     if enable {
@@ -328,7 +340,8 @@ fn ask_auth_setup_migration(onboarding: &dyn Onboarding) -> Result<bool> {
 
 /// Merge `enable` into the `behavior` section of `config.yml`, creating the file
 /// when absent. Sibling keys are preserved; this hand-patch bypasses
-/// `UserConfig::save_config` on purpose (it runs before that config is loaded).
+/// `UserConfig::save_config` on purpose: a full save writes every default back
+/// into a config that predates the setting, and a written key reads as chosen.
 fn persist_global_song_count(config_file_path: &Path, enable: bool) -> Result<()> {
   let config_yml = if config_file_path.exists() {
     fs::read_to_string(config_file_path).unwrap_or_default()
@@ -356,7 +369,7 @@ fn persist_global_song_count(config_file_path: &Path, enable: bool) -> Result<()
   }
 
   let updated_config = serde_yaml::to_string(&config)?;
-  fs::write(config_file_path, updated_config)?;
+  auth::write_private_file_atomic(config_file_path, updated_config.as_bytes())?;
 
   Ok(())
 }
@@ -912,6 +925,25 @@ mod tests {
     assert!(persisted.contains("enable_global_song_count: false"));
     assert!(!onboarding.saw("\nWould you like to participate? (Y/n): "));
     assert!(!onboarding.saw("Opted out. You can change this anytime in Settings -> Behavior.\n"));
+    assert!(!onboarding.saw("Thank you for participating!\n"));
+  }
+
+  #[test]
+  fn a_failed_global_song_counter_write_does_not_abort_boot() {
+    let dir = tempfile::tempdir().unwrap();
+    // A missing parent fails the write on every platform, root included.
+    let config_path = dir.path().join("no-such-directory").join("config.yml");
+    let mut user_config = user_config_at(config_path.clone());
+    let onboarding = ScriptedOnboarding::with_answers(&["y"]);
+
+    prompt_global_song_count_opt_in(&mut user_config, &onboarding).unwrap();
+
+    assert!(user_config.behavior.enable_global_song_count);
+    assert!(!config_path.exists());
+    assert!(onboarding.saw(&format!(
+      "Could not save your answer to {} (read-only config?). Set `enable_global_song_count` under `behavior:` there to stop this prompt.\n",
+      config_path.display()
+    )));
     assert!(!onboarding.saw("Thank you for participating!\n"));
   }
 

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -15,4 +15,4 @@ view_writes_outside_tui = 12           # target 0 (producers outside tui/ and co
 pub_fields_on_app = 139                # target 1 (App.view stays public for the frontend; the rest go through App methods)
 direct_playback_context_reads = 92     # target 0 (readers of App::current_playback_context outside the ownership resolver and the snapshot builder, which are excluded)
 action_refs_in_tui_handlers = 183      # adoption: may only rise
-test_attribute_total = 1830            # adoption: may only rise
+test_attribute_total = 1833            # adoption: may only rise

--- a/tools/gates.count
+++ b/tools/gates.count
@@ -15,4 +15,4 @@ view_writes_outside_tui = 12           # target 0 (producers outside tui/ and co
 pub_fields_on_app = 139                # target 1 (App.view stays public for the frontend; the rest go through App methods)
 direct_playback_context_reads = 92     # target 0 (readers of App::current_playback_context outside the ownership resolver and the snapshot builder, which are excluded)
 action_refs_in_tui_handlers = 183      # adoption: may only rise
-test_attribute_total = 1826            # adoption: may only rise
+test_attribute_total = 1830            # adoption: may only rise


### PR DESCRIPTION
# Summary

Fixes #512. A `config.yml` that is a symlink into a read-only store (home-manager, stow, chezmoi) no longer crashes boot or loses its link.

- `write_private_file_atomic` follows the link chain before the temp write and the rename, so the swap happens at the link's target. A symlinked `config.yml` (also `state.yml` and the Qobuz credentials file) keeps its link. A dangling link keeps its link too, and the write creates the target. A link into a read-only store makes the write fail with an error, and the link stays.
- The global song counter prompt logs a warning when the answer cannot be saved and tells the user which key to set by hand. It no longer aborts boot. The write now goes through `write_private_file_atomic` like every other config write.
- The first-run source picker and the Subsonic setup warn instead of abort when `config.yml` cannot be saved.
- The settings editor still shows the error frame on a read-only config. The change applies in memory for the session. That matches the repo rule for an operation the user asked for.

# Testing

- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features telemetry,tui -- -D warnings`: clean
- `cargo test --no-default-features --features telemetry,tui`: 957 passed
- `cargo clippy --no-default-features --features telemetry -- -D warnings`: clean
- New tests: three symlink tests in `core/auth.rs` (a linked target, a dangling link, a read-only target) and a failed opt-in write in `runtime/bootstrap.rs`. The symlink tests ran for real on Windows with Developer Mode and return early on a machine that cannot create symlinks. The `0o500` Unix arm runs on the Linux CI legs.
- `tools/gates.count`: `test_attribute_total` 1826 to 1830 for the four new tests.

# Additional notes

Not verified on a real home-manager setup. I will ask the reporter to test a build from this branch.

---
<sub>💬 Questions or want to chat with other contributors? Join the [spotatui Discord](https://spotatui.com/discord).</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration updates made through symbolic links now preserve the link instead of replacing it.
  - Configuration writes are more resilient when files are unavailable and use safer temporary-file handling.
  - First-run setup and startup no longer abort when configuration changes cannot be saved.
  - Failed saves now generate non-fatal warnings and onboarding messages, including whether details remain available only for the current session.
  - Configuration writes are performed atomically, reducing the risk of partial updates and leftover temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->