### PR TITLE
refactor: feature aliasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ tui = ["dep:ratatui", "dep:crossterm", "dep:tui-bar-graph", "dep:colorgrad"]
 # plumbing); the frontend itself has not landed yet.
 gui = []
 self-update = ["dep:self_update", "dep:sha2", "dep:hex"]
-streaming = ["librespot-core", "librespot-playback", "librespot-connect", "librespot-oauth", "librespot-metadata", "librespot-protocol", "protobuf"]
+streaming = ["librespot-core", "librespot-playback", "librespot-connect", "librespot-oauth", "librespot-metadata", "librespot-protocol", "protobuf", "queue"]
 # Audio backend features
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]
 pulseaudio-backend = ["streaming", "librespot-playback/pulseaudio-backend"]
@@ -184,23 +184,35 @@ scripting = ["dep:mlua"]
 # Shared audio decode/output engine (rodio bundles symphonia). Pulled by any
 # source that plays decoded audio through the local sink (local files, Subsonic, Qobuz).
 audio-decode = ["dep:rodio"]
+# Meta-feature, this ensures at least one source that supports queues and needs
+# decoding is enabled.
+audio-decode-queue = ["queue"]
+# Meta-feature, this ensures onboarding is compiled only if there's at least one
+# feature needing it.
+onboarding = []
+# Meta-feature, this ensures at least one source with queue support.
+# Namely: `audio-decode-queue` + `streaming`
+queue = []
+# Meta-feature, this ensures at least one source that supports queues and needs
+# track download / track info fetching.
+queue-download = []
 # Convenience alias to pull in every alternative (non-Spotify) source at once,
 # e.g. `cargo run --features all-sources`. Deliberately NOT part of `default`:
 # the release binaries enable these explicitly (see .github/workflows/cd.yml) and
 # adding them to `default` would pull lofty/symphonia/md-5/stream-download into
 # every plain `cargo build`.
 all-sources = ["local-files", "subsonic", "internet-radio", "youtube", "qobuz"]
-local-files = ["audio-decode", "dep:lofty", "dep:symphonia"]
-subsonic = ["dep:md-5", "audio-decode", "dep:tempfile", "reqwest/stream"]
+local-files = ["audio-decode", "audio-decode-queue", "onboarding", "dep:lofty", "dep:symphonia"]
+subsonic = ["dep:md-5", "audio-decode", "audio-decode-queue", "onboarding", "queue-download", "dep:tempfile", "reqwest/stream"]
 internet-radio = ["audio-decode", "dep:stream-download", "dep:icy-metadata"]
 # YouTube via an external `yt-dlp` binary (no new crates): search with
 # `--flat-playlist --dump-json`, download the AAC/M4A audio (format 140, which
 # rodio's default `mp4` feature decodes) to a tempfile, play through the shared
 # LocalPlayer. Unofficial-fragile by design — see plan-multi-source.md.
-youtube = ["audio-decode", "dep:tempfile"]
+youtube = ["audio-decode", "audio-decode-queue", "onboarding", "queue-download", "dep:tempfile"]
 # Qobuz through its encrypted CMAF stream: each track is decrypted and rebuilt
 # as a FLAC tempfile while it plays through the shared LocalPlayer.
-qobuz = ["audio-decode", "dep:tempfile", "reqwest/stream", "dep:stream-download", "dep:bytes", "dep:md-5", "dep:sha2", "dep:hex", "dep:base64", "dep:regex", "dep:aes", "dep:cbc", "dep:ctr", "dep:hkdf"]
+qobuz = ["audio-decode", "audio-decode-queue", "queue-download", "dep:tempfile", "reqwest/stream", "dep:stream-download", "dep:bytes", "dep:md-5", "dep:sha2", "dep:hex", "dep:base64", "dep:regex", "dep:aes", "dep:cbc", "dep:ctr", "dep:hkdf"]
 
 # --- AI DJ / MCP -------------------------------------------------------------
 # Shared tool layer behind both front doors: the taste brief built from the local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,10 +186,10 @@ scripting = ["dep:mlua"]
 audio-decode = ["dep:rodio"]
 # Meta-feature, this ensures at least one source that supports queues and needs
 # decoding is enabled.
-audio-decode-queue = ["queue"]
 # Meta-feature, this ensures onboarding is compiled only if there's at least one
 # feature needing it.
 onboarding = []
+audio-decode-queue = []
 # Meta-feature, this ensures at least one source with queue support.
 # Namely: `audio-decode-queue` + `streaming`
 queue = []
@@ -202,17 +202,17 @@ queue-download = []
 # adding them to `default` would pull lofty/symphonia/md-5/stream-download into
 # every plain `cargo build`.
 all-sources = ["local-files", "subsonic", "internet-radio", "youtube", "qobuz"]
-local-files = ["audio-decode", "audio-decode-queue", "onboarding", "dep:lofty", "dep:symphonia"]
-subsonic = ["dep:md-5", "audio-decode", "audio-decode-queue", "onboarding", "queue-download", "dep:tempfile", "reqwest/stream"]
+local-files = ["audio-decode", "audio-decode-queue", "queue", "onboarding", "dep:lofty", "dep:symphonia"]
+subsonic = ["dep:md-5", "audio-decode", "audio-decode-queue", "queue", "onboarding", "queue-download", "dep:tempfile", "reqwest/stream"]
 internet-radio = ["audio-decode", "dep:stream-download", "dep:icy-metadata"]
 # YouTube via an external `yt-dlp` binary (no new crates): search with
 # `--flat-playlist --dump-json`, download the AAC/M4A audio (format 140, which
 # rodio's default `mp4` feature decodes) to a tempfile, play through the shared
 # LocalPlayer. Unofficial-fragile by design — see plan-multi-source.md.
-youtube = ["audio-decode", "audio-decode-queue", "onboarding", "queue-download", "dep:tempfile"]
+youtube = ["audio-decode", "audio-decode-queue", "queue", "onboarding", "queue-download", "dep:tempfile"]
 # Qobuz through its encrypted CMAF stream: each track is decrypted and rebuilt
 # as a FLAC tempfile while it plays through the shared LocalPlayer.
-qobuz = ["audio-decode", "audio-decode-queue", "queue-download", "dep:tempfile", "reqwest/stream", "dep:stream-download", "dep:bytes", "dep:md-5", "dep:sha2", "dep:hex", "dep:base64", "dep:regex", "dep:aes", "dep:cbc", "dep:ctr", "dep:hkdf"]
+qobuz = ["audio-decode", "audio-decode-queue", "queue", "queue-download", "dep:tempfile", "reqwest/stream", "dep:stream-download", "dep:bytes", "dep:md-5", "dep:sha2", "dep:hex", "dep:base64", "dep:regex", "dep:aes", "dep:cbc", "dep:ctr", "dep:hkdf"]
 
 # --- AI DJ / MCP -------------------------------------------------------------
 # Shared tool layer behind both front doors: the taste brief built from the local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,9 +186,6 @@ scripting = ["dep:mlua"]
 audio-decode = ["dep:rodio"]
 # Meta-feature, this ensures at least one source that supports queues and needs
 # decoding is enabled.
-# Meta-feature, this ensures onboarding is compiled only if there's at least one
-# feature needing it.
-onboarding = []
 audio-decode-queue = []
 # Meta-feature, this ensures at least one source with queue support.
 # Namely: `audio-decode-queue` + `streaming`
@@ -202,14 +199,14 @@ queue-download = []
 # adding them to `default` would pull lofty/symphonia/md-5/stream-download into
 # every plain `cargo build`.
 all-sources = ["local-files", "subsonic", "internet-radio", "youtube", "qobuz"]
-local-files = ["audio-decode", "audio-decode-queue", "queue", "onboarding", "dep:lofty", "dep:symphonia"]
-subsonic = ["dep:md-5", "audio-decode", "audio-decode-queue", "queue", "onboarding", "queue-download", "dep:tempfile", "reqwest/stream"]
+local-files = ["audio-decode", "audio-decode-queue", "queue", "dep:lofty", "dep:symphonia"]
+subsonic = ["dep:md-5", "audio-decode", "audio-decode-queue", "queue", "queue-download", "dep:tempfile", "reqwest/stream"]
 internet-radio = ["audio-decode", "dep:stream-download", "dep:icy-metadata"]
 # YouTube via an external `yt-dlp` binary (no new crates): search with
 # `--flat-playlist --dump-json`, download the AAC/M4A audio (format 140, which
 # rodio's default `mp4` feature decodes) to a tempfile, play through the shared
 # LocalPlayer. Unofficial-fragile by design — see plan-multi-source.md.
-youtube = ["audio-decode", "audio-decode-queue", "queue", "onboarding", "queue-download", "dep:tempfile"]
+youtube = ["audio-decode", "audio-decode-queue", "queue", "queue-download", "dep:tempfile"]
 # Qobuz through its encrypted CMAF stream: each track is decrypted and rebuilt
 # as a FLAC tempfile while it plays through the shared LocalPlayer.
 qobuz = ["audio-decode", "audio-decode-queue", "queue", "queue-download", "dep:tempfile", "reqwest/stream", "dep:stream-download", "dep:bytes", "dep:md-5", "dep:sha2", "dep:hex", "dep:base64", "dep:regex", "dep:aes", "dep:cbc", "dep:ctr", "dep:hkdf"]

--- a/src/core/app/construction.rs
+++ b/src/core/app/construction.rs
@@ -58,23 +58,11 @@ impl Default for App {
       queue: None,
       native_queue: Vec::new(),
       queue_suspended: None,
-      #[cfg(any(
-        feature = "streaming",
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "queue")]
       queue_now: None,
       #[cfg(feature = "streaming")]
       spotify_queue_guard_reloads: 0,
-      #[cfg(any(
-        feature = "streaming",
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "queue")]
       queue_slot_desired_playing: true,
       playlist_offset: 0,
       playlist_tracks: None,
@@ -184,13 +172,7 @@ impl Default for App {
       radio_playback: None,
       #[cfg(feature = "youtube")]
       youtube_playback: None,
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "internet-radio",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode")]
       decoded_sink_claim: None,
       #[cfg(feature = "streaming")]
       streaming_recovery_tx: None,

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -15,13 +15,7 @@ use crate::core::user_config::{color_to_string, normalize_tick_rate_milliseconds
 use crate::infra::history::{RecapPeriod, StatsData, StreakSummary};
 use crate::infra::network::sync::{ControlMode, PartySession, PartyStatus};
 use crate::infra::network::IoEvent;
-#[cfg(any(
-  feature = "streaming",
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "queue")]
 use crate::infra::queue::QueueNowPlaying;
 use anyhow::anyhow;
 use rspotify::{
@@ -39,11 +33,7 @@ use std::sync::mpsc::Sender;
 // and the decoded queue-slot accessors below (whose gate is the queueable
 // sources, not `audio-decode` — a radio-only build has no queue slot).
 #[cfg(any(
-  feature = "streaming",
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube",
+  feature = "queue",
   all(feature = "mpris", target_os = "linux")
 ))]
 use std::sync::Arc;
@@ -197,13 +187,7 @@ pub struct App {
   /// track — i.e. native streaming or a source with a finite track list, which
   /// excludes internet radio — and every read goes through the unconditional
   /// [`Self::queue_owns_playback`] accessor.
-  #[cfg(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "queue")]
   pub queue_now: Option<crate::infra::queue::QueueNowPlaying>,
   /// Bounded retry guard for the native-Spotify queue slot. When a queued
   /// Spotify track is playing via a direct `player.load` (no Spirc context) and
@@ -218,13 +202,7 @@ pub struct App {
   /// decoded item and by the suspended context's resume. Unlike
   /// `native_is_playing` this survives a backend teardown, so a recovery
   /// replay of the slot can honor a user's pause.
-  #[cfg(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "queue")]
   pub queue_slot_desired_playing: bool,
   /// Decoded cover art for the current track plus its load status. The TUI
   /// renderer (`tui::cover_art`) caches its terminal protocols on this
@@ -532,13 +510,7 @@ pub struct App {
   /// (a failed start, a lost output device), cleared when an explicit Spotify
   /// start takes the sink. Covers the window in which every `*_playback` field
   /// is `None` for a source the user asked for.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   decoded_sink_claim: Option<Source>,
   /// Sender used to recover native streaming when a stale/disconnected player is detected.
   #[cfg(feature = "streaming")]

--- a/src/core/app/mod.rs
+++ b/src/core/app/mod.rs
@@ -32,10 +32,7 @@ use std::sync::mpsc::Sender;
 // Bare `Arc` here is only ever named by the streaming player, the MPRIS manager,
 // and the decoded queue-slot accessors below (whose gate is the queueable
 // sources, not `audio-decode` — a radio-only build has no queue slot).
-#[cfg(any(
-  feature = "queue",
-  all(feature = "mpris", target_os = "linux")
-))]
+#[cfg(any(feature = "queue", all(feature = "mpris", target_os = "linux")))]
 use std::sync::Arc;
 use std::{
   cmp::{max, min},

--- a/src/core/app/persistence.rs
+++ b/src/core/app/persistence.rs
@@ -26,12 +26,7 @@ impl App {
   /// active decoded context was suspended under the native queue, or `None` when
   /// no decoded context is suspended. Only one context is ever active, so this
   /// unambiguously describes it.
-  #[cfg(any(
-    feature = "youtube",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "local-files"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   fn suspended_resume(&self) -> Option<(Option<usize>, u64)> {
     match self.queue_suspended.as_ref()? {
       #[cfg(feature = "local-files")]
@@ -65,13 +60,7 @@ impl App {
     if !self.has_persistable_playback() {
       return None;
     }
-    #[cfg(any(
-      feature = "youtube",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "local-files",
-      feature = "internet-radio"
-    ))]
+    #[cfg(feature = "audio-decode")]
     use crate::core::persisted_playback::PersistedPlayback;
     #[cfg(feature = "youtube")]
     if let Some(s) = self.youtube_playback.as_ref() {
@@ -233,12 +222,7 @@ impl App {
   fn has_persistable_playback(&self) -> bool {
     // Mirrors `current_persisted_playback`: a decoded context suspended past
     // its end (resume_index == None) does not persist.
-    #[cfg(any(
-      feature = "youtube",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "local-files"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     {
       let context_resumable = !matches!(self.suspended_resume(), Some((None, _)));
       #[cfg(feature = "youtube")]

--- a/src/core/app/playback_routing.rs
+++ b/src/core/app/playback_routing.rs
@@ -90,49 +90,25 @@ impl App {
 
   /// Record that `source` took the audio sink; its start path calls this
   /// before it pauses librespot.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   pub(crate) fn claim_decoded_sink(&mut self, source: Source) {
     self.decoded_sink_claim = Some(source);
   }
 
   /// Spotify takes the sink back: an explicit Spotify start reached the
   /// network layer.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   pub(crate) fn release_decoded_sink_claim(&mut self) {
     self.decoded_sink_claim = None;
   }
 
   /// Whether a decoded source holds the sink claim, session or not.
   pub(crate) fn decoded_sink_claimed(&self) -> bool {
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     {
       self.decoded_sink_claim.is_some()
     }
-    #[cfg(not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    )))]
+    #[cfg(not(feature = "audio-decode"))]
     {
       false
     }
@@ -151,23 +127,11 @@ impl App {
   /// `Some(true)` when a decoded source owns the sink and plays, `Some(false)`
   /// when it owns the sink and is paused, `None` when none owns it.
   pub(crate) fn decoded_playing_state(&self) -> Option<bool> {
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     {
       self.active_decoded_player().map(|p| !p.is_paused())
     }
-    #[cfg(not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    )))]
+    #[cfg(not(feature = "audio-decode"))]
     {
       None
     }
@@ -259,12 +223,7 @@ impl App {
   pub(crate) fn active_decoded_source(&self) -> bool {
     // The native queue slot playing a decoded track owns the sink even when no
     // per-source `*_playback` context is set (e.g. queueing from an idle app).
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     if self.queue_now_decoded_player().is_some() {
       return true;
     }
@@ -275,13 +234,7 @@ impl App {
     }
     // A decoded start in flight, or a source whose session died with nothing to
     // replace it, still owns the sink: librespot is paused underneath.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     if self.decoded_sink_claim.is_some() {
       return true;
     }
@@ -344,13 +297,7 @@ impl App {
   /// Take every decoded session except `keep`'s, so one backend can own the
   /// output device, and return their players. Stop them off the `App` lock: a
   /// sink clear waits for the audio thread.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   pub(crate) fn take_decoded_sessions_except(
     &mut self,
     keep: crate::core::source::Source,
@@ -386,20 +333,9 @@ impl App {
   /// Spotify (or nothing) owns it. All five decode through the same `LocalPlayer`
   /// sink, so a single accessor covers transport/seek routing for every one.
   /// Ordering mirrors [`Self::active_decoded_source`].
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   pub fn active_decoded_player(&self) -> Option<&std::sync::Arc<crate::infra::audio::LocalPlayer>> {
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     if let Some(p) = self.queue_now_decoded_player() {
       return Some(p);
     }
@@ -439,12 +375,7 @@ impl App {
   /// and seek keys become correct no-ops for radio. In a build with all seekable
   /// source features off this reduces to `None`.
   pub(super) fn active_source_position_ms(&self) -> Option<u128> {
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     if let Some(p) = self.queue_now_decoded_player() {
       return Some(p.position().as_millis());
     }

--- a/src/core/app/queue.rs
+++ b/src/core/app/queue.rs
@@ -108,23 +108,11 @@ impl App {
   /// where the slot cannot exist (slim, or one whose only decoded source is
   /// internet radio, which is never queueable).
   pub fn queue_owns_playback(&self) -> bool {
-    #[cfg(any(
-      feature = "streaming",
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "queue")]
     {
       self.queue_now.is_some()
     }
-    #[cfg(not(any(
-      feature = "streaming",
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )))]
+    #[cfg(not(feature = "queue"))]
     {
       false
     }
@@ -155,12 +143,7 @@ impl App {
   /// on exactly those four sources: they are the decoded ones a queue item can
   /// name, so a build whose only decoded source is internet radio has no
   /// decoded slot to look up.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   pub fn queue_now_decoded_player(&self) -> Option<&Arc<crate::infra::audio::LocalPlayer>> {
     match self.queue_now.as_ref()? {
       QueueNowPlaying::Decoded(d) => Some(&d.player),
@@ -171,12 +154,7 @@ impl App {
 
   /// Take the queue slot, returning its player when it was a decoded track (so
   /// the caller can stop it). Clears [`Self::queue_now`] either way.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   pub fn take_queue_now_decoded_player(&mut self) -> Option<Arc<crate::infra::audio::LocalPlayer>> {
     match self.queue_now.take() {
       Some(QueueNowPlaying::Decoded(d)) => Some(d.player),
@@ -188,33 +166,16 @@ impl App {
   /// persistence to prepend it back onto the saved queue so a mid-queue quit
   /// doesn't lose the in-flight track.
   pub(super) fn queue_now_track(&self) -> Option<&TrackInfo> {
-    #[cfg(any(
-      feature = "streaming",
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "queue")]
     {
       match self.queue_now.as_ref()? {
-        #[cfg(any(
-          feature = "local-files",
-          feature = "subsonic",
-          feature = "qobuz",
-          feature = "youtube"
-        ))]
+        #[cfg(feature = "audio-decode-queue")]
         QueueNowPlaying::Decoded(d) => Some(&d.track),
         #[cfg(feature = "streaming")]
         QueueNowPlaying::Spotify { track } => Some(track),
       }
     }
-    #[cfg(not(any(
-      feature = "streaming",
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )))]
+    #[cfg(not(feature = "queue"))]
     {
       None
     }
@@ -293,12 +254,7 @@ impl App {
     playing_base62_id: &str,
   ) -> Option<String> {
     let queued_uri = match self.queue_now.as_ref()? {
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       QueueNowPlaying::Decoded(_) => return None,
       QueueNowPlaying::Spotify { track } => track.uri.clone(),
     }?;

--- a/src/core/app/queue_suspend.rs
+++ b/src/core/app/queue_suspend.rs
@@ -12,10 +12,7 @@ impl App {
   /// [`crate::infra::queue::resume_index_after_queue`].
   pub(crate) fn suspend_active_decoded_context_for_skip(
     &mut self,
-    #[cfg_attr(
-      not(feature = "audio-decode-queue"),
-      allow(unused_variables)
-    )]
+    #[cfg_attr(not(feature = "audio-decode-queue"), allow(unused_variables))]
     cause: crate::infra::queue::SuspendCause,
   ) {
     // `resume_index_after_queue` applies the per-mode wrap/clamp: Repeat All
@@ -23,10 +20,7 @@ impl App {
     // first one rather than reading as exhausted (`None`); Repeat One resumes
     // the *same* track on an auto-advance (a queued song must not consume the
     // repeat) but advances on a manual skip; Off clamps to `None` at the boundary.
-    #[cfg_attr(
-      not(feature = "audio-decode-queue"),
-      allow(unused_variables)
-    )]
+    #[cfg_attr(not(feature = "audio-decode-queue"), allow(unused_variables))]
     let repeat = self.decoded_repeat;
     #[cfg(feature = "local-files")]
     #[allow(clippy::needless_return)]

--- a/src/core/app/queue_suspend.rs
+++ b/src/core/app/queue_suspend.rs
@@ -13,12 +13,7 @@ impl App {
   pub(crate) fn suspend_active_decoded_context_for_skip(
     &mut self,
     #[cfg_attr(
-      not(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      )),
+      not(feature = "audio-decode-queue"),
       allow(unused_variables)
     )]
     cause: crate::infra::queue::SuspendCause,
@@ -29,16 +24,12 @@ impl App {
     // the *same* track on an auto-advance (a queued song must not consume the
     // repeat) but advances on a manual skip; Off clamps to `None` at the boundary.
     #[cfg_attr(
-      not(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      )),
+      not(feature = "audio-decode-queue"),
       allow(unused_variables)
     )]
     let repeat = self.decoded_repeat;
     #[cfg(feature = "local-files")]
+    #[allow(clippy::needless_return)]
     if let Some(local) = self.local_playback.as_mut() {
       let resume_index = crate::infra::queue::resume_index_after_queue(
         local.index,
@@ -54,6 +45,7 @@ impl App {
       return;
     }
     #[cfg(feature = "subsonic")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.subsonic_playback.as_mut() {
       let resume_index =
         crate::infra::queue::resume_index_after_queue(s.index, s.tracks.len(), repeat, cause);
@@ -65,6 +57,7 @@ impl App {
       return;
     }
     #[cfg(feature = "youtube")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.youtube_playback.as_mut() {
       let resume_index =
         crate::infra::queue::resume_index_after_queue(s.index, s.tracks.len(), repeat, cause);
@@ -76,6 +69,7 @@ impl App {
       return;
     }
     #[cfg(feature = "qobuz")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.qobuz_playback.as_mut() {
       let resume_index =
         crate::infra::queue::resume_index_after_queue(s.index, s.tracks.len(), repeat, cause);
@@ -91,6 +85,7 @@ impl App {
       return;
     }
     #[cfg(feature = "internet-radio")]
+    #[allow(clippy::needless_return)]
     if let Some(radio) = self.radio_playback.take() {
       radio.player.stop();
       self.queue_suspended = Some(crate::core::queue::SuspendedContext::Radio {
@@ -104,6 +99,7 @@ impl App {
   /// seekable position, so it is stashed for reconnect like the skip path.
   pub(crate) fn suspend_active_decoded_context_mid_track(&mut self) {
     #[cfg(feature = "local-files")]
+    #[allow(clippy::needless_return)]
     if let Some(local) = self.local_playback.as_mut() {
       let position_ms = local.player.position().as_millis() as u64;
       let index = local.index;
@@ -115,6 +111,7 @@ impl App {
       return;
     }
     #[cfg(feature = "subsonic")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.subsonic_playback.as_mut() {
       let position_ms = s.player.position().as_millis() as u64;
       let index = s.index;
@@ -126,6 +123,7 @@ impl App {
       return;
     }
     #[cfg(feature = "youtube")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.youtube_playback.as_mut() {
       let position_ms = s.player.position().as_millis() as u64;
       let index = s.index;
@@ -137,6 +135,7 @@ impl App {
       return;
     }
     #[cfg(feature = "qobuz")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.qobuz_playback.as_mut() {
       let position_ms = s.player.position().as_millis() as u64;
       let index = s.index;

--- a/src/core/app/shuffle_repeat.rs
+++ b/src/core/app/shuffle_repeat.rs
@@ -8,12 +8,7 @@ impl App {
   /// Call only when [`active_queueable_decoded_source`](Self::active_queueable_decoded_source)
   /// holds, so exactly one branch applies.
   #[cfg_attr(
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )),
+    not(feature = "audio-decode-queue"),
     allow(unused_variables)
   )]
   fn apply_decoded_shuffle(&mut self) {
@@ -24,6 +19,7 @@ impl App {
     // [`reconcile_decoded_shuffle`](Self::reconcile_decoded_shuffle), driven by
     // the runner tick, applies it once the advance commits.
     #[cfg(feature = "local-files")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.local_playback.as_mut() {
       if !s.advancing {
         s.set_shuffle(on);
@@ -31,6 +27,7 @@ impl App {
       return;
     }
     #[cfg(feature = "subsonic")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.subsonic_playback.as_mut() {
       if !s.advancing {
         s.set_shuffle(on);
@@ -38,6 +35,7 @@ impl App {
       return;
     }
     #[cfg(feature = "youtube")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.youtube_playback.as_mut() {
       if !s.advancing {
         s.set_shuffle(on);
@@ -56,12 +54,7 @@ impl App {
   /// because a track change was in flight. Driven by the runner tick, so it lands
   /// as soon as the advance commits (`advancing` clears). A no-op whenever the
   /// order already matches `decoded_shuffle`, so it is cheap to call every tick.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   pub(crate) fn reconcile_decoded_shuffle(&mut self) {
     // The native queue owns the sink: any per-source struct is a suspended
     // context whose order is reconciled when it resumes, not now.
@@ -70,6 +63,7 @@ impl App {
     }
     let on = self.decoded_shuffle;
     #[cfg(feature = "local-files")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.local_playback.as_mut() {
       if !s.advancing && s.shuffle_backup.is_some() != on {
         s.set_shuffle(on);
@@ -77,6 +71,7 @@ impl App {
       return;
     }
     #[cfg(feature = "subsonic")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.subsonic_playback.as_mut() {
       if !s.advancing && s.shuffle_backup.is_some() != on {
         s.set_shuffle(on);
@@ -84,6 +79,7 @@ impl App {
       return;
     }
     #[cfg(feature = "youtube")]
+    #[allow(clippy::needless_return)]
     if let Some(s) = self.youtube_playback.as_mut() {
       if !s.advancing && s.shuffle_backup.is_some() != on {
         s.set_shuffle(on);
@@ -107,12 +103,7 @@ impl App {
   /// handler) when the native queue owns playback or no queueable decoded source
   /// is active — the same ownership gate as the MPRIS mode setters, so a
   /// suspended context under the queue is never touched.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   pub(crate) fn set_decoded_repeat_from_state(
     &mut self,
     state: rspotify::model::enums::RepeatState,
@@ -141,13 +132,7 @@ impl App {
   #[cfg(all(
     feature = "mpris",
     target_os = "linux",
-    any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    )
+    feature = "audio-decode",
   ))]
   pub fn set_decoded_shuffle(&mut self, on: bool) -> bool {
     if !self.active_queueable_decoded_source() {
@@ -166,13 +151,7 @@ impl App {
   #[cfg(all(
     feature = "mpris",
     target_os = "linux",
-    any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    )
+    feature = "audio-decode"
   ))]
   pub fn set_decoded_repeat(&mut self, mode: RepeatMode) -> bool {
     if !self.active_queueable_decoded_source() {

--- a/src/core/app/shuffle_repeat.rs
+++ b/src/core/app/shuffle_repeat.rs
@@ -7,10 +7,7 @@ impl App {
   /// is unaffected (it stays at the front), so audio continues uninterrupted.
   /// Call only when [`active_queueable_decoded_source`](Self::active_queueable_decoded_source)
   /// holds, so exactly one branch applies.
-  #[cfg_attr(
-    not(feature = "audio-decode-queue"),
-    allow(unused_variables)
-  )]
+  #[cfg_attr(not(feature = "audio-decode-queue"), allow(unused_variables))]
   fn apply_decoded_shuffle(&mut self) {
     let on = self.decoded_shuffle;
     // While a track change is in flight (`advancing`), an async `play_index`
@@ -129,11 +126,7 @@ impl App {
   /// client's property instead, because reaching this method at all means a
   /// decoded source (radio, or the queue slot) owns playback and the Spotify
   /// context is not what the user is listening to.
-  #[cfg(all(
-    feature = "mpris",
-    target_os = "linux",
-    feature = "audio-decode",
-  ))]
+  #[cfg(all(feature = "mpris", target_os = "linux", feature = "audio-decode",))]
   pub fn set_decoded_shuffle(&mut self, on: bool) -> bool {
     if !self.active_queueable_decoded_source() {
       return false;
@@ -148,11 +141,7 @@ impl App {
   /// Set the decoded repeat mode to an explicit value from an external media
   /// controller (MPRIS). Returns whether a queueable decoded source consumed it
   /// (see [`set_decoded_shuffle`](Self::set_decoded_shuffle)).
-  #[cfg(all(
-    feature = "mpris",
-    target_os = "linux",
-    feature = "audio-decode"
-  ))]
+  #[cfg(all(feature = "mpris", target_os = "linux", feature = "audio-decode"))]
   pub fn set_decoded_repeat(&mut self, mode: RepeatMode) -> bool {
     if !self.active_queueable_decoded_source() {
       return false;

--- a/src/core/app/transport.rs
+++ b/src/core/app/transport.rs
@@ -24,12 +24,7 @@ impl App {
   pub fn toggle_playback(&mut self) {
     // The native queue slot owns the sink: toggle its player directly (covers the
     // idle-app case where no per-source context is set).
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     if let Some(player) = self.queue_now_decoded_player() {
       if player.is_paused() {
         player.resume();

--- a/src/core/driver/mod.rs
+++ b/src/core/driver/mod.rs
@@ -425,12 +425,7 @@ impl Driver {
     // whatever play/pause state the session had. The seek and the pause ride
     // on the session as `resume_at`, applied by the path that stages the
     // track, never as events queued behind it.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     macro_rules! decoded_device_recovery {
       ($app:ident, $playback:ident) => {
         // Not while the queue owns the sink: the session below is suspended, and
@@ -519,12 +514,7 @@ impl Driver {
     // a removal clears the slot's desired play state, which every path that
     // stages the next item (and the suspended context's resume) reads, so the
     // queue does not play out loud on a device the user just left.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     {
       use crate::infra::audio::Reopen;
       use crate::infra::queue::QueueNowPlaying;
@@ -571,12 +561,7 @@ impl Driver {
     // Native queue slot: when the queued track finishes, advance the queue
     // (play the next queued item, or resume the suspended context). Runs
     // before the per-source blocks so it takes precedence over them.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     {
       use crate::infra::queue::QueueNowPlaying;
       let advance = match app.queue_now.as_mut() {
@@ -627,12 +612,7 @@ impl Driver {
     // dispatching) because the sink stays empty for the whole decode — or,
     // for Subsonic/YouTube, multi-second download — window; without it the
     // next tick would re-dispatch and skip several tracks per advance.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     macro_rules! decoded_auto_advance {
       ($app:ident, $playback:ident, $queue:ident) => {
         if !$app.queue_owns_playback() {
@@ -688,12 +668,7 @@ impl Driver {
     // Apply any shuffle toggle that was deferred while a track change was in
     // flight, now that the advance may have committed (a cheap no-op when the
     // queue order already matches the decoded shuffle state).
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     app.reconcile_decoded_shuffle();
 
     // Internet radio has no queue to auto-advance; instead the tick watches
@@ -725,12 +700,7 @@ impl Driver {
     // The native queue slot owns the sink when playing a decoded track; read
     // progress from its player first (it may share the suspended context's
     // player, in which case a per-source block below reads the same value).
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode-queue")]
     if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
       source_owns_playback = true;
       app.song_progress_ms = d.player.position().as_millis();

--- a/src/core/driver/plan.rs
+++ b/src/core/driver/plan.rs
@@ -7,12 +7,7 @@
 
 #[cfg(feature = "art-decode")]
 use crate::core::art::CoverArtStatus;
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 use crate::infra::queue::{advance_decision, Decision, RepeatMode};
 use std::time::{Duration, Instant, SystemTime};
 
@@ -84,12 +79,7 @@ pub(super) fn session_persist_action(
 /// `advancing` is the atomic check-and-set flag that guarantees one dispatch
 /// per finished track: the sink stays empty for the whole decode/download of
 /// the next item, so without it every tick in that window would re-dispatch.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub(super) fn native_queue_advance_due(finished: bool, advancing: bool) -> bool {
   finished && !advancing
 }
@@ -97,12 +87,7 @@ pub(super) fn native_queue_advance_due(finished: bool, advancing: bool) -> bool 
 /// What the tick does about a decoded-source session, as plain data so the
 /// glue between [`advance_decision`] and the dispatch/suspend/teardown calls
 /// is testable without a sink.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 #[derive(Debug, PartialEq)]
 pub(super) enum DecodedAdvance {
   /// Mark the session advancing and dispatch the track change: replay the
@@ -119,12 +104,7 @@ pub(super) enum DecodedAdvance {
 
 /// Decoded-source auto-advance for one tick, composing [`advance_decision`]
 /// (the shared end-of-track policy) with the action the driver takes on it.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub(super) fn decoded_advance(
   finished: bool,
   advancing: bool,
@@ -284,12 +264,7 @@ mod tests {
     );
   }
 
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   mod decoded {
     use super::*;
 

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -148,13 +148,7 @@ async fn apply_selections(
 fn compiled_in_sources() -> Vec<Source> {
   // `mut` is unused in a Spotify-only (slim) build where every push is cfg'd out.
   #[cfg_attr(
-    not(any(
-      feature = "youtube",
-      feature = "subsonic",
-      feature = "internet-radio",
-      feature = "local-files",
-      feature = "qobuz"
-    )),
+    not(feature = "audio-decode"),
     allow(unused_mut)
   )]
   let mut options = vec![Source::Spotify];
@@ -174,7 +168,7 @@ fn compiled_in_sources() -> Vec<Source> {
 // `user_config` and `onboarding` are only read by credential/config-collecting
 // sources; a build with none of them (slim, or Qobuz alone) leaves them unused.
 #[cfg_attr(
-  not(any(feature = "subsonic", feature = "youtube", feature = "local-files")),
+  not(feature = "onboarding"),
   allow(unused_variables)
 )]
 async fn configure_source(

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -164,7 +164,10 @@ fn compiled_in_sources() -> Vec<Source> {
 
 // `user_config` and `onboarding` are only read by credential/config-collecting
 // sources; a build with none of them (slim, or Qobuz alone) leaves them unused.
-#[cfg_attr(not(feature = "onboarding"), allow(unused_variables))]
+#[cfg_attr(
+  not(any(feature = "subsonic", feature = "youtube", feature = "local-files")),
+  allow(unused_variables)
+)]
 async fn configure_source(
   source: Source,
   user_config: &mut UserConfig,

--- a/src/core/first_run.rs
+++ b/src/core/first_run.rs
@@ -147,10 +147,7 @@ async fn apply_selections(
 /// Spotify is always present.
 fn compiled_in_sources() -> Vec<Source> {
   // `mut` is unused in a Spotify-only (slim) build where every push is cfg'd out.
-  #[cfg_attr(
-    not(feature = "audio-decode"),
-    allow(unused_mut)
-  )]
+  #[cfg_attr(not(feature = "audio-decode"), allow(unused_mut))]
   let mut options = vec![Source::Spotify];
   #[cfg(feature = "youtube")]
   options.push(Source::YouTube);
@@ -167,10 +164,7 @@ fn compiled_in_sources() -> Vec<Source> {
 
 // `user_config` and `onboarding` are only read by credential/config-collecting
 // sources; a build with none of them (slim, or Qobuz alone) leaves them unused.
-#[cfg_attr(
-  not(feature = "onboarding"),
-  allow(unused_variables)
-)]
+#[cfg_attr(not(feature = "onboarding"), allow(unused_variables))]
 async fn configure_source(
   source: Source,
   user_config: &mut UserConfig,

--- a/src/core/onboarding.rs
+++ b/src/core/onboarding.rs
@@ -67,7 +67,10 @@ pub trait Onboarding: Send + Sync {
   /// completed by a later [`Self::info`] (a flushed `print!` on the console).
   // Only the source-configuration flows emit progress fragments; builds
   // without those sources have no caller.
-  #[cfg_attr(not(feature = "onboarding"), allow(dead_code))]
+  #[cfg_attr(
+    not(any(feature = "subsonic", feature = "qobuz", feature = "youtube")),
+    allow(dead_code)
+  )]
   fn progress(&self, text: &str);
 
   /// Show `prompt` verbatim (nothing appended) and read one line of input,

--- a/src/core/onboarding.rs
+++ b/src/core/onboarding.rs
@@ -67,10 +67,7 @@ pub trait Onboarding: Send + Sync {
   /// completed by a later [`Self::info`] (a flushed `print!` on the console).
   // Only the source-configuration flows emit progress fragments; builds
   // without those sources have no caller.
-  #[cfg_attr(
-    not(feature = "onboarding"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "onboarding"), allow(dead_code))]
   fn progress(&self, text: &str);
 
   /// Show `prompt` verbatim (nothing appended) and read one line of input,

--- a/src/core/onboarding.rs
+++ b/src/core/onboarding.rs
@@ -68,7 +68,7 @@ pub trait Onboarding: Send + Sync {
   // Only the source-configuration flows emit progress fragments; builds
   // without those sources have no caller.
   #[cfg_attr(
-    not(any(feature = "subsonic", feature = "qobuz", feature = "youtube")),
+    not(feature = "onboarding"),
     allow(dead_code)
   )]
   fn progress(&self, text: &str);

--- a/src/infra/audio/mod.rs
+++ b/src/infra/audio/mod.rs
@@ -14,12 +14,7 @@ mod player;
 pub use player::LocalPlayer;
 #[cfg(feature = "qobuz")]
 pub use player::PreparedStream;
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub use player::Reopen;
 
 #[cfg(any(feature = "audio-viz", feature = "audio-viz-cpal"))]

--- a/src/infra/audio/player.rs
+++ b/src/infra/audio/player.rs
@@ -256,12 +256,7 @@ impl LocalPlayer {
   /// else. Recovery pauses only for removal — that is what macOS itself does,
   /// and a device the user just *plugged in* should keep playing.
   #[cfg_attr(
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )),
+    not(feature = "audio-decode-queue"),
     allow(dead_code)
   )]
   pub fn device_removed(&self) -> bool {
@@ -392,12 +387,7 @@ impl LocalPlayer {
   /// Radio has no track to restage, so a build with just `internet-radio`
   /// never recovers a device.
   #[cfg_attr(
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )),
+    not(feature = "audio-decode-queue"),
     allow(dead_code)
   )]
   pub fn recover_device(&self) -> Reopen {

--- a/src/infra/audio/player.rs
+++ b/src/infra/audio/player.rs
@@ -255,10 +255,7 @@ impl LocalPlayer {
   /// DAC pulled), as against the OS merely moving its default output somewhere
   /// else. Recovery pauses only for removal — that is what macOS itself does,
   /// and a device the user just *plugged in* should keep playing.
-  #[cfg_attr(
-    not(feature = "audio-decode-queue"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "audio-decode-queue"), allow(dead_code))]
   pub fn device_removed(&self) -> bool {
     self.sink.lock().unwrap().lost.load(Ordering::Relaxed)
   }
@@ -386,10 +383,7 @@ impl LocalPlayer {
   ///
   /// Radio has no track to restage, so a build with just `internet-radio`
   /// never recovers a device.
-  #[cfg_attr(
-    not(feature = "audio-decode-queue"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "audio-decode-queue"), allow(dead_code))]
   pub fn recover_device(&self) -> Reopen {
     let attempts = {
       let mut state = self.reopen.lock().unwrap();

--- a/src/infra/media_metadata.rs
+++ b/src/infra/media_metadata.rs
@@ -64,13 +64,7 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
   // MPRIS/macOS fallback path) would keep showing the stale paused Spotify
   // track. Progress and play-state are read live from the owning source's
   // player, so they stay correct regardless of librespot's frozen position.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode")]
   if let Some(snapshot) = source_playback_snapshot(app) {
     return Some(snapshot);
   }
@@ -174,23 +168,12 @@ pub fn current_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
 /// currently owns playback (at most one `*_playback` is `Some`). Metadata comes
 /// from the source's stored track info; progress and play-state are read live
 /// from its player. Returns `None` when no such source is active.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "internet-radio",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode")]
 fn source_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
   // The native queue slot playing a decoded track wins over every per-source
   // context: it is what is actually audible, and it drives the playbar / MPRIS /
   // cover art / lyrics via the shared track-change detector.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
     let mut snapshot = source_snapshot(
       d.track.name.clone(),
@@ -325,13 +308,7 @@ fn source_playback_snapshot(app: &App) -> Option<PlaybackSnapshot> {
 /// embedded art fetched separately; radio has none). Sources are always treated
 /// as a single track; shuffle/repeat come from the player-global decoded state
 /// (the radio caller overrides them since a live stream has no queue).
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "internet-radio",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode")]
 #[allow(clippy::too_many_arguments)]
 fn source_snapshot(
   title: String,

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -150,12 +150,7 @@ pub enum IoEvent {
   /// network handler. Only the decoded queue slot can lose a device, so in a
   /// build without a queueable decoded source nothing dispatches it.
   #[cfg_attr(
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    )),
+    not(feature = "audio-decode-queue"),
     allow(dead_code)
   )]
   FinishNativeQueue,
@@ -164,12 +159,7 @@ pub enum IoEvent {
   /// `route_youtube_event`); it never reaches the Spotify network handler. Only
   /// dispatched by the runner tick under a decoded source feature.
   #[cfg_attr(
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "youtube",
-      feature = "qobuz"
-    )),
+    not(feature = "audio-decode-queue"),
     allow(dead_code)
   )]
   ReplayCurrentTrack,

--- a/src/infra/network/mod.rs
+++ b/src/infra/network/mod.rs
@@ -149,19 +149,13 @@ pub enum IoEvent {
   /// `infra::queue::dispatch::route_queue_event`; it never reaches the Spotify
   /// network handler. Only the decoded queue slot can lose a device, so in a
   /// build without a queueable decoded source nothing dispatches it.
-  #[cfg_attr(
-    not(feature = "audio-decode-queue"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "audio-decode-queue"), allow(dead_code))]
   FinishNativeQueue,
   /// Replay the current track of the active decoded source (repeat-one). Consumed
   /// by the per-source routers (`route_local_event` / `route_subsonic_event` /
   /// `route_youtube_event`); it never reaches the Spotify network handler. Only
   /// dispatched by the runner tick under a decoded source feature.
-  #[cfg_attr(
-    not(feature = "audio-decode-queue"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "audio-decode-queue"), allow(dead_code))]
   ReplayCurrentTrack,
   /// Resume a suspended native-streaming Spotify context after the native queue
   /// drains (context URI, resume-track URI). Re-loads the context on the native

--- a/src/infra/network/playback.rs
+++ b/src/infra/network/playback.rs
@@ -1441,13 +1441,7 @@ impl PlaybackNetwork for Network {
     // An explicit Spotify start that reached this handler passed every source
     // router and the pump's prelude: Spotify takes the sink, so the decoded
     // claim ends here. A bare resume never releases it.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     if context_id.is_some() || uris.is_some() {
       self.app.lock().await.release_decoded_sink_claim();
     }

--- a/src/infra/player/events.rs
+++ b/src/infra/player/events.rs
@@ -563,24 +563,14 @@ async fn handle_player_events(
           let stray_over_queue = {
             let guard = app.lock().await;
             let decoded_slot = {
-              #[cfg(any(
-                feature = "local-files",
-                feature = "subsonic",
-                feature = "qobuz",
-                feature = "youtube"
-              ))]
+              #[cfg(feature = "audio-decode-queue")]
               {
                 guard.queue_now_decoded_player().is_some()
               }
               // Without a queueable decoded source the slot can never be
               // decoded (internet radio enables `audio-decode` but is never
               // queued), so there is nothing to shadow librespot here.
-              #[cfg(not(any(
-                feature = "local-files",
-                feature = "subsonic",
-                feature = "qobuz",
-                feature = "youtube"
-              )))]
+              #[cfg(not(feature = "audio-decode-queue"))]
               {
                 false
               }

--- a/src/infra/qobuz/mod.rs
+++ b/src/infra/qobuz/mod.rs
@@ -902,7 +902,8 @@ mod tests {
     eprintln!("decoder ready after {:?}", started.elapsed());
 
     let player = LocalPlayer::new().expect("open default output device");
-    player.play_prepared(prepared);
+    player.play_prepared(prepared)
+    .unwrap();
     eprintln!("playing after {:?}", started.elapsed());
     tokio::time::sleep(Duration::from_millis(600)).await;
     assert!(

--- a/src/infra/qobuz/mod.rs
+++ b/src/infra/qobuz/mod.rs
@@ -902,8 +902,7 @@ mod tests {
     eprintln!("decoder ready after {:?}", started.elapsed());
 
     let player = LocalPlayer::new().expect("open default output device");
-    player.play_prepared(prepared)
-    .unwrap();
+    player.play_prepared(prepared).unwrap();
     eprintln!("playing after {:?}", started.elapsed());
     tokio::time::sleep(Duration::from_millis(600)).await;
     assert!(

--- a/src/infra/qobuz/stream/download.rs
+++ b/src/infra/qobuz/stream/download.rs
@@ -121,7 +121,6 @@ pub(super) mod test_support {
 
 #[cfg(test)]
 mod tests {
-  use super::test_support::*;
   use super::*;
 
   #[tokio::test]

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -204,10 +204,7 @@ async fn clear_queue_playback(app: &Arc<Mutex<App>>) {
       player.stop();
     }
   }
-  #[cfg(all(
-    feature = "streaming",
-    not(feature = "audio-decode-queue")
-  ))]
+  #[cfg(all(feature = "streaming", not(feature = "audio-decode-queue")))]
   {
     let mut guard = app.lock().await;
     guard.queue_suspended = None;
@@ -587,10 +584,7 @@ async fn finish_decoded_fetch(
     Some(QueueNowPlaying::Decoded(d)) if d.fetch_id == fetch_id => Arc::clone(&d.player),
     _ => return, // superseded — the tempfile drops here
   };
-  #[cfg_attr(
-    not(feature = "tui"),
-    allow(unused_variables)
-  )]
+  #[cfg_attr(not(feature = "tui"), allow(unused_variables))]
   let (tmp, quality) = match result {
     Ok(fetched) => fetched,
     Err(e) => {
@@ -644,12 +638,8 @@ async fn publish_decoded(
   app: &Arc<Mutex<App>>,
   player: Arc<LocalPlayer>,
   track: TrackInfo,
-  #[cfg(feature = "queue-download")] tempfile: Option<
-    tempfile::NamedTempFile,
-  >,
-  #[cfg(not(feature = "queue-download"))] _tempfile: Option<
-    (),
-  >,
+  #[cfg(feature = "queue-download")] tempfile: Option<tempfile::NamedTempFile>,
+  #[cfg(not(feature = "queue-download"))] _tempfile: Option<()>,
 ) {
   use crate::infra::queue::{DecodedQueuePlayback, QueueNowPlaying};
   let name = track.name.clone();
@@ -769,10 +759,7 @@ async fn apply_volume(app: &Arc<Mutex<App>>, player: &Arc<LocalPlayer>) {
 /// suspended. The queue slot's player is stopped only when it is **not** shared
 /// with the context being resumed (`Arc::ptr_eq`).
 async fn resume_or_finish(app: &Arc<Mutex<App>>) {
-  #[cfg(any(
-    feature = "queue",
-    feature = "internet-radio"
-  ))]
+  #[cfg(any(feature = "queue", feature = "internet-radio"))]
   use crate::core::queue::SuspendedContext;
 
   let suspended = { app.lock().await.queue_suspended.take() };
@@ -806,10 +793,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   // Take the queue slot's player so we can decide whether to stop it.
   #[cfg(feature = "audio-decode-queue")]
   let queue_player = { app.lock().await.take_queue_now_decoded_player() };
-  #[cfg(all(
-    feature = "streaming",
-    not(feature = "audio-decode-queue")
-  ))]
+  #[cfg(all(feature = "streaming", not(feature = "audio-decode-queue")))]
   {
     app.lock().await.queue_now = None;
   }
@@ -1205,8 +1189,8 @@ mod tests {
   use std::time::SystemTime;
 
   #[cfg(any(
-      feature = "streaming",
-      not(all(feature = "qobuz", feature = "subsonic"))
+    feature = "streaming",
+    not(all(feature = "qobuz", feature = "subsonic"))
   ))]
   fn track(uri: &str, name: &str) -> TrackInfo {
     TrackInfo {

--- a/src/infra/queue/dispatch.rs
+++ b/src/infra/queue/dispatch.rs
@@ -16,32 +16,16 @@ use tokio::sync::Mutex;
 
 use crate::core::app::App;
 use crate::core::plugin_api::TrackInfo;
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube",
-  feature = "streaming"
-))]
+#[cfg(feature = "queue")]
 use crate::core::queue::QueueItemSource;
 use crate::core::queue::{queue_item_source, source_available, source_label};
 use crate::infra::network::IoEvent;
 
 // The decoded queue slot exists only for the sources that own a finite track
 // list; internet radio enables `audio-decode` but is never queueable.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 use crate::infra::audio::LocalPlayer;
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 use std::time::Duration;
 
 /// Intercept queue-owned events before the per-source dispatchers.
@@ -86,12 +70,7 @@ pub async fn route_queue_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool {
   // Transport for the queue slot's own player (Pause / Seek / Volume / Next /
   // bare-resume). Only meaningful when a decoded queued track owns the sink;
   // compiles out entirely without a queueable decoded source.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   if let Some(handled) = route_queue_transport(app, event).await {
     return handled;
   }
@@ -115,12 +94,7 @@ pub async fn route_queue_event(app: &Arc<Mutex<App>>, event: &IoEvent) -> bool {
 /// Transport controls for the queue slot's player, when a decoded queued track
 /// owns the sink. Returns `Some(true)` when consumed, `None` when this event is
 /// not a queue-slot transport control (so the caller falls through).
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 async fn route_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -> Option<bool> {
   let player = {
     let guard = app.lock().await;
@@ -217,12 +191,7 @@ async fn route_spotify_queue_transport(app: &Arc<Mutex<App>>, event: &IoEvent) -
 /// Drop the queue slot (stopping its player) and forget any suspended context,
 /// but keep the queued items. Called when the user starts an unrelated playback.
 async fn clear_queue_playback(app: &Arc<Mutex<App>>) {
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   {
     let player = {
       let mut guard = app.lock().await;
@@ -237,12 +206,7 @@ async fn clear_queue_playback(app: &Arc<Mutex<App>>) {
   }
   #[cfg(all(
     feature = "streaming",
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))
+    not(feature = "audio-decode-queue")
   ))]
   {
     let mut guard = app.lock().await;
@@ -252,13 +216,7 @@ async fn clear_queue_playback(app: &Arc<Mutex<App>>) {
   // No queueable source at all (includes a radio-only build): there is no queue
   // slot to clear, and `queue_suspended` is only ever set by a source that can
   // be suspended *under* the queue.
-  #[cfg(not(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  )))]
+  #[cfg(not(feature = "queue"))]
   {
     let _ = app;
   }
@@ -463,12 +421,7 @@ async fn play_queued_spotify(app: &Arc<Mutex<App>>, track: &TrackInfo, uri: &str
   // its player for resume) is paused — resume reloads its sink either way.
   // Both lookups only ever see the queueable sources (radio is torn down at
   // suspension rather than kept for reuse), so this compiles out without them.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   {
     if let Some(p) = { app.lock().await.take_queue_now_decoded_player() } {
       p.stop();
@@ -573,20 +526,10 @@ fn preload_next_queued_spotify(app: &App) {
 }
 
 /// Monotonic source for [`DecodedQueuePlayback::fetch_id`] stamps.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 static QUEUE_FETCH_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 fn next_fetch_id() -> u64 {
   QUEUE_FETCH_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
@@ -600,12 +543,7 @@ fn next_fetch_id() -> u64 {
 /// which re-suspended the context and dispatched a second advance — dropping
 /// one queued item on the floor. Returns the slot's fetch stamp, which a
 /// background fetch passes back to [`finish_decoded_fetch`].
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 async fn publish_pending_decoded(
   app: &Arc<Mutex<App>>,
   player: &Arc<LocalPlayer>,
@@ -619,8 +557,9 @@ async fn publish_pending_decoded(
     track: track.clone(),
     advancing: true,
     fetch_id,
-    #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+    #[cfg(feature = "queue-download")]
     tempfile: None,
+    #[cfg(feature = "tui")]
     quality: None,
   }));
   fetch_id
@@ -635,7 +574,7 @@ async fn publish_pending_decoded(
 /// thread, and the runner takes the lock on every frame); the slot is
 /// re-checked before the finalize, and a stage that a newer fetch superseded
 /// is left paused in the sink for that fetch's own stage to clear.
-#[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+#[cfg(feature = "queue-download")]
 async fn finish_decoded_fetch(
   app: &Arc<Mutex<App>>,
   fetch_id: u64,
@@ -648,6 +587,10 @@ async fn finish_decoded_fetch(
     Some(QueueNowPlaying::Decoded(d)) if d.fetch_id == fetch_id => Arc::clone(&d.player),
     _ => return, // superseded — the tempfile drops here
   };
+  #[cfg_attr(
+    not(feature = "tui"),
+    allow(unused_variables)
+  )]
   let (tmp, quality) = match result {
     Ok(fetched) => fetched,
     Err(e) => {
@@ -682,7 +625,10 @@ async fn finish_decoded_fetch(
   }
   if let Some(QueueNowPlaying::Decoded(d)) = guard.queue_now.as_mut() {
     d.tempfile = Some(tmp);
-    d.quality = quality;
+    #[cfg(feature = "tui")]
+    {
+      d.quality = quality;
+    }
     d.advancing = false;
   }
   guard.set_status_message(format!("\u{266a} {track_name} (queue)"), 4);
@@ -698,10 +644,10 @@ async fn publish_decoded(
   app: &Arc<Mutex<App>>,
   player: Arc<LocalPlayer>,
   track: TrackInfo,
-  #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))] tempfile: Option<
+  #[cfg(feature = "queue-download")] tempfile: Option<
     tempfile::NamedTempFile,
   >,
-  #[cfg(not(any(feature = "subsonic", feature = "qobuz", feature = "youtube")))] _tempfile: Option<
+  #[cfg(not(feature = "queue-download"))] _tempfile: Option<
     (),
   >,
 ) {
@@ -717,8 +663,9 @@ async fn publish_decoded(
     track,
     advancing: false,
     fetch_id: next_fetch_id(),
-    #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+    #[cfg(feature = "queue-download")]
     tempfile,
+    #[cfg(feature = "tui")]
     quality: None,
   }));
   guard.set_status_message(format!("\u{266a} {name} (queue)"), 4);
@@ -735,12 +682,7 @@ async fn publish_decoded(
 /// fresh-device path: the outgoing queue slot can be a still-playing Spotify
 /// track (mid-track skip / Enter-jump), and on the reuse paths nothing else
 /// silences it — it would keep playing under the whole download window.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 async fn acquire_queue_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>> {
   if let Some(p) = {
     let guard = app.lock().await;
@@ -771,12 +713,7 @@ async fn acquire_queue_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>>
 /// That exclusion is exactly why this is gated on the three queueable sources
 /// rather than `audio-decode` — under radio alone every arm below is cfg'd out
 /// and the function is unreachable.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 async fn suspended_context_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlayer>> {
   let guard = app.lock().await;
   #[cfg(feature = "local-files")]
@@ -803,12 +740,7 @@ async fn suspended_context_player(app: &Arc<Mutex<App>>) -> Option<Arc<LocalPlay
 /// still-playing queued Spotify track that is being skipped mid-play. Called
 /// unconditionally at the top of every decoded queue-play path — a Spirc pause
 /// on an already-paused or idle librespot is a no-op.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 async fn release_librespot(app: &Arc<Mutex<App>>) {
   #[cfg(feature = "streaming")]
   {
@@ -838,11 +770,7 @@ async fn apply_volume(app: &Arc<Mutex<App>>, player: &Arc<LocalPlayer>) {
 /// with the context being resumed (`Arc::ptr_eq`).
 async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   #[cfg(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube",
+    feature = "queue",
     feature = "internet-radio"
   ))]
   use crate::core::queue::SuspendedContext;
@@ -851,21 +779,9 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   // The slot's desired play state carries into the resume, then resets: a
   // device removal that paused the slot keeps the context paused, and the
   // next queue episode starts playing.
-  #[cfg(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "queue")]
   let playing = std::mem::replace(&mut app.lock().await.queue_slot_desired_playing, true);
-  #[cfg(not(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  )))]
+  #[cfg(not(feature = "queue"))]
   #[allow(unused_variables)]
   let playing = true;
 
@@ -888,21 +804,11 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   }
 
   // Take the queue slot's player so we can decide whether to stop it.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   let queue_player = { app.lock().await.take_queue_now_decoded_player() };
   #[cfg(all(
     feature = "streaming",
-    not(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "youtube"
-    ))
+    not(feature = "audio-decode-queue")
   ))]
   {
     app.lock().await.queue_now = None;
@@ -911,12 +817,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
   // The slot gave its device up (see the driver's tick): a decoded context
   // sharing that player cannot restage onto it either. End it with the device
   // error instead of a failed track.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   if let Some(dead) = queue_player.as_ref().filter(|p| p.device_lost()) {
     let mut guard = app.lock().await;
     if drop_context_sharing(&mut guard, suspended.as_ref(), dead) {
@@ -929,12 +830,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
     None => {
       // Nothing was suspended: the queue was playing over an idle app (or a
       // context finished before the queue started). Stop the slot and note it.
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       if let Some(player) = queue_player {
         player.stop();
         app
@@ -967,12 +863,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
     Some(SuspendedContext::Radio { station }) => {
       // Radio uses its own fresh player, so always stop the queue slot. A
       // radio-only build has no queueable source, hence no slot to stop.
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       if let Some(player) = queue_player {
         player.stop();
       }
@@ -998,12 +889,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
       // The network handler reloads the session's app-owned track list at the
       // resume index — same order, no refetch, no reshuffle. Stop the decoded
       // queue slot if one exists.
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       if let Some(player) = queue_player {
         player.stop();
       }
@@ -1025,12 +911,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
     }) => {
       // The network handler re-loads the Spotify context (offset by the resume
       // track) on the native device. Stop the decoded queue slot if one exists.
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       if let Some(player) = queue_player {
         player.stop();
       }
@@ -1045,12 +926,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
     #[allow(unreachable_patterns)]
     _ =>
     {
-      #[cfg(any(
-        feature = "local-files",
-        feature = "subsonic",
-        feature = "qobuz",
-        feature = "youtube"
-      ))]
+      #[cfg(feature = "audio-decode-queue")]
       if let Some(player) = queue_player {
         player.stop();
       }
@@ -1060,12 +936,7 @@ async fn resume_or_finish(app: &Arc<Mutex<App>>) {
 
 /// Drop the suspended decoded context whose player is `dead` (the queue slot
 /// shared it), returning whether there was one.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 fn drop_context_sharing(
   app: &mut App,
   suspended: Option<&crate::core::queue::SuspendedContext>,
@@ -1333,6 +1204,10 @@ mod tests {
   use std::sync::mpsc::channel;
   use std::time::SystemTime;
 
+  #[cfg(any(
+      feature = "streaming",
+      not(all(feature = "qobuz", feature = "subsonic"))
+  ))]
   fn track(uri: &str, name: &str) -> TrackInfo {
     TrackInfo {
       uri: Some(uri.to_string()),

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -19,13 +19,13 @@
 
 pub mod dispatch;
 
-#[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+#[cfg(feature = "queue-download")]
 use crate::core::plugin_api::TrackInfo;
 
 /// Snapshot the `TrackInfo`s for `uris` in order from the track table, then
 /// the search results (a play can come from either view). Unknown URIs are
 /// dropped.
-#[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+#[cfg(feature = "queue-download")]
 pub fn snapshot_tracks(
   table: &[TrackInfo],
   search: Option<&[TrackInfo]>,
@@ -364,12 +364,7 @@ fn restore_in_place<T>(items: &mut Vec<T>, backup: &ShuffleBackup, current: usiz
 /// Gated on the *queueable* decoded sources rather than `audio-decode`: replay
 /// is the repeat-one path of a finite track list. Internet radio decodes audio
 /// too, but a live stream has no track to re-decode.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub async fn replay_file(
   player: std::sync::Arc<crate::infra::audio::LocalPlayer>,
   path: std::path::PathBuf,
@@ -387,12 +382,7 @@ pub async fn replay_file(
 /// taken by whichever path stages the track (a replay, a `play_index`, or a
 /// download's commit), so the seek and the pause are applied to the track
 /// they belong to, and never as events that race it.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ResumePoint {
   pub position_ms: u64,
@@ -404,12 +394,7 @@ pub struct ResumePoint {
 ///
 /// **Blocking:** the stage clears the sink and decodes; call it off the async
 /// runtime and off the `App` lock.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub fn restage(
   player: &crate::infra::audio::LocalPlayer,
   path: &std::path::Path,
@@ -434,12 +419,7 @@ pub fn restage(
 /// [`dispatch::try_play_queued`] can play. Internet radio pulls `audio-decode`
 /// in as well, but a live stream is never a queue item, so a radio-only build
 /// can never construct this.
-#[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "audio-decode-queue")]
 pub struct DecodedQueuePlayback {
   /// The output-device sink. Shared (`Arc::ptr_eq`) with the suspended context's
   /// player when there is one, so no second device is opened.
@@ -457,7 +437,7 @@ pub struct DecodedQueuePlayback {
   /// Subsonic/YouTube fetch-completion path, so a build with neither (e.g. a
   /// local-files-only build) writes it without reading it.
   #[cfg_attr(
-    not(any(feature = "subsonic", feature = "qobuz", feature = "youtube")),
+    not(feature = "queue-download"),
     allow(dead_code)
   )]
   pub fetch_id: u64,
@@ -465,11 +445,12 @@ pub struct DecodedQueuePlayback {
   /// local file, which is played straight from disk. Held purely to keep the
   /// file alive on disk for the duration of playback (dropped with the slot), so
   /// it is never read back.
-  #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+  #[cfg(feature = "queue-download")]
   #[allow(dead_code)]
   pub tempfile: Option<tempfile::NamedTempFile>,
   /// The delivered audio format of a downloaded track (Qobuz, e.g.
   /// `FLAC 24/96`), shown after the artists in the playbar.
+  #[cfg(feature = "tui")]
   pub quality: Option<String>,
 }
 
@@ -482,20 +463,9 @@ pub struct DecodedQueuePlayback {
 /// `App::queue_owns_playback()` accessor. Note internet radio is deliberately
 /// absent from both halves of the gate: it decodes audio, but a `radio:` URI is
 /// never a queue item, so it can neither fill nor own this slot.
-#[cfg(any(
-  feature = "streaming",
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "youtube"
-))]
+#[cfg(feature = "queue")]
 pub enum QueueNowPlaying {
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   Decoded(DecodedQueuePlayback),
   /// A Spotify track playing via native streaming (`player.load`, no Spirc
   /// context).
@@ -509,7 +479,7 @@ pub enum QueueNowPlaying {
 mod tests {
   use super::*;
 
-  #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+  #[cfg(feature = "queue-download")]
   mod snapshot {
     use super::*;
 

--- a/src/infra/queue/mod.rs
+++ b/src/infra/queue/mod.rs
@@ -436,10 +436,7 @@ pub struct DecodedQueuePlayback {
   /// one, and the stale result is silently discarded. Only *read* by the
   /// Subsonic/YouTube fetch-completion path, so a build with neither (e.g. a
   /// local-files-only build) writes it without reading it.
-  #[cfg_attr(
-    not(feature = "queue-download"),
-    allow(dead_code)
-  )]
+  #[cfg_attr(not(feature = "queue-download"), allow(dead_code))]
   pub fetch_id: u64,
   /// The tempfile backing a downloaded track (Subsonic / YouTube). `None` for a
   /// local file, which is played straight from disk. Held purely to keep the

--- a/src/infra/youtube/mod.rs
+++ b/src/infra/youtube/mod.rs
@@ -107,6 +107,7 @@ pub struct YouTubePlaybackState {
 
 impl YouTubePlaybackState {
   /// The currently playing video, if `index` is in range.
+  #[cfg(feature = "tui")]
   pub fn current(&self) -> Option<&TrackInfo> {
     self.tracks.get(self.index)
   }

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -663,13 +663,7 @@ async fn restore_playback_session(
   session: crate::core::persisted_playback::PersistedPlayback,
   startup_behavior: StartupBehavior,
 ) {
-  #[cfg(any(
-    feature = "youtube",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "local-files",
-    feature = "internet-radio"
-  ))]
+  #[cfg(feature = "audio-decode")]
   use crate::core::persisted_playback::PersistedPlayback;
 
   // Resolve whether the restored track should end up paused.
@@ -874,13 +868,7 @@ async fn handle_mpris_events(
     // Spotify network) so media keys follow the audible source instead of
     // librespot. This must run *before* the streaming-player branches below,
     // since librespot is initialized even while a decoded source is playing.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     if route_decoded_mpris_event(&event, &app, &mpris_manager).await {
       continue;
     }
@@ -1086,13 +1074,7 @@ async fn handle_mpris_events(
 #[cfg(all(
   feature = "mpris",
   target_os = "linux",
-  any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  )
+  feature = "audio-decode",
 ))]
 async fn route_decoded_mpris_event(
   event: &mpris::MprisEvent,
@@ -1248,13 +1230,7 @@ async fn handle_macos_media_events(
     // Spotify network) so media keys follow the audible source instead of
     // librespot. This must run *before* `active_streaming_player` below, since
     // librespot stays active even while a decoded source is playing.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     if route_decoded_macos_event(&event, &app).await {
       continue;
     }
@@ -1306,13 +1282,7 @@ async fn handle_macos_media_events(
 #[cfg(all(
   feature = "macos-media",
   target_os = "macos",
-  any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  )
+  feature = "audio-decode",
 ))]
 async fn route_decoded_macos_event(
   event: &macos_media::MacMediaEvent,
@@ -1372,13 +1342,7 @@ async fn handle_windows_media_events(
     // Spotify network) so SMTC controls follow the audible source instead of
     // librespot. This must run *before* the streaming-player branches below,
     // since librespot stays active even while a decoded source is playing.
-    #[cfg(any(
-      feature = "local-files",
-      feature = "subsonic",
-      feature = "qobuz",
-      feature = "internet-radio",
-      feature = "youtube"
-    ))]
+    #[cfg(feature = "audio-decode")]
     if route_decoded_windows_event(&event, &app).await {
       continue;
     }
@@ -1458,13 +1422,7 @@ async fn handle_windows_media_events(
 #[cfg(all(
   feature = "windows-media",
   target_os = "windows",
-  any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  )
+  feature = "audio-decode",
 ))]
 async fn route_decoded_windows_event(
   event: &smtc_tokio::WindowsMediaEvent,

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -1071,11 +1071,7 @@ async fn handle_mpris_events(
 /// source is actually audible instead of the paused librespot session.
 /// Non-transport events (shuffle/loop) return `false` so existing behaviour is
 /// preserved.
-#[cfg(all(
-  feature = "mpris",
-  target_os = "linux",
-  feature = "audio-decode",
-))]
+#[cfg(all(feature = "mpris", target_os = "linux", feature = "audio-decode",))]
 async fn route_decoded_mpris_event(
   event: &mpris::MprisEvent,
   app: &Arc<Mutex<App>>,
@@ -1279,11 +1275,7 @@ async fn handle_macos_media_events(
 /// `IoEvent`s the keyboard uses; the per-source `route_*_event` dispatchers
 /// intercept them before the Spotify network, so the control lands on whichever
 /// source is actually audible instead of the paused librespot session.
-#[cfg(all(
-  feature = "macos-media",
-  target_os = "macos",
-  feature = "audio-decode",
-))]
+#[cfg(all(feature = "macos-media", target_os = "macos", feature = "audio-decode",))]
 async fn route_decoded_macos_event(
   event: &macos_media::MacMediaEvent,
   app: &Arc<Mutex<App>>,

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -549,13 +549,7 @@ fn playbar_controls_available(app: &App) -> bool {
 /// all-sources build.
 fn non_spotify_source_playback_active(app: &App) -> bool {
   // Slim builds (no source features) never reference `app` below.
-  #[cfg(not(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "internet-radio",
-    feature = "youtube"
-  )))]
+  #[cfg(not(feature = "audio-decode"))]
   let _ = app;
 
   #[cfg(feature = "local-files")]
@@ -840,11 +834,6 @@ fn extract_track_info(app: &App) -> (Option<String>, Option<String>) {
 /// Gated to every build that can render one: the decoded sources plus the
 /// native queue slot (`streaming` covers a queued Spotify track).
 #[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "internet-radio",
-  feature = "youtube",
   feature = "streaming",
   feature = "audio-decode"
 ))]
@@ -1012,11 +1001,6 @@ fn draw_radio_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
 }
 
 #[cfg(any(
-  feature = "local-files",
-  feature = "subsonic",
-  feature = "qobuz",
-  feature = "internet-radio",
-  feature = "youtube",
   feature = "streaming",
   feature = "audio-decode"
 ))]
@@ -1186,12 +1170,7 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   // suspended context (whose `*_playback` is still `Some`) and not the stale
   // Spotify context (still cached when a Spotify context was suspended).
   // Checked first so the playbar always shows what is actually audible.
-  #[cfg(any(
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube"
-  ))]
+  #[cfg(feature = "audio-decode-queue")]
   if let Some(crate::infra::queue::QueueNowPlaying::Decoded(d)) = app.queue_now.as_ref() {
     let source_label = d
       .track
@@ -1220,6 +1199,7 @@ pub fn draw_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
       // The native queue ignores the decoded shuffle/repeat modes (they belong
       // to the suspended source resumed once the queue drains), so hide them.
       show_modes: false,
+      #[cfg(any(feature = "queue-download", feature = "local-files"))]
       quality: d.quality.clone(),
     };
     render_local_playbar(f, app, layout_chunk, &view);

--- a/src/tui/ui/player.rs
+++ b/src/tui/ui/player.rs
@@ -833,10 +833,7 @@ fn extract_track_info(app: &App) -> (Option<String>, Option<String>) {
 /// of plain values and can be unit-tested with `TestBackend` (no audio device).
 /// Gated to every build that can render one: the decoded sources plus the
 /// native queue slot (`streaming` covers a queued Spotify track).
-#[cfg(any(
-  feature = "streaming",
-  feature = "audio-decode"
-))]
+#[cfg(any(feature = "streaming", feature = "audio-decode"))]
 struct LocalPlaybarView {
   /// Source name shown in the playbar title, e.g. `"Local"` or `"Subsonic"`.
   source_label: &'static str,
@@ -1000,10 +997,7 @@ fn draw_radio_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect) {
   render_local_playbar(f, app, layout_chunk, &view);
 }
 
-#[cfg(any(
-  feature = "streaming",
-  feature = "audio-decode"
-))]
+#[cfg(any(feature = "streaming", feature = "audio-decode"))]
 fn render_local_playbar(f: &mut Frame<'_>, app: &App, layout_chunk: Rect, view: &LocalPlaybarView) {
   let playbar_areas = playbar_layout_areas(app, layout_chunk);
 

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -369,7 +369,7 @@ fn queue_item_line(item: &PlayableInfo) -> String {
 /// tracks. Rows read from the still-alive per-source `*_playback` state.
 fn context_preview_lines(app: &App, max: usize) -> Vec<String> {
   // Format the upcoming rows of a Subsonic/YouTube `TrackInfo` context list.
-  #[cfg(any(feature = "subsonic", feature = "qobuz", feature = "youtube"))]
+  #[cfg(feature = "queue-download")]
   fn track_rows(
     tracks: &[crate::core::plugin_api::TrackInfo],
     start: usize,
@@ -413,11 +413,7 @@ fn context_preview_lines(app: &App, max: usize) -> Vec<String> {
 
   // 1. A suspended context is authoritative: the queue is draining over it.
   #[cfg(any(
-    feature = "streaming",
-    feature = "local-files",
-    feature = "subsonic",
-    feature = "qobuz",
-    feature = "youtube",
+    feature = "queue",
     feature = "internet-radio"
   ))]
   if let Some(ctx) = app.queue_suspended.as_ref() {

--- a/src/tui/ui/popups.rs
+++ b/src/tui/ui/popups.rs
@@ -412,10 +412,7 @@ fn context_preview_lines(app: &App, max: usize) -> Vec<String> {
   };
 
   // 1. A suspended context is authoritative: the queue is draining over it.
-  #[cfg(any(
-    feature = "queue",
-    feature = "internet-radio"
-  ))]
+  #[cfg(any(feature = "queue", feature = "internet-radio"))]
   if let Some(ctx) = app.queue_suspended.as_ref() {
     use crate::core::queue::SuspendedContext;
     return match ctx {


### PR DESCRIPTION
# Summary
this aims to solve #494, by adding some "meta-features". meta-features indicates empty cargo features, referenced by other "real" ones. when inserting `#[cfg(feature = "meta-feature1")]` is the equivalent of `#[cfg(any(feature = "f1", feature = "f2", ...))]`. this simplifies complex feature gates.

the added features are the following:
- `audio-decode-queue`: `qobuz`, `youtube`, `local-files`, `subsonic`
  audio features that needs to be decoded using `rodio`, but also supports a non-infinite (unlike internet-radio) queue.
- `queue`: `audio-decode-queue`, `streaming` 
  features supporting a non-infinite queue.
- `queue-download`: `subsonic`, `youtube`, `qobuz`
  features that needs full file download before playback that also supports non-infinite queue.
- ~~`onboarding`: `local-files`, `subsonic`, `youtube`
  features that requires onboarding.~~

# Testing
i did run `cargo {clippy,test} --no-default-features` on the following feature sets: empty (core only), each source on its own (`streaming`, `qobuz`, `youtube`, `local-files`, `subsonic`), each source with `streaming`, each source with `streaming` and `tui`.
everything passed.

edit: removed `onboarding` feature, as it was used only once and it was confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated playback, audio decoding, queue, and download feature configuration for more consistent builds across supported sources.
  * Updated queue and playback components to use unified capability settings while preserving runtime playback behavior.
  * Improved feature-specific handling for queue downloads, playback quality, and suspended-context previews.

* **Tests**
  * Qobuz playback tests now report failures when playback cannot be started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->