### PR TITLE
fix(cd): list the .deb assets explicitly so the gui shim is not packaged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,12 @@ depends = "$auto"
 suggests = "yt-dlp, ffmpeg"
 section = "utils"
 priority = "optional"
+# cargo-deb packages every [[bin]] by default, and spotatui-gui only exists
+# in a `gui` build, so the assets are listed explicitly.
+assets = [
+  ["target/release/spotatui", "usr/bin/", "755"],
+  ["README.md", "usr/share/doc/spotatui/README", "644"],
+]
 
 # cargo-binstall: fetch the prebuilt release binaries instead of compiling.
 #   cargo binstall spotatui


### PR DESCRIPTION
# Summary

The v0.42.0 release run failed on both Linux builds at the `Package Debian (.deb)` step:

```
error: Unable to read asset to add to archive: .../target/x86_64-unknown-linux-gnu/release/spotatui-gui
  cause: No such file or directory (os error 2)
```

cargo-deb packages every `[[bin]]` by default, and the `spotatui-gui` shim from #462 only builds with the `gui` feature, so the release build never produces it. `[package.metadata.deb]` now lists its assets explicitly: the `spotatui` binary and the README. The `.deb` step has not passed since #462; the two previous release runs failed earlier, at the crates.io publish.

# Testing

- `cargo metadata --locked` passes (no lockfile change)
- `cargo build --release --no-default-features --features telemetry,tui`, then `cargo deb --no-build` with the new table: the package holds `usr/bin/spotatui`, `usr/share/doc/spotatui/README` and `copyright`, with `Suggests: yt-dlp, ffmpeg` intact
- Not verified locally: `dpkg-shlibdeps` (Arch has no dpkg), so the local package has an empty `Depends:`. The failed CI job shows it running on the Ubuntu runner, so the released package gets the real dependencies

# Additional notes

After merge the `v0.42.0` tag is moved to the merge commit and pushed again. The failed run published nothing (no release object, no crates.io upload), so there is nothing to clean up.

The package's long description is the whole README because cargo-deb defaults `extended-description` to it. Pre-existing, left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Debian packages now install the `spotatui` executable correctly with appropriate permissions.
  - Package documentation now includes the README in the standard system documentation location.
  - Packaging is more consistent across standard and GUI build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->